### PR TITLE
feat(qa): add playwright smoke skill, web e2e, and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,25 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: true
+
+  web-e2e-smoke:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+      - name: Install web dependencies
+        run: pnpm install
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run smoke e2e
+        run: npx playwright test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           fail: true
 
   web-e2e-smoke:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: apps/web

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,8 @@ cd apps/web
 pnpm test:e2e
 ```
 
-If Playwright browsers are not installed yet, run `pnpm test:e2e:setup` first (see `apps/web/README.md`).
+If Playwright browsers are not installed yet, run `pnpm test:e2e:setup`
+first (see `apps/web/README.md`).
 
 ## Branch and commit guidance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,24 @@
 - Failures and fallback paths are documented.
 - Output shape is consistent and testable.
 
+## Quality gates
+
+Run before opening a PR:
+
+```bash
+bash scripts/validate-skills.sh
+```
+
+If your changes touch `apps/web`, also run:
+
+```bash
+cd apps/web
+pnpm test:e2e
+```
+
+If Playwright browsers are not installed yet, run `pnpm test:e2e:setup` first (see `apps/web/README.md`).
+
 ## Branch and commit guidance
 
-- Use short feature branches (e.g., `feature/skill-utm-linter`).
+- Use short feature branches prefixed with `codex/` (e.g., `codex/skill-utm-linter`).
 - Use scoped commit messages (e.g., `feat(skill): add pmax creative workshop`).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AI Skills Guide
 
 Practical, reusable AI skills for marketing practitioners and ad-tech
-software engineers.
+software engineers, plus a hub UI and QA automation flows.
 
 ## What this repo is
 
@@ -16,7 +16,7 @@ scripts, test prompts, and contribution standards.
 - Community references:
   [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)
 
-## v0.1 Scope (6 practical skills)
+## Current Scope (7 practical skills)
 
 1. `meta-google-weekly-performance-review` (Beginner)
 2. `creative-workshop-pmax-reels` (Intermediate)
@@ -24,6 +24,7 @@ scripts, test prompts, and contribution standards.
 4. `policy-brand-compliance-checker` (Intermediate)
 5. `seo-paid-search-synergy` (Advanced)
 6. `analyst-copilot-bigquery-redshift` (Advanced)
+7. `playwright-agentic-e2e` (QA / Infrastructure)
 
 ## Definition of done for each skill
 
@@ -39,6 +40,8 @@ scripts, test prompts, and contribution standards.
 skills/
   marketing/
   adtech/
+apps/
+  web/
 shared/
   metrics/
   policies/
@@ -132,8 +135,8 @@ The repo now includes a Next.js catalog app at `apps/web`.
 
 ```bash
 cd apps/web
-npm install
-npm run dev
+pnpm install
+pnpm dev
 ```
 
 Core routes:
@@ -141,3 +144,11 @@ Core routes:
 - `/` overview
 - `/skills` searchable catalog
 - `/skills/<category>/<slug>` skill details and install snippets
+
+Smoke E2E tests:
+
+```bash
+cd apps/web
+pnpm test:e2e:setup
+pnpm test:e2e
+```

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,3 +1,5 @@
 .next/
 out/
 node_modules/
+playwright-report/
+test-results/

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -6,17 +6,32 @@ This app renders a static-first skills catalog from `../../registry/index.json`.
 
 ```bash
 cd apps/web
-npm install
-npm run dev
+pnpm install
+pnpm dev
 ```
 
 Then open `http://localhost:3000`.
 
