### PR TITLE
feat(web): launch hub MVP UI and integrate registry-driven install experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,12 @@ __pycache__/
 # Go build artifacts
 bin/
 
+# Node / Next.js
+node_modules/
+.pnpm-store/
+pnpm-debug.log*
+.vercel/
+*.tsbuildinfo
+
 # Logs
 *.log

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help doctor validate manifests registry test-scripts test ci-local cli-build cli-test
+.PHONY: help doctor validate manifests registry test-scripts test ci-local cli-build cli-test web-dev web-build
 
 help:
 	@echo "Targets:"
@@ -13,6 +13,8 @@ help:
 	@echo "  make ci-local      - Run local checks similar to CI"
 	@echo "  make cli-test      - Run Go unit tests for CLI packages"
 	@echo "  make cli-build     - Build the skills-hub CLI binary"
+	@echo "  make web-dev       - Run Next.js hub app in dev mode"
+	@echo "  make web-build     - Build Next.js hub app"
 
 doctor:
 	@echo "[check] go"
@@ -47,3 +49,9 @@ cli-test:
 
 cli-build:
 	go build -o bin/skills-hub ./cmd/skills-hub
+
+web-dev:
+	cd apps/web && npm run dev
+
+web-build:
+	cd apps/web && npm run build

--- a/README.md
+++ b/README.md
@@ -125,3 +125,19 @@ Runtime target defaults:
 
 See `CONTRIBUTING.md` and `docs/how-to-contribute-a-skill.md`.
 For local toolchain setup, see `docs/dev-setup.md`.
+
+## Hub Website (MVP Scaffold)
+
+The repo now includes a Next.js catalog app at `apps/web`.
+
+```bash
+cd apps/web
+npm install
+npm run dev
+```
+
+Core routes:
+
+- `/` overview
+- `/skills` searchable catalog
+- `/skills/<category>/<slug>` skill details and install snippets

