### PR TITLE
playwright -codex skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ For local toolchain setup, see `docs/dev-setup.md`.
 The repo now includes a Next.js catalog app at `apps/web`.
 
 Production site:
-[hub.ai-knowledge-hub.org](https://hub.ai-knowledge-hub.org/)
+[skills.ai-knowledge-hub.org](https://skills.ai-knowledge-hub.org/)
 
 ```bash
 cd apps/web

--- a/registry/index.json
+++ b/registry/index.json
@@ -60,6 +60,35 @@
       "deprecated": false
     },
     {
+      "id": "adtech/playwright-vscode-loop-codex",
+      "name": "Playwright VS Code Loop for Codex",
+      "description": "Orchestrate Playwright planner, generator, and healer workflows from Codex with VS Code loop execution for reusable web UX QA.",
+      "category": "adtech/other",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/adtech/playwright-vscode-loop-codex/skill.yaml",
+          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/adtech/playwright-vscode-loop-codex/0.1.0.tar.gz",
+          "sha256": "93ef3df77fd46d685ae4f49524807bc350e7dd954c57c4306760f3a98e76dba4"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "qa",
+        "playwright",
+        "codex",
+        "vscode",
+        "ux-testing"
+      ],
+      "deprecated": false
+    },
+    {
       "id": "adtech/policy-brand-compliance-checker",
       "name": "Policy + Brand Compliance Checker",
       "description": "Validate ad copy, landing URLs, and UTM tracking for policy and brand compliance before campaign launch.",

--- a/skills/adtech/playwright-vscode-loop-codex/README.md
+++ b/skills/adtech/playwright-vscode-loop-codex/README.md
@@ -1,0 +1,3 @@
+# Playwright VS Code Loop for Codex
+
+Reusable skill for driving Playwright planner/generator/healer loops from Codex while using the VS Code loop backend.

--- a/skills/adtech/playwright-vscode-loop-codex/SKILL.md
+++ b/skills/adtech/playwright-vscode-loop-codex/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: playwright-vscode-loop-codex
+description: Use Codex as orchestrator for Playwright planner, generator, and healer loops executed through VS Code-compatible Playwright agent flow.
+---
+
+# Playwright VS Code Loop for Codex
+
+## When to use
+Use when you want Codex to run repeatable UX smoke/regression loops while delegating Playwright agent execution to a VS Code-compatible loop.
+
+## Inputs required
+- app_dir (for monorepos, explicit app subdirectory)
+- playwright_config_path
+- base_url and/or local web command
+- smoke routes and high-risk interactions
+- sample detail page route
+
+## Workflow
+1. **Planner phase**
+   - Confirm target routes and pass criteria.
+   - Keep first scope to smoke tests only.
+2. **Generator phase**
+   - Generate or update Playwright specs with stable locators (role/text/test-id).
+   - Ensure config has explicit `testDir`, `outputDir`, and `webServer.cwd`.
+3. **Runner phase**
+   - Run Playwright tests and collect traces/report artifacts.
+4. **Healer phase**
+   - Apply the smallest safe selector/flow patch for failures.
+   - Re-run and summarize behavioral changes.
+5. **Promote phase**
+   - Keep a reusable baseline suite for all future web feature PRs.
+
+## VS Code loop execution notes
+- Codex remains the orchestrator and decision-maker.
+- Use VS Code loop tooling for the Playwright agent cycle where supported.
+- If loop tooling is unavailable, run equivalent planner/generator/healer steps manually with Playwright tests.
+
+## Global Codex usage
+- Keep this skill in your global Codex skills directory for cross-project reuse.
+- Suggested install target: `$CODEX_HOME/skills/playwright-vscode-loop-codex`.
+- In each project, pass explicit monorepo paths before generation.
+
+## Output format
+- Test Plan
+- Generated/Updated Files
+- Run Summary
+- Healing Notes
+- Residual Risk
+
+## Guardrails
+- Never claim passing coverage for untested flows.
+- Do not widen scope automatically from smoke to full regression.
+- Do not auto-delete failing tests; heal with minimal changes.
+- Prefer robust user-facing locators over brittle CSS selectors.

--- a/skills/adtech/playwright-vscode-loop-codex/examples/output.md
+++ b/skills/adtech/playwright-vscode-loop-codex/examples/output.md
@@ -1,0 +1,19 @@
+# Example Output
+
+## Test Plan
+- Routes: `/`, `/skills`, `/skills/marketing/meta-google-weekly-performance-review`
+- Interactions: filter apply, copy command button click
+
+## Generated/Updated Files
+- `apps/web/playwright.config.ts`
+- `apps/web/e2e/smoke.spec.ts`
+
+## Run Summary
+- Passed: 3
+- Failed: 0
+
+## Healing Notes
+- Updated one selector from text match to role+name for stability.
+
+## Residual Risk
+- Dynamic content cards may need test-id anchors if UI copy changes frequently.

--- a/skills/adtech/playwright-vscode-loop-codex/scripts/install-global-codex.sh
+++ b/skills/adtech/playwright-vscode-loop-codex/scripts/install-global-codex.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CODEX_SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"
+TARGET="$CODEX_SKILLS_DIR/playwright-vscode-loop-codex"
+
+mkdir -p "$CODEX_SKILLS_DIR"
+rm -rf "$TARGET"
+cp -R "$ROOT" "$TARGET"
+
+echo "Installed skill to $TARGET"

--- a/skills/adtech/playwright-vscode-loop-codex/skill.yaml
+++ b/skills/adtech/playwright-vscode-loop-codex/skill.yaml
@@ -1,0 +1,37 @@
+id: adtech/playwright-vscode-loop-codex
+name: Playwright VS Code Loop for Codex
+description: Orchestrate Playwright planner, generator, and healer workflows from Codex with VS Code loop execution for reusable web UX QA.
+version: 0.1.0
+released_at: "2026-02-23T00:00:00Z"
+category: adtech/other
+tags:
+  - qa
+  - playwright
+  - codex
+  - vscode
+  - ux-testing
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  scripts_dir: scripts
+  examples_dir: examples
+dependencies:
+  tools:
+    - node
+    - npx
+    - playwright
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/adtech/playwright-vscode-loop-codex/tests/test-prompts.md
+++ b/skills/adtech/playwright-vscode-loop-codex/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Create a planner scope for smoke UX checks on `/`, `/skills`, and one detail page.
+2. Generate Playwright smoke specs using monorepo-safe config paths in `apps/web`.
+3. Run and heal a failing selector after a filter label changes.
+4. Summarize run artifacts and residual UX risk after healing.
+5. Adapt the same workflow to a new app directory while keeping Codex orchestration.


### PR DESCRIPTION
## Summary
This PR adds a new reusable skill for running Playwright planner/generator/healer workflows with **Codex orchestration** and **VS Code loop-compatible execution**.

## What Changed
- Added new skill: `adtech/playwright-vscode-loop-codex`
  - `SKILL.md`
  - `skill.yaml`
  - `README.md`
  - `tests/test-prompts.md`
  - `examples/output.md`
  - `scripts/install-global-codex.sh` (helper to install into global Codex skills dir)
- Regenerated registry index to include the new skill:
  - `registry/index.json`

## Skill Intent
- Use Codex as orchestrator for:
  - `planner` phase (scope + pass criteria)
  - `generator` phase (spec/config generation)
  - `healer` phase (minimal failure fixes + rerun)
- Designed for monorepo-safe setups with explicit paths (`testDir`, `outputDir`, `webServer.cwd`).
- Reusable across any web app project.

## Validation
- `bash scripts/validate-skills.sh`
- `go run ./cmd/registry-builder`

## Notes
- Includes optional global install helper:
  - `bash skills/adtech/playwright-vscode-loop-codex/scripts/install-global-codex.sh`
- Installs to:
  - `$CODEX_HOME/skills/playwright-vscode-loop-codex` (or `~/.codex/skills/...`)

## Why
- Standardizes UX QA workflows across projects.
- Keeps smoke-first quality gates repeatable.
- Makes Playwright agentic loop usage practical in a Codex-centric development setup.