+## E2E smoke tests (Playwright)
+
+First-time setup downloads the browser binary:
+
+```bash
+cd apps/web
+pnpm test:e2e:setup
+```
+
+Run tests:
+
+```bash
+pnpm test:e2e
+```
+
 ## Build
 
 ```bash
-npm run build
-npm start
+pnpm build
+pnpm start
 ```
 
 ## Routes

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+const sampleSkillPath = "/skills/marketing/meta-google-weekly-performance-review";
+
+test("home route smoke", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("link", { name: "Browse Skills" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Explore catalog" })).toBeVisible();
+});
+
+test("skills route filter interaction smoke", async ({ page }) => {
+  await page.goto("/skills");
+  const runtimeTrigger = page.getByRole("button", { name: "Runtime" });
+
+  await runtimeTrigger.click();
+  await page.getByRole("button", { name: "codex" }).click();
+  await page.getByRole("button", { name: "Apply Filters" }).click();
+
+  await expect(runtimeTrigger).toContainText("codex");
+  await expect(page.getByText(/\d+ result\(s\)/)).toBeVisible();
+});
+
+test("skill detail copy-button smoke", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: async () => {} }
+    });
+  });
+
+  await page.goto(sampleSkillPath);
+  const copyButtons = page.locator(".copy-button");
+
+  await expect(copyButtons).toHaveCount(3);
+  await expect(copyButtons.first()).toHaveText("Copy");
+  await copyButtons.first().click();
+  await expect(copyButtons.first()).toHaveText("Copied");
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e:setup": "playwright install chromium",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "next": "14.2.11",
@@ -14,6 +16,7 @@
     "react-dom": "18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "1.41.2",
     "@types/node": "20.14.15",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,29 @@
+import path from "node:path";
+import { defineConfig, devices } from "@playwright/test";
+
+const webAppRoot = __dirname;
+
+export default defineConfig({
+  testDir: path.join(webAppRoot, "e2e"),
+  outputDir: path.join(webAppRoot, "test-results"),
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "on-first-retry"
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ],
+  webServer: {
+    command: "pnpm dev --port 3000",
+    cwd: webAppRoot,
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000
+  }
+});

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       next:
         specifier: 14.2.11