--- a/README.md
+++ b/README.md
@@ -98,16 +98,18 @@ Example usage:
 
 ```bash
 ./bin/skills-hub list
+./bin/skills-hub search --tag paid-media --runtime codex
 ./bin/skills-hub validate
-./bin/skills-hub info --skill marketing/meta-google-weekly-performance-review
+./bin/skills-hub info \
+  --skill marketing/meta-google-weekly-performance-review@latest
 ./bin/skills-hub install \
-  --skill marketing/meta-google-weekly-performance-review \
+  marketing/meta-google-weekly-performance-review@latest \
   --runtime codex
 ./bin/skills-hub install \
-  --skill marketing/meta-google-weekly-performance-review \
+  marketing/meta-google-weekly-performance-review@latest \
   --runtime claude
 ./bin/skills-hub install \
-  --skill marketing/meta-google-weekly-performance-review \
+  marketing/meta-google-weekly-performance-review@0.1.0 \
   --runtime generic \
   --target ./my-agent/skills
 ```

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,3 @@
+.next/
+out/
+node_modules/

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,26 @@
+# Web App (Hub MVP)
+
+This app renders a static-first skills catalog from `../../registry/index.json`.
+
+## Local development
+
+```bash
+cd apps/web
+npm install
+npm run dev
+```
+
+Then open `http://localhost:3000`.
+
+## Build
+
+```bash
+npm run build
+npm start
+```
+
+## Routes
+
+- `/` overview
+- `/skills` catalog with filters
+- `/skills/<category>/<slug>` skill details with install snippets

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,366 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+}
+
+body {
+  color: var(--ink);
+  font-family: var(--font-ui);
+  background:
+    linear-gradient(transparent 0, transparent 95%, rgba(255, 255, 255, 0.03) 95%),
+    linear-gradient(90deg, transparent 0, transparent 95%, rgba(255, 255, 255, 0.03) 95%),
+    radial-gradient(circle at 80% -30%, rgba(51, 215, 111, 0.13) 0%, transparent 45%),
+    radial-gradient(circle at 5% 0%, rgba(18, 173, 152, 0.1) 0%, transparent 35%),
+    var(--bg);
+  background-size: 48px 48px, 48px 48px, auto, auto, auto;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+main {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0 0 0.6rem;
+}
+
+h1 {
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+p {
+  color: var(--ink-soft);
+  line-height: 1.55;
+}
+
+.strip {
+  background: var(--hub-accent);
+  color: #0b0c0f;
+  border-bottom: 1px solid #0f1116;
+  padding: 0.4rem 0.75rem;
+  font-family: var(--font-code);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.pill {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.38rem 0.78rem;
+  background: var(--paper);
+  font-size: 0.82rem;
+}
+
+.theme-hybrid .pill {
+  background: rgba(10, 14, 21, 0.8);
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.card {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 1rem;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
+}
+
+.theme-hybrid .card {
+  background: rgba(12, 15, 20, 0.88);
+  backdrop-filter: blur(3px);
+}
+
+.meta {
+  font-family: var(--font-code);
+  font-size: 0.78rem;
+  color: var(--ink-soft);
+}
+
+.install {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--code-bg);
+  color: var(--code-ink);
+  font-family: var(--font-code);
+  font-size: 0.83rem;
+  line-height: 1.45;
+  padding: 0.75rem;
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  overflow-x: hidden;
+}
+
+.filters {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1rem 0 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.input,
+.select {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.58rem 0.68rem;
+  background: var(--paper-muted);
+  color: var(--ink);
+}
+
+.filter-select {
+  position: relative;
+}
+
+.filter-trigger {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.58rem 0.68rem;
+  background: var(--paper-muted);
+  color: var(--ink);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  text-align: left;
+}
+
+.theme-hybrid .filter-trigger {
+  background: rgba(14, 19, 27, 0.96);
+}
+
+.filter-trigger:hover,
+.filter-trigger:focus-visible {
+  border-color: #33d76f;
+}
+
+.caret {
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+}
+
+.filter-menu {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  right: 0;
+  max-height: 260px;
+  overflow-y: auto;
+  background: rgba(13, 19, 27, 0.98);
+  border: 1px solid #2f3b49;
+  border-radius: 12px;
+  padding: 0.3rem;
+  margin: 0;
+  list-style: none;
+  z-index: 40;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
+}
+
+.filter-option {
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  padding: 0.48rem 0.58rem;
+  background: transparent;
+  color: var(--ink);
+  text-align: left;
+  font-size: 0.86rem;
+}
+
+.filter-option:hover,
+.filter-option:focus-visible {
+  border-color: #33d76f;
+  background: rgba(51, 215, 111, 0.14);
+}
+
+.filter-option.is-selected {
+  border-color: #33d76f;
+  background: rgba(51, 215, 111, 0.2);
+}
+
+.theme-hybrid .input,
+.theme-hybrid .select {
+  background: rgba(14, 19, 27, 0.96);
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.75rem;
+}
+
+.tag {
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  padding: 0.2rem 0.55rem;
+  font-size: 0.73rem;
+  background: var(--brand-primary-soft);
+  color: var(--ink);
+}
+
+.hero {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1.2fr 1fr;
+  margin-bottom: 1.5rem;
+}
+
+.display {
+  font-size: clamp(2.2rem, 9vw, 5.4rem);
+  line-height: 0.92;
+  text-transform: uppercase;
+}
+
+.display .accent {
+  color: var(--hub-accent);
+}
+
+.kicker {
+  display: inline-block;
+  margin-bottom: 0.65rem;
+  color: var(--brand-primary);
+  font-family: var(--font-code);
+  font-size: 0.76rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.button {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.52rem 0.8rem;
+  font-size: 0.82rem;
+  background: var(--paper-muted);
+  transition: border-color 160ms ease, color 160ms ease, background 160ms ease;
+}
+
+.button--secondary {
+  background: rgba(12, 17, 24, 0.95);
+  color: var(--ink);
+  border-color: var(--line);
+}
+
+.button--secondary:hover,
+.button--secondary:focus-visible {
+  border-color: #33d76f;
+  color: #d8fee7;
+  background: rgba(16, 25, 30, 0.98);
+}
+
+.button--accent {
+  background: var(--hub-accent);
+  color: #0f1218;
+  border-color: #28b85d;
+  font-weight: 700;
+}
+
+.button--accent:hover,
+.button--accent:focus-visible {
+  background: #40e57b;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  gap: 1rem;
+  margin-top: 1rem;
+  align-items: stretch;
+}
+
+.detail-panel {
+  height: 100%;
+}
+
+.install-card {
+  display: flex;
+  flex-direction: column;
+  padding: 0.9rem;
+}
+
+.install-item + .install-item {
+  margin-top: 0.9rem;
+}
+
+.install-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.7rem;
+  margin-bottom: 0.45rem;
+}
+
+.copy-button {
+  padding: 0.36rem 0.62rem;
+  font-size: 0.76rem;
+}
+
+@media (max-width: 820px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-panel {
+    height: auto;
+  }
+
+  .filters {
+    grid-template-columns: 1fr;
+  }
+
+  .strip {
+    font-size: 0.72rem;
+  }
+
+  .actions {
+    width: 100%;
+  }
+
+  .button {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { Space_Grotesk, IBM_Plex_Mono } from "next/font/google";
+import "./tokens.css";
+import "./globals.css";
+
+const heading = Space_Grotesk({
+  subsets: ["latin"],
+  variable: "--font-heading",
+  weight: ["400", "600", "700"]
+});
+
+const mono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+  weight: ["400", "500"]
+});
+
+export const metadata: Metadata = {
+  title: "AI Knowledge Hub",
+  description: "Open skills hub for marketing and adtech AI workflows"
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className={`${heading.variable} ${mono.variable}`}>
+      <body className="theme-hybrid">
+        <div className="strip">
+          AI KNOWLEDGE HUB • SUPER EARLY BUILD • OPEN SOURCE SKILLS •
+          CONTRIBUTE VIA PR •
+        </div>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+export default function NotFoundPage() {
+  return (
+    <main>
+      <h1>Skill not found</h1>
+      <p>We could not find that skill in the current registry snapshot.</p>
+      <div className="nav">
+        <Link href="/" className="button button--secondary">Home</Link>
+        <Link href="/skills" className="button button--secondary">Catalog</Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { loadRegistry, uniqueValues } from "@/lib/registry";
+
+export default async function HomePage() {
+  const registry = await loadRegistry();
+  const skills = registry.skills;
+  const categories = uniqueValues(skills.map((s) => s.category));
+  const tags = uniqueValues(skills.flatMap((s) => s.tags));
+
+  return (
+    <main>
+      <div className="nav">
+        <span className="pill">AI Knowledge Hub</span>
+        <Link href="/skills" className="pill">Browse Skills</Link>
+      </div>
+
+      <section className="hero">
+        <article className="card">
+          <span className="kicker">Open Skill Registry</span>
+          <h1 className="display">
+            Build
+            <br />
+            agents
+            <br />
+            with <span className="accent">real skills.</span>
+          </h1>
+          <p>
+            Discover reusable AI skill packages, copy runtime-specific install
+            commands, and contribute new workflows via pull requests.
+          </p>
+          <div className="actions">
+            <Link href="/skills" className="button button--accent">
+              Explore catalog
+            </Link>
+            <a
+              href="https://github.com/ai-knowledge-hub/ai-skills-guide"
+              className="button button--secondary"
+            >
+              View repository
+            </a>
+          </div>
+          <div className="tags">
+            <span className="tag">{skills.length} skills</span>
+            <span className="tag">Registry v{registry.registry_version}</span>
+            <span className="tag">Generated {registry.generated_at.slice(0, 10)}</span>
+          </div>
+        </article>
+        <article className="card">
+          <h2>Catalog Snapshot</h2>
+          <p><span className="meta">Categories:</span> {categories.length}</p>
+          <p><span className="meta">Tags:</span> {tags.length}</p>
+          <p><span className="meta">Runtimes:</span> codex, claude, generic</p>
+          <div className="actions">
+            <Link href="/skills" className="button button--secondary">Open full catalog</Link>
+          </div>
+        </article>
+      </section>
+
+      <section className="grid">
+        {skills.slice(0, 6).map((skill) => (
+          <Link key={skill.id} href={`/skills/${skill.id}`} className="card">
+            <p className="meta">{skill.category}</p>
+            <h3>{skill.name}</h3>
+            <p>{skill.description}</p>
+            <div className="tags">
+              {skill.tags.slice(0, 3).map((tag) => (
+                <span key={tag} className="tag">{tag}</span>
+              ))}
+            </div>
+          </Link>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/skills/[...id]/page.tsx
+++ b/apps/web/app/skills/[...id]/page.tsx
@@ -1,0 +1,54 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { buildInstallSnippet, getSkillById, loadRegistry } from "@/lib/registry";
+import InstallCommands from "@/components/InstallCommands";
+
+export async function generateStaticParams() {
+  const registry = await loadRegistry();
+  return registry.skills.map((skill) => ({ id: skill.id.split("/") }));
+}
+
+export default async function SkillDetailPage({ params }: { params: { id: string[] } }) {
+  const skillId = params.id.join("/");
+  const skill = await getSkillById(skillId);
+  if (!skill) {
+    notFound();
+  }
+
+  return (
+    <main>
+      <div className="nav">
+        <Link href="/" className="pill">Home</Link>
+        <Link href="/skills" className="pill">Catalog</Link>
+        <span className="pill">{skill.id}</span>
+      </div>
+
+      <article className="card">
+        <p className="meta">{skill.category}</p>
+        <h1>{skill.name}</h1>
+        <p>{skill.description}</p>
+        <div className="tags">
+          {skill.tags.map((tag) => (
+            <span key={tag} className="tag">{tag}</span>
+          ))}
+        </div>
+      </article>
+
+      <section className="detail-grid">
+        <article className="card detail-panel">
+          <h2>Metadata</h2>
+          <p><span className="meta">ID:</span> {skill.id}</p>
+          <p><span className="meta">Latest:</span> {skill.latest}</p>
+          <p><span className="meta">Runtimes:</span> {skill.runtimes.join(", ")}</p>
+          <p><span className="meta">Deprecated:</span> {String(skill.deprecated)}</p>
+          {skill.replaced_by ? <p><span className="meta">Replaced by:</span> {skill.replaced_by}</p> : null}
+        </article>
+        <InstallCommands
+          codex={buildInstallSnippet(skill, "codex")}
+          claude={buildInstallSnippet(skill, "claude")}
+          generic={buildInstallSnippet(skill, "generic")}
+        />
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/skills/page.tsx
+++ b/apps/web/app/skills/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import { loadRegistry, uniqueValues } from "@/lib/registry";
+import SkillsCatalogClient from "@/components/SkillsCatalogClient";
+
+type SearchParams = {
+  q?: string;
+  tag?: string;
+  category?: string;
+  runtime?: string;
+};
+
+export default async function SkillsPage({ searchParams }: { searchParams: SearchParams }) {
+  const registry = await loadRegistry();
+  const q = searchParams.q ?? "";
+  const tag = searchParams.tag ?? "";
+  const category = searchParams.category ?? "";
+  const runtime = searchParams.runtime ?? "";
+
+  const categories = uniqueValues(registry.skills.map((s) => s.category));
+  const tags = uniqueValues(registry.skills.flatMap((s) => s.tags));
+
+  return (
+    <main>
+      <div className="nav">
+        <Link href="/" className="pill">Home</Link>
+        <span className="pill">Catalog</span>
+      </div>
+
+      <h1>Skills Catalog</h1>
+      <p>Filter by intent, runtime, and category to find install-ready skills.</p>
+
+      <SkillsCatalogClient
+        skills={registry.skills}
+        categories={categories}
+        tags={tags}
+        initial={{ q, tag, category, runtime }}
+      />
+    </main>
+  );
+}

--- a/apps/web/app/tokens.css
+++ b/apps/web/app/tokens.css
@@ -1,0 +1,34 @@
+:root {
+  --font-ui: var(--font-heading), sans-serif;
+  --font-code: var(--font-mono), ui-monospace, monospace;
+}
+
+.theme-brand {
+  --bg: #f3f2ec;
+  --paper: #fffefb;
+  --paper-muted: #f0eee5;
+  --ink: #20242a;
+  --ink-soft: #606974;
+  --line: #d6d1c6;
+  --brand-primary: #0f7b6c;
+  --brand-primary-soft: #d7eee8;
+  --hub-accent: #33d76f;
+  --hub-accent-soft: rgba(51, 215, 111, 0.14);
+  --code-bg: #161a20;
+  --code-ink: #eff4f9;
+}
+
+.theme-hybrid {
+  --bg: #060709;
+  --paper: #0c0f14;
+  --paper-muted: #11151d;
+  --ink: #eef1f4;
+  --ink-soft: #9ca6b3;
+  --line: #1f2733;
+  --brand-primary: #12ad98;
+  --brand-primary-soft: #113d38;
+  --hub-accent: #33d76f;
+  --hub-accent-soft: rgba(51, 215, 111, 0.14);
+  --code-bg: #10141c;
+  --code-ink: #f3f7fb;
+}

--- a/apps/web/components/FilterSelect.tsx
+++ b/apps/web/components/FilterSelect.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type FilterSelectProps = {
+  label: string;
+  value: string;
+  options: string[];
+  placeholder: string;
+  onChange: (value: string) => void;
+};
+
+export default function FilterSelect({ label, value, options, placeholder, onChange }: FilterSelectProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function onPointerDown(event: MouseEvent) {
+      if (!rootRef.current) return;
+      if (!rootRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", onPointerDown);
+    return () => document.removeEventListener("mousedown", onPointerDown);
+  }, []);
+
+  return (
+    <div className="filter-select" ref={rootRef}>
+      <button
+        type="button"
+        className="filter-trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={label}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <span>{value || placeholder}</span>
+        <span className="caret" aria-hidden>
+          {open ? "▴" : "▾"}
+        </span>
+      </button>
+
+      {open ? (
+        <ul className="filter-menu" role="listbox" aria-label={label}>
+          <li>
+            <button
+              type="button"
+              className={`filter-option ${value === "" ? "is-selected" : ""}`}
+              onClick={() => {
+                onChange("");
+                setOpen(false);
+              }}
+            >
+              {placeholder}
+            </button>
+          </li>
+          {options.map((option) => (
+            <li key={option}>
+              <button
+                type="button"
+                className={`filter-option ${value === option ? "is-selected" : ""}`}
+                onClick={() => {
+                  onChange(option);
+                  setOpen(false);
+                }}
+              >
+                {option}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/InstallCommands.tsx
+++ b/apps/web/components/InstallCommands.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+
+type InstallCommandsProps = {
+  codex: string;
+  claude: string;
+  generic: string;
+};
+
+type RuntimeKey = "codex" | "claude" | "generic";
+
+export default function InstallCommands({ codex, claude, generic }: InstallCommandsProps) {
+  const [copied, setCopied] = useState<RuntimeKey | null>(null);
+
+  async function copy(runtime: RuntimeKey, value: string) {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(runtime);
+      window.setTimeout(() => setCopied((prev) => (prev === runtime ? null : prev)), 1400);
+    } catch {
+      setCopied(null);
+    }
+  }
+
+  const rows: Array<{ key: RuntimeKey; title: string; command: string }> = [
+    { key: "codex", title: "Install (Codex)", command: codex },
+    { key: "claude", title: "Install (Claude)", command: claude },
+    { key: "generic", title: "Install (Generic)", command: generic }
+  ];
+
+  return (
+    <article className="card detail-panel install-card">
+      {rows.map((row) => (
+        <section key={row.key} className="install-item">
+          <div className="install-head">
+            <h2>{row.title}</h2>
+            <button
+              type="button"
+              className="button button--secondary copy-button"
+              onClick={() => copy(row.key, row.command)}
+            >
+              {copied === row.key ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <pre className="install">{row.command}</pre>
+        </section>
+      ))}
+    </article>
+  );
+}

--- a/apps/web/components/SkillsCatalogClient.tsx
+++ b/apps/web/components/SkillsCatalogClient.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import type { SkillEntry } from "@/lib/registry";
+import FilterSelect from "@/components/FilterSelect";
+
+type SkillsCatalogClientProps = {
+  skills: SkillEntry[];
+  categories: string[];
+  tags: string[];
+  initial: {
+    q: string;
+    tag: string;
+    category: string;
+    runtime: string;
+  };
+};
+
+export default function SkillsCatalogClient({ skills, categories, tags, initial }: SkillsCatalogClientProps) {
+  const [draftQ, setDraftQ] = useState(initial.q);
+  const [draftTag, setDraftTag] = useState(initial.tag);
+  const [draftCategory, setDraftCategory] = useState(initial.category);
+  const [draftRuntime, setDraftRuntime] = useState(initial.runtime);
+
+  const [q, setQ] = useState(initial.q);
+  const [tag, setTag] = useState(initial.tag);
+  const [category, setCategory] = useState(initial.category);
+  const [runtime, setRuntime] = useState(initial.runtime);
+
+  const filtered = useMemo(() => {
+    const qLower = q.toLowerCase();
+    return skills.filter((skill) => {
+      if (qLower) {
+        const haystack = `${skill.id} ${skill.name} ${skill.description}`.toLowerCase();
+        if (!haystack.includes(qLower)) {
+          return false;
+        }
+      }
+      if (tag && !skill.tags.includes(tag)) {
+        return false;
+      }
+      if (category && skill.category !== category) {
+        return false;
+      }
+      if (runtime && !skill.runtimes.includes(runtime)) {
+        return false;
+      }
+      return true;
+    });
+  }, [skills, q, tag, category, runtime]);
+
+  function applyFilters() {
+    setQ(draftQ);
+    setTag(draftTag);
+    setCategory(draftCategory);
+    setRuntime(draftRuntime);
+  }
+
+  return (
+    <>
+      <div className="filters">
+        <input
+          className="input"
+          value={draftQ}
+          onChange={(event) => setDraftQ(event.target.value)}
+          placeholder="Search name, id, description"
+        />
+
+        <FilterSelect
+          label="Category"
+          value={draftCategory}
+          options={categories}
+          placeholder="All categories"
+          onChange={setDraftCategory}
+        />
+
+        <FilterSelect
+          label="Tag"
+          value={draftTag}
+          options={tags}
+          placeholder="All tags"
+          onChange={setDraftTag}
+        />
+
+        <FilterSelect
+          label="Runtime"
+          value={draftRuntime}
+          options={["codex", "claude", "generic"]}
+          placeholder="All runtimes"
+          onChange={setDraftRuntime}
+        />
+
+        <button className="button button--accent" type="button" onClick={applyFilters}>
+          Apply Filters
+        </button>
+      </div>
+
+      <p className="meta">{filtered.length} result(s)</p>
+
+      <section className="grid">
+        {filtered.map((skill) => (
+          <Link key={skill.id} href={`/skills/${skill.id}`} className="card">
+            <p className="meta">{skill.id}</p>
+            <h2>{skill.name}</h2>
+            <p>{skill.description}</p>
+            <div className="tags">
+              {skill.tags.map((entry) => (
+                <span key={entry} className="tag">{entry}</span>
+              ))}
+            </div>
+          </Link>
+        ))}
+      </section>
+    </>
+  );
+}

--- a/apps/web/lib/registry.ts
+++ b/apps/web/lib/registry.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type VersionEntry = {
+  version: string;
+  released_at: string;
+  manifest_url: string;
+  artifact_url: string;
+  sha256: string;
+};
+
+export type SkillEntry = {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  latest: string;
+  versions: VersionEntry[];
+  runtimes: string[];
+  tags: string[];
+  deprecated: boolean;
+  replaced_by?: string;
+};
+
+export type RegistryIndex = {
+  registry_version: string;
+  generated_at: string;
+  skills: SkillEntry[];
+};
+
+function registryPath() {
+  return path.resolve(process.cwd(), "..", "..", "registry", "index.json");
+}
+
+export async function loadRegistry(): Promise<RegistryIndex> {
+  const data = await fs.readFile(registryPath(), "utf-8");
+  return JSON.parse(data) as RegistryIndex;
+}
+
+export async function getSkillById(id: string): Promise<SkillEntry | undefined> {
+  const registry = await loadRegistry();
+  return registry.skills.find((s) => s.id === id);
+}
+
+export function buildInstallSnippet(skill: SkillEntry, runtime: "codex" | "claude" | "generic") {
+  const base = `./bin/skills-hub install ${skill.id}@${skill.latest}`;
+  if (runtime === "generic") {
+    return `${base} --runtime generic --target ./my-agent/skills`;
+  }
+  return `${base} --runtime ${runtime}`;
+}
+
+export function uniqueValues(values: string[]) {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "skills-hub-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.11",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.15",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "typescript": "5.5.4"
+  },
+  "packageManager": "pnpm@10.30.1+sha512.3590e550d5384caa39bd5c7c739f72270234b2f6059e13018f975c313b1eb9fefcc09714048765d4d9efe961382c312e624572c0420762bdc5d5940cdf9be73a"
+}

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -1,0 +1,345 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      next:
+        specifier: 14.2.11
+        version: 14.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/node':
+        specifier: 20.14.15
+        version: 20.14.15
+      '@types/react':
+        specifier: 18.3.3
+        version: 18.3.3
+      '@types/react-dom':
+        specifier: 18.3.0
+        version: 18.3.0
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
+
+packages:
+
+  '@next/env@14.2.11':
+    resolution: {integrity: sha512-HYsQRSIXwiNqvzzYThrBwq6RhXo3E0n8j8nQnAs8i4fCEo2Zf/3eS0IiRA8XnRg9Ha0YnpkyJZIZg1qEwemrHw==}
+
+  '@next/swc-darwin-arm64@14.2.11':
+    resolution: {integrity: sha512-eiY9u7wEJZWp/Pga07Qy3ZmNEfALmmSS1HtsJF3y1QEyaExu7boENz11fWqDmZ3uvcyAxCMhTrA1jfVxITQW8g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@14.2.11':
+    resolution: {integrity: sha512-lnB0zYCld4yE0IX3ANrVMmtAbziBb7MYekcmR6iE9bujmgERl6+FK+b0MBq0pl304lYe7zO4yxJus9H/Af8jbg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@14.2.11':
+    resolution: {integrity: sha512-Ulo9TZVocYmUAtzvZ7FfldtwUoQY0+9z3BiXZCLSUwU2bp7GqHA7/bqrfsArDlUb2xeGwn3ZuBbKtNK8TR0A8w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@14.2.11':
+    resolution: {integrity: sha512-fH377DnKGyUnkWlmUpFF1T90m0dADBfK11dF8sOQkiELF9M+YwDRCGe8ZyDzvQcUd20Rr5U7vpZRrAxKwd3Rzg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@14.2.11':
+    resolution: {integrity: sha512-a0TH4ZZp4NS0LgXP/488kgvWelNpwfgGTUCDXVhPGH6pInb7yIYNgM4kmNWOxBFt+TIuOH6Pi9NnGG4XWFUyXQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@14.2.11':
+    resolution: {integrity: sha512-DYYZcO4Uir2gZxA4D2JcOAKVs8ZxbOFYPpXSVIgeoQbREbeEHxysVsg3nY4FrQy51e5opxt5mOHl/LzIyZBoKA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@14.2.11':
+    resolution: {integrity: sha512-PwqHeKG3/kKfPpM6of1B9UJ+Er6ySUy59PeFu0Un0LBzJTRKKAg2V6J60Yqzp99m55mLa+YTbU6xj61ImTv9mg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-ia32-msvc@14.2.11':
+    resolution: {integrity: sha512-0U7PWMnOYIvM74GY6rbH6w7v+vNPDVH1gUhlwHpfInJnNe5LkmUZqhp7FNWeNa5wbVgRcRi1F1cyxp4dmeLLvA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@14.2.11':
+    resolution: {integrity: sha512-gQpS7mcgovWoaTG1FbS5/ojF7CGfql1Q0ZLsMrhcsi2Sr9HEqsUZ70MPJyaYBXbk6iEAP7UXMD9HC8KY1qNwvA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/helpers@0.5.5':
+    resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
+
+  '@types/node@20.14.15':
+    resolution: {integrity: sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.0':
+    resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
+
+  '@types/react@18.3.3':
+    resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
+  caniuse-lite@1.0.30001774:
+    resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  next@14.2.11:
+    resolution: {integrity: sha512-8MDFqHBhdmR2wdfaWc8+lW3A/hppFe1ggQ9vgIu/g2/2QEMYJrPoQP6b+VNk56gIug/bStysAmrpUKtj3XN8Bw==}
+    engines: {node: '>=18.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      sass:
+        optional: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
+  styled-jsx@5.1.1:
+    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+snapshots:
+
+  '@next/env@14.2.11': {}
+
+  '@next/swc-darwin-arm64@14.2.11':
+    optional: true
+
+  '@next/swc-darwin-x64@14.2.11':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@14.2.11':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@14.2.11':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@14.2.11':
+    optional: true
+
+  '@next/swc-linux-x64-musl@14.2.11':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@14.2.11':
+    optional: true
+
+  '@next/swc-win32-ia32-msvc@14.2.11':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@14.2.11':
+    optional: true
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.5':
+    dependencies:
+      '@swc/counter': 0.1.3
+      tslib: 2.8.1
+
+  '@types/node@20.14.15':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.0':
+    dependencies:
+      '@types/react': 18.3.3
+
+  '@types/react@18.3.3':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
+  caniuse-lite@1.0.30001774: {}
+
+  client-only@0.0.1: {}
+
+  csstype@3.2.3: {}
+
+  graceful-fs@4.2.11: {}
+
+  js-tokens@4.0.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  nanoid@3.3.11: {}
+
+  next@14.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@next/env': 14.2.11
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001774
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.11
+      '@next/swc-darwin-x64': 14.2.11
+      '@next/swc-linux-arm64-gnu': 14.2.11
+      '@next/swc-linux-arm64-musl': 14.2.11
+      '@next/swc-linux-x64-gnu': 14.2.11
+      '@next/swc-linux-x64-musl': 14.2.11
+      '@next/swc-win32-arm64-msvc': 14.2.11
+      '@next/swc-win32-ia32-msvc': 14.2.11
+      '@next/swc-win32-x64-msvc': 14.2.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  picocolors@1.1.1: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  source-map-js@1.2.1: {}
+
+  streamsearch@1.1.0: {}
+
+  styled-jsx@5.1.1(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
+
+  tslib@2.8.1: {}
+
+  typescript@5.5.4: {}
+
+  undici-types@5.26.5: {}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/cmd/skills-hub/main.go
+++ b/cmd/skills-hub/main.go
@@ -5,9 +5,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/ai-knowledge-hub/ai-skills-guide/internal/installer"
+	"github.com/ai-knowledge-hub/ai-skills-guide/internal/registry"
 	"github.com/ai-knowledge-hub/ai-skills-guide/internal/skills"
 )
 
@@ -24,6 +27,8 @@ func main() {
 	switch cmd {
 	case "list":
 		err = runList(args)
+	case "search":
+		err = runSearch(args)
 	case "info":
 		err = runInfo(args)
 	case "validate":
@@ -45,49 +50,98 @@ func main() {
 
 func runList(args []string) error {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	root := fs.String("root", "skills", "skills root directory")
+	registryPath := fs.String("registry", "registry/index.json", "registry index path")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	all, err := skills.Discover(*root)
+	idx, err := registry.LoadIndex(*registryPath)
 	if err != nil {
 		return err
 	}
-	for _, s := range all {
+	for _, s := range idx.Skills {
 		status := "active"
 		if s.Deprecated {
 			status = "deprecated"
 		}
-		fmt.Printf("%s\t%s\t%s\n", s.ID, status, s.Name)
+		fmt.Printf("%s\t%s\t%s\t%s\n", s.ID, status, s.Latest, s.Name)
 	}
+	return nil
+}
+
+func runSearch(args []string) error {
+	fs := flag.NewFlagSet("search", flag.ContinueOnError)
+	registryPath := fs.String("registry", "registry/index.json", "registry index path")
+	text := fs.String("q", "", "free text search against id/name/description")
+	tag := fs.String("tag", "", "filter by tag")
+	category := fs.String("category", "", "filter by category")
+	runtime := fs.String("runtime", "", "filter by runtime")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	idx, err := registry.LoadIndex(*registryPath)
+	if err != nil {
+		return err
+	}
+	results := registry.Search(idx, registry.SearchQuery{
+		Text:     *text,
+		Tag:      *tag,
+		Category: *category,
+		Runtime:  *runtime,
+	})
+	for _, s := range results {
+		fmt.Printf("%s\t%s\t%s\n", s.ID, s.Category, s.Latest)
+	}
+	fmt.Printf("Found %d skill(s).\n", len(results))
 	return nil
 }
 
 func runInfo(args []string) error {
 	fs := flag.NewFlagSet("info", flag.ContinueOnError)
-	root := fs.String("root", "skills", "skills root directory")
-	skillID := fs.String("skill", "", "skill id (category/slug)")
+	registryPath := fs.String("registry", "registry/index.json", "registry index path")
+	skillsRoot := fs.String("root", "skills", "skills root directory")
+	skillSpec := fs.String("skill", "", "skill id, optionally with @version")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *skillID == "" {
+	if *skillSpec == "" {
 		return errors.New("--skill is required")
 	}
 
-	all, err := skills.Discover(*root)
+	id, requestedVersion, err := parseSkillSpec(*skillSpec)
 	if err != nil {
 		return err
 	}
-	skill, ok := skills.FindByID(all, *skillID)
+
+	idx, err := registry.LoadIndex(*registryPath)
+	if err != nil {
+		return err
+	}
+	skill, ok := registry.FindSkill(idx, id)
 	if !ok {
-		return fmt.Errorf("skill not found: %s", *skillID)
+		return fmt.Errorf("skill not found in registry: %s", id)
+	}
+	resolvedVersion, err := registry.ResolveVersion(skill, requestedVersion)
+	if err != nil {
+		return err
 	}
 
+	versions := make([]string, 0, len(skill.Versions))
+	for _, v := range skill.Versions {
+		versions = append(versions, v.Version)
+	}
+	sort.Strings(versions)
+
 	fmt.Printf("id: %s\n", skill.ID)
-	fmt.Printf("path: %s\n", skill.Path)
+	fmt.Printf("path: %s\n", filepath.Join(*skillsRoot, filepath.FromSlash(skill.ID)))
 	fmt.Printf("name: %s\n", skill.Name)
 	fmt.Printf("description: %s\n", skill.Description)
+	fmt.Printf("category: %s\n", skill.Category)
+	fmt.Printf("latest: %s\n", skill.Latest)
+	fmt.Printf("selected_version: %s\n", resolvedVersion.Version)
+	fmt.Printf("versions: %s\n", strings.Join(versions, ", "))
+	fmt.Printf("runtimes: %s\n", strings.Join(skill.Runtimes, ", "))
 	fmt.Printf("deprecated: %t\n", skill.Deprecated)
 	if skill.ReplacedBy != "" {
 		fmt.Printf("replaced_by: %s\n", skill.ReplacedBy)
@@ -118,26 +172,48 @@ func runValidate(args []string) error {
 }
 
 func runInstall(args []string) error {
-	fs := flag.NewFlagSet("install", flag.ContinueOnError)
-	root := fs.String("root", "skills", "skills root directory")
-	runtimeName := fs.String("runtime", "generic", "runtime adapter: codex|claude|generic")
-	target := fs.String("target", "", "destination skills directory (optional for codex/claude)")
-	skillID := fs.String("skill", "", "skill id (category/slug)")
-	force := fs.Bool("force", false, "overwrite destination if it already exists")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	if *skillID == "" {
-		return errors.New("--skill is required")
+	positionalSpec := ""
+	parsedArgs := args
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		positionalSpec = args[0]
+		parsedArgs = args[1:]
 	}
 
-	all, err := skills.Discover(*root)
+	fs := flag.NewFlagSet("install", flag.ContinueOnError)
+	skillsRoot := fs.String("root", "skills", "skills root directory")
+	registryPath := fs.String("registry", "registry/index.json", "registry index path")
+	runtimeName := fs.String("runtime", "generic", "runtime adapter: codex|claude|generic")
+	target := fs.String("target", "", "destination skills directory (optional for codex/claude)")
+	skillSpecFlag := fs.String("skill", "", "skill id, optionally with @version")
+	force := fs.Bool("force", false, "overwrite destination if it already exists")
+	if err := fs.Parse(parsedArgs); err != nil {
+		return err
+	}
+
+	skillSpec := strings.TrimSpace(*skillSpecFlag)
+	if skillSpec == "" {
+		skillSpec = positionalSpec
+	}
+	if skillSpec == "" {
+		return errors.New("skill is required (use --skill <id[@version]> or positional <id[@version]>)")
+	}
+
+	id, requestedVersion, err := parseSkillSpec(skillSpec)
 	if err != nil {
 		return err
 	}
-	skill, ok := skills.FindByID(all, *skillID)
+
+	idx, err := registry.LoadIndex(*registryPath)
+	if err != nil {
+		return err
+	}
+	skill, ok := registry.FindSkill(idx, id)
 	if !ok {
-		return fmt.Errorf("skill not found: %s", *skillID)
+		return fmt.Errorf("skill not found in registry: %s", id)
+	}
+	resolvedVersion, err := registry.ResolveVersion(skill, requestedVersion)
+	if err != nil {
+		return err
 	}
 
 	if skill.Deprecated {
@@ -148,17 +224,43 @@ func runInstall(args []string) error {
 		fmt.Fprintln(os.Stderr)
 	}
 
+	sourceDir := filepath.Join(*skillsRoot, filepath.FromSlash(skill.ID))
+	if stat, statErr := os.Stat(sourceDir); statErr != nil || !stat.IsDir() {
+		return fmt.Errorf("local source not found for %s at %s", skill.ID, sourceDir)
+	}
+
 	rt, err := installer.ResolveRuntimeTarget(*runtimeName, *target)
 	if err != nil {
 		return err
 	}
-	destination, err := installer.InstallSkill(skill.Path, rt.TargetPath, skill.ID, *force)
+	destination, err := installer.InstallSkill(sourceDir, rt.TargetPath, skill.ID, *force)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Installed %s to %s (runtime=%s)\n", skill.ID, destination, rt.Runtime)
+	fmt.Printf("Installed %s@%s to %s (runtime=%s)\n", skill.ID, resolvedVersion.Version, destination, rt.Runtime)
 	return nil
+}
+
+func parseSkillSpec(spec string) (string, string, error) {
+	trimmed := strings.TrimSpace(spec)
+	if trimmed == "" {
+		return "", "", errors.New("empty skill spec")
+	}
+
+	parts := strings.SplitN(trimmed, "@", 2)
+	id := strings.TrimSpace(parts[0])
+	if id == "" {
+		return "", "", fmt.Errorf("invalid skill spec: %s", spec)
+	}
+	version := "latest"
+	if len(parts) == 2 {
+		version = strings.TrimSpace(parts[1])
+		if version == "" {
+			return "", "", fmt.Errorf("invalid version in skill spec: %s", spec)
+		}
+	}
+	return id, version, nil
 }
 
 func printUsage() {
@@ -169,18 +271,19 @@ func printUsage() {
 		"  skills-hub <command> [flags]",
 		"",
 		"Commands:",
-		"  list      List available skills",
+		"  list      List skills from registry/index.json",
+		"  search    Search skills by text/tag/category/runtime",
 		"  info      Show details for one skill",
-		"  validate  Validate skill structure and prompt coverage",
-		"  install   Copy a skill into a target runtime directory",
+		"  validate  Validate local skill structure and prompt coverage",
+		"  install   Install a local skill package resolved from registry metadata",
 		"",
 		"Examples:",
 		"  skills-hub list",
-		"  skills-hub info --skill marketing/meta-google-weekly-performance-review",
+		"  skills-hub search --tag paid-media --runtime codex",
+		"  skills-hub info --skill marketing/meta-google-weekly-performance-review@latest",
 		"  skills-hub validate",
-		"  skills-hub install --skill marketing/meta-google-weekly-performance-review --runtime codex",
-		"  skills-hub install --skill marketing/meta-google-weekly-performance-review --runtime claude",
-		"  skills-hub install --skill marketing/meta-google-weekly-performance-review --runtime generic --target ./my-agent/skills",
+		"  skills-hub install marketing/meta-google-weekly-performance-review@latest --runtime codex",
+		"  skills-hub install --skill marketing/meta-google-weekly-performance-review@0.1.0 --runtime generic --target ./my-agent/skills",
 	}
 	fmt.Println(strings.Join(lines, "\n"))
 }

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -99,6 +99,19 @@ into a public skills hub while staying on free-tier infrastructure.
   - short term: registry metadata + local install paths
   - next phase: hosted versioned artifacts and signatures
 
+## Vercel Deployment Notes (Web MVP)
+
+- Deploy target: `apps/web`.
+- Build command: `npm run build`.
+- Install command: `npm install`.
+- Output: standard Next.js deployment on Vercel.
+- Environment assumptions:
+  - app reads `registry/index.json` from repository at build/runtime
+  - no database or auth dependency required for MVP
+- Domain plan:
+  - production custom domain on Vercel
+  - preview deployments from pull requests
+
 ## Open Questions
 
 - Final public name for the hub website.

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -42,6 +42,7 @@ func BuildIndex(root string) (Index, error) {
 			ID:          m.ID,
 			Name:        m.Name,
 			Description: m.Description,
+			Category:    m.Category,
 			Latest:      m.Version,
 			Versions: []VersionEntry{{
 				Version:     m.Version,

--- a/internal/registry/index.go
+++ b/internal/registry/index.go
@@ -1,0 +1,89 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+func LoadIndex(path string) (Index, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Index{}, fmt.Errorf("read registry index %s: %w", path, err)
+	}
+	var idx Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return Index{}, fmt.Errorf("parse registry index %s: %w", path, err)
+	}
+	return idx, nil
+}
+
+func FindSkill(idx Index, id string) (SkillEntry, bool) {
+	for _, s := range idx.Skills {
+		if s.ID == id {
+			return s, true
+		}
+	}
+	return SkillEntry{}, false
+}
+
+func ResolveVersion(skill SkillEntry, requested string) (VersionEntry, error) {
+	version := strings.TrimSpace(requested)
+	if version == "" || version == "latest" {
+		version = skill.Latest
+	}
+	for _, v := range skill.Versions {
+		if v.Version == version {
+			return v, nil
+		}
+	}
+	return VersionEntry{}, fmt.Errorf("version %s not found for %s", version, skill.ID)
+}
+
+type SearchQuery struct {
+	Text     string
+	Tag      string
+	Category string
+	Runtime  string
+}
+
+func Search(idx Index, q SearchQuery) []SkillEntry {
+	text := strings.ToLower(strings.TrimSpace(q.Text))
+	tag := strings.ToLower(strings.TrimSpace(q.Tag))
+	category := strings.ToLower(strings.TrimSpace(q.Category))
+	runtime := strings.ToLower(strings.TrimSpace(q.Runtime))
+
+	out := make([]SkillEntry, 0)
+	for _, s := range idx.Skills {
+		if text != "" {
+			haystack := strings.ToLower(s.ID + " " + s.Name + " " + s.Description)
+			if !strings.Contains(haystack, text) {
+				continue
+			}
+		}
+		if tag != "" && !containsFold(s.Tags, tag) {
+			continue
+		}
+		if category != "" && strings.ToLower(s.Category) != category {
+			continue
+		}
+		if runtime != "" && !containsFold(s.Runtimes, runtime) {
+			continue
+		}
+		out = append(out, s)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+func containsFold(items []string, needle string) bool {
+	for _, item := range items {
+		if strings.EqualFold(item, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/registry/index_test.go
+++ b/internal/registry/index_test.go
@@ -1,0 +1,47 @@
+package registry
+
+import "testing"
+
+func TestResolveVersion(t *testing.T) {
+	skill := SkillEntry{
+		ID:     "marketing/demo",
+		Latest: "0.2.0",
+		Versions: []VersionEntry{
+			{Version: "0.1.0"},
+			{Version: "0.2.0"},
+		},
+	}
+	v, err := ResolveVersion(skill, "latest")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Version != "0.2.0" {
+		t.Fatalf("expected latest version, got %s", v.Version)
+	}
+}
+
+func TestSearchFilters(t *testing.T) {
+	idx := Index{Skills: []SkillEntry{
+		{
+			ID:          "marketing/meta-weekly",
+			Name:        "Meta Weekly",
+			Description: "weekly report",
+			Category:    "marketing-tools/ads-ops",
+			Tags:        []string{"paid-media", "weekly"},
+			Runtimes:    []string{"codex", "generic"},
+		},
+		{
+			ID:          "adtech/sql-safety",
+			Name:        "SQL Safety",
+			Description: "query checks",
+			Category:    "adtech/analytics-engineering",
+			Tags:        []string{"sql"},
+			Runtimes:    []string{"claude"},
+		},
+	}}
+
+	results := Search(idx, SearchQuery{Tag: "paid-media", Runtime: "codex"})
+	if len(results) != 1 || results[0].ID != "marketing/meta-weekly" {
+		t.Fatalf("unexpected search results: %#v", results)
+	}
+}

--- a/internal/registry/manifest_parser.go
+++ b/internal/registry/manifest_parser.go
@@ -84,6 +84,8 @@ func ParseManifest(path string) (Manifest, error) {
 			out.Version = value
 		case "released_at":
 			out.ReleasedAt = value
+		case "category":
+			out.Category = value
 		case "tags":
 			currentListKey = "tags"
 		case "runtimes":
@@ -124,6 +126,9 @@ func validateManifestFields(m Manifest, path string) error {
 	}
 	if len(m.Runtimes) == 0 {
 		return fmt.Errorf("manifest %s missing runtimes", path)
+	}
+	if m.Category == "" {
+		return fmt.Errorf("manifest %s missing category", path)
 	}
 	if len(m.Tags) == 0 {
 		return fmt.Errorf("manifest %s missing tags", path)

--- a/internal/registry/manifest_parser_test.go
+++ b/internal/registry/manifest_parser_test.go
@@ -41,6 +41,9 @@ deprecated: false
 	if m.Description != "First sentence, second sentence." {
 		t.Fatalf("unexpected description: %s", m.Description)
 	}
+	if m.Category != "marketing-tools/ads-ops" {
+		t.Fatalf("unexpected category: %s", m.Category)
+	}
 	if len(m.Tags) != 2 || m.Tags[0] != "one" || m.Tags[1] != "two" {
 		t.Fatalf("unexpected tags: %#v", m.Tags)
 	}

--- a/internal/registry/types.go
+++ b/internal/registry/types.go
@@ -6,6 +6,7 @@ type Manifest struct {
 	Description string
 	Version     string
 	ReleasedAt  string
+	Category    string
 	Tags        []string
 	Runtimes    []string
 	Deprecated  bool
@@ -22,6 +23,7 @@ type SkillEntry struct {
 	ID          string         `json:"id"`
 	Name        string         `json:"name"`
 	Description string         `json:"description"`
+	Category    string         `json:"category"`
 	Latest      string         `json:"latest"`
 	Versions    []VersionEntry `json:"versions"`
 	Runtimes    []string       `json:"runtimes"`

--- a/registry/index.json
+++ b/registry/index.json
@@ -6,6 +6,7 @@
       "id": "adtech/analyst-copilot-bigquery-redshift",
       "name": "Analyst Co-pilot (BigQuery + Redshift)",
       "description": "Assist analysts with safe SQL drafting, metric validation, and stakeholder-ready summaries across BigQuery and Redshift.",
+      "category": "adtech/analytics-engineering",
       "latest": "0.1.0",
       "versions": [
         {
@@ -33,6 +34,7 @@
       "id": "adtech/policy-brand-compliance-checker",
       "name": "Policy + Brand Compliance Checker",
       "description": "Validate ad copy, landing URLs, and UTM tracking for policy and brand compliance before campaign launch.",
+      "category": "adtech/compliance",
       "latest": "0.1.0",
       "versions": [
         {
@@ -60,6 +62,7 @@
       "id": "marketing/creative-workshop-pmax-reels",
       "name": "Creative Workshop (PMax + Reels)",
       "description": "Generate channel-specific creative variants for Google PMax and Meta Reels with deterministic length checks.",
+      "category": "marketing-tools/creative-ops",
       "latest": "0.1.0",
       "versions": [
         {
@@ -87,6 +90,7 @@
       "id": "marketing/lifecycle-experiment-planner",
       "name": "Lifecycle Experiment Planner",
       "description": "Design lifecycle A/B tests with hypothesis checks, sample-size guidance, and stopping criteria.",
+      "category": "marketing-tools/lifecycle-crm",
       "latest": "0.1.0",
       "versions": [
         {
@@ -114,6 +118,7 @@
       "id": "marketing/meta-google-weekly-performance-review",
       "name": "Meta + Google Weekly Performance Review",
       "description": "Analyze weekly paid media performance across Meta and Google Ads with KPI deltas and prioritized actions.",
+      "category": "marketing-tools/ads-ops",
       "latest": "0.1.0",
       "versions": [
         {
@@ -141,6 +146,7 @@
       "id": "marketing/seo-paid-search-synergy",
       "name": "SEO to Paid Search Synergy",
       "description": "Turn top-performing SEO themes into paid search opportunities with keyword clustering and launch-ready recommendations.",
+      "category": "marketing-tools/seo-sem",
       "latest": "0.1.0",
       "versions": [
         {

--- a/shared/schemas/registry-index.schema.json
+++ b/shared/schemas/registry-index.schema.json
@@ -32,6 +32,7 @@
           "id",
           "name",
           "description",
+          "category",
           "latest",
           "versions",
           "runtimes",
@@ -50,6 +51,10 @@
           "description": {
             "type": "string",
             "minLength": 10
+          },
+          "category": {
+            "type": "string",
+            "minLength": 3
           },
           "latest": {
             "type": "string",


### PR DESCRIPTION
This PR introduces the first public-facing Hub MVP web app and aligns it with the registry/CLI foundation already implemented on `dev`.  

## **What’s included**

1. Hub web app scaffold (`apps/web`)
- Next.js app with TypeScript setup.
- Route structure:
  - `/` overview/hero
  - `/skills` catalog
  - `/skills/[...id]` skill details
  - `not-found` fallback
- Registry-driven data loading from `registry/index.json`.

2. Catalog and discovery UX
- Searchable skills catalog.
- Custom filter dropdowns (category/tag/runtime) replacing native select UI.
- Better visual consistency with app styling and interaction states.

3. Skill detail install UX
- Install commands for `codex`, `claude`, and `generic`.
- Copy-to-clipboard controls for each command.
- Responsive detail layout improvements:
  - desktop symmetry (equal-height metadata/install panels)
  - mobile-safe stacking and spacing
  - command wrapping to avoid horizontal scrollbar noise.

4. Visual design system
- Added tokenized theme layer:
  - `theme-brand` and `theme-hybrid`
- Defaulted to hybrid branded style.
- Clear hierarchy between tags vs secondary action buttons.

5. Repo/docs/dev UX updates
- New make targets:
  - `web-dev`
  - `web-build`
- README updates for web app usage.
- Architecture docs updated with stack/deployment notes.
- `.gitignore` expanded for Node/Next/pnpm local artifacts.


**Notes**
- Web app is static-first and intentionally has no backend/auth dependency in MVP.
- Vercel deployment target should be `apps/web`.