-        version: 14.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.11(@playwright/test@1.41.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -18,6 +18,9 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@playwright/test':
+        specifier: 1.41.2
+        version: 1.41.2
       '@types/node':
         specifier: 20.14.15
         version: 20.14.15
@@ -94,6 +97,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.41.2':
+    resolution: {integrity: sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==}
+    engines: {node: '>=16'}
+    deprecated: Please update to the latest version of Playwright to test up-to-date browsers.
+    hasBin: true
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -124,6 +133,11 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -160,6 +174,16 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  playwright-core@1.41.2:
+    resolution: {integrity: sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  playwright@1.41.2:
+    resolution: {integrity: sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -240,6 +264,10 @@ snapshots:
   '@next/swc-win32-x64-msvc@14.2.11':
     optional: true
 
+  '@playwright/test@1.41.2':
+    dependencies:
+      playwright: 1.41.2
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.5':
@@ -272,6 +300,9 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   graceful-fs@4.2.11: {}
 
   js-tokens@4.0.0: {}
@@ -282,7 +313,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@14.2.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.11(@playwright/test@1.41.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.11
       '@swc/helpers': 0.5.5
@@ -303,11 +334,20 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.11
       '@next/swc-win32-ia32-msvc': 14.2.11
       '@next/swc-win32-x64-msvc': 14.2.11
+      '@playwright/test': 1.41.2
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
   picocolors@1.1.1: {}
+
+  playwright-core@1.41.2: {}
+
+  playwright@1.41.2:
+    dependencies:
+      playwright-core: 1.41.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -4,6 +4,8 @@
 
 - Go `>= 1.22`
 - Python `>= 3.10`
+- Node `>= 20`
+- pnpm `>= 10`
 - `check-jsonschema` (for manifest/schema checks)
 
 ## Install Options for `check-jsonschema`
@@ -42,4 +44,13 @@ make manifests
 make test
 make cli-test
 make cli-build
+```
+
+## Web App + E2E QA
+
+```bash
+cd apps/web
+pnpm install
+pnpm test:e2e:setup
+pnpm test:e2e
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,3 +19,12 @@
 ## Runtime notes
 
 These skills are authored for Agent Skills-style runtimes and can be adapted to Codex, Claude-style, and similar ecosystems.
+
+## Hub UI quick check
+
+If you are working on the website catalog:
+
+1. `cd apps/web`
+2. `pnpm install`
+3. `pnpm dev`
+4. `pnpm test:e2e`

--- a/docs/how-to-contribute-a-skill.md
+++ b/docs/how-to-contribute-a-skill.md
@@ -5,4 +5,5 @@
 3. Write clear routing text in `description` and `When to use`.
 4. Add realistic tests and example artifacts.
 5. Run `bash scripts/validate-skills.sh`.
-6. Open a PR with test evidence and assumptions.
+6. If your change touches the hub UI, run `pnpm test:e2e` from `apps/web`.
+7. Open a PR with test evidence and assumptions.

--- a/docs/how-to-test-skills.md
+++ b/docs/how-to-test-skills.md
@@ -7,6 +7,7 @@
 3. Failure mode: missing data/tool errors handled safely.
 4. Output shape: required sections/schema preserved.
 5. Guardrails: no fabrication, risky actions require confirmation.
+6. UI Smoke (when UI changes): key routes render and critical interactions still work.
 
 ## Test evidence format
 
@@ -16,3 +17,18 @@ For each prompt:
 - observed behavior
 - pass/fail
 - notes
+
+## UI smoke baseline (hub website)
+
+Run from `apps/web`:
+
+```bash
+pnpm test:e2e
+```
+
+Current smoke scope:
+- `/`
+- `/skills`
+- `/skills/<sample>`
+- filter interaction
+- copy-button presence/click

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,10 @@
   - 6 practical skills from the guide
   - shared conventions and validation
   - CI and contribution templates
+- v0.3 in progress:
+  - Hub website MVP routes are live in `apps/web`
+  - Playwright smoke E2E is wired into CI
+  - reusable `adtech/playwright-agentic-e2e` QA skill added
 - Current focus: evolve from companion repo to public skills hub.
 
 ## v0.2 (Foundation)

--- a/registry/index.json
+++ b/registry/index.json
@@ -31,6 +31,35 @@
       "deprecated": false
     },
     {
+      "id": "adtech/playwright-agentic-e2e",
+      "name": "Playwright Agentic E2E QA",
+      "description": "Build and maintain reusable Playwright smoke tests with planner, generator, and healer loops for web app regression checks.",
+      "category": "adtech/other",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/adtech/playwright-agentic-e2e/skill.yaml",
+          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/adtech/playwright-agentic-e2e/0.1.0.tar.gz",
+          "sha256": "d3d52ad5a6aab365b24dfdaf99dac9e40ae8758b83c6b577ac97bc57c3d2d6fa"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "qa",
+        "e2e",
+        "playwright",
+        "smoke-tests",
+        "ci"
+      ],
+      "deprecated": false
+    },
+    {
       "id": "adtech/policy-brand-compliance-checker",
       "name": "Policy + Brand Compliance Checker",
       "description": "Validate ad copy, landing URLs, and UTM tracking for policy and brand compliance before campaign launch.",

--- a/skills/adtech/playwright-agentic-e2e/README.md
+++ b/skills/adtech/playwright-agentic-e2e/README.md
@@ -1,0 +1,3 @@
+# Playwright Agentic E2E QA
+
+Reusable smoke-test skill for Playwright-based web QA with planner, test generation, and healing loops.

--- a/skills/adtech/playwright-agentic-e2e/SKILL.md
+++ b/skills/adtech/playwright-agentic-e2e/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: playwright-agentic-e2e
+description: Plan, generate, run, and heal Playwright smoke tests for web routes and core UI interactions in monorepo-safe setups.
+---
+
+# Playwright Agentic E2E QA
+
+## When to use
+Use for repeatable browser QA before merge, especially when UI changes often and tests need fast regeneration/healing.
+
+## Inputs required
+- app_base_url or local dev command
+- target routes (default smoke set)
+- selectors or user-visible labels for key actions
+- monorepo path hints (where `playwright.config.*` and app package live)
+
+## Workflow
+1. **Planner**: lock test scope first (smoke routes + highest-risk interactions).
+2. **Generator**: produce Playwright tests using user-facing locators and stable assertions.
+3. **Runner**: execute tests locally/CI and capture traces/screenshots on failure.
+4. **Healer**: when tests break, update selectors/flows with smallest safe patch and re-run.
+5. **Promote**: keep the suite reusable as shared QA coverage for new hub features.
+
+## Monorepo / subdir setup rules
+- Always set explicit `testDir`, `outputDir`, and `webServer.cwd` in Playwright config.
+- Keep CI working directory explicit when app code is in a subfolder (for example `apps/web`).
+- Prefer a deterministic base URL (`http://127.0.0.1:3000`) for local + CI parity.
+
+## Output format
+- Test Plan: routes + interactions + pass criteria
+- Generated/updated test files
+- Run Summary: pass/fail, key failures, healing changes applied
+- Follow-up Risks: flaky areas and selector hardening actions
+
+## Guardrails
+- Do not claim coverage beyond implemented tests.
+- Keep smoke scope small and deterministic before expanding.
+- Never auto-delete failing tests; heal with minimal, explainable changes.
+- If selectors are unstable, prefer role/text/test-id improvements over brittle CSS chains.

--- a/skills/adtech/playwright-agentic-e2e/examples/output.md
+++ b/skills/adtech/playwright-agentic-e2e/examples/output.md
@@ -1,0 +1,12 @@
+# Example Run Summary
+
+## Test Plan
+- Routes: `/`, `/skills`, `/skills/marketing/meta-google-weekly-performance-review`
+- Interactions: runtime filter select, apply filters, install command copy button
+
+## Results
+- Passed: 3
+- Failed: 0
+
+## Notes
+- Playwright config used explicit `testDir`, `outputDir`, and `webServer.cwd` for monorepo reliability.

--- a/skills/adtech/playwright-agentic-e2e/skill.yaml
+++ b/skills/adtech/playwright-agentic-e2e/skill.yaml
@@ -1,0 +1,37 @@
+id: adtech/playwright-agentic-e2e
+name: Playwright Agentic E2E QA
+description: Build and maintain reusable Playwright smoke tests with planner, generator, and healer loops for web app regression checks.
+version: 0.1.0
+released_at: "2026-02-23T00:00:00Z"
+category: adtech/other
+tags:
+  - qa
+  - e2e
+  - playwright
+  - smoke-tests
+  - ci
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  scripts_dir: scripts
+  examples_dir: examples
+dependencies:
+  tools:
+    - node
+    - pnpm
+    - npx
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/adtech/playwright-agentic-e2e/tests/test-prompts.md
+++ b/skills/adtech/playwright-agentic-e2e/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Create a Playwright smoke suite for `/`, `/skills`, and one skill-detail route in this repo.
+2. Add a CI job that runs only smoke E2E checks for `apps/web`.
+3. A filter dropdown label changed in `/skills`; heal the failing test with minimal selector updates.
+4. Generate a new smoke test for the install copy button and prove click behavior.
+5. Review existing E2E tests and propose what should remain smoke vs move to regression.


### PR DESCRIPTION
This PR introduces a reusable Playwright QA skill and wires smoke E2E testing into the hub web app + CI, then updates docs to reflect the current product state (skills + UI).

## What Changed
- Added new reusable skill: `adtech/playwright-agentic-e2e`
  - `SKILL.md` with Planner/Generator/Healer workflow
  - `skill.yaml` manifest
  - `tests/test-prompts.md`
  - `examples/output.md`
- Added Playwright setup for `apps/web`
  - `playwright.config.ts` with explicit monorepo-safe paths (`testDir`, `outputDir`, `webServer.cwd`)
  - `e2e/smoke.spec.ts` smoke coverage for:
    - `/`
    - `/skills`
    - `/skills/<sample>`
    - filter interaction
    - copy-button presence + click behavior
- Added web script updates
  - `pnpm test:e2e`
  - `pnpm test:e2e:setup` (browser install bootstrap)
- Added CI smoke E2E job in `.github/workflows/ci.yml`
  - install dependencies in `apps/web`
  - install Chromium
  - run Playwright tests
- Refreshed documentation to include UI + E2E workflow:
  - `README.md`
  - `CONTRIBUTING.md`
  - `docs/dev-setup.md`
  - `docs/getting-started.md`
  - `docs/how-to-contribute-a-skill.md`
  - `docs/how-to-test-skills.md`
  - `docs/roadmap.md`
- Regenerated `registry/index.json` to include the new skill.

## Validation
- `bash scripts/validate-skills.sh`
- `go run ./cmd/registry-builder`
- `go test ./...`

## Notes
- Playwright browser binaries must be installed locally once:
  - `cd apps/web && pnpm test:e2e:setup`
- Added ignore entries for Playwright artifacts:
  - `apps/web/playwright-report/`
  - `apps/web/test-results/`

## Why
- Dogfoods the skill model with a reusable QA skill.
- Adds repeatable UI quality gates before merge.
- Establishes a clear baseline smoke suite that can be expanded safely.