### PR TITLE
fe polish plus first wave of new skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ same automations in silos.
 - Community references:
   [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)
 
-## Current Scope (7 practical skills)
+## Current Scope (11 practical skills)
 
 1. `meta-google-weekly-performance-review` (Beginner)
 2. `creative-workshop-pmax-reels` (Intermediate)
@@ -32,6 +32,16 @@ same automations in silos.
 5. `seo-paid-search-synergy` (Advanced)
 6. `analyst-copilot-bigquery-redshift` (Advanced)
 7. `playwright-agentic-e2e` (QA / Infrastructure)
+8. `playwright-vscode-loop-codex` (QA / VS Code Loop)
+9. `ai-output-eval-scorecard` (Governance / Evaluation)
+10. `cross-channel-budget-pacing-agent` (Ads Ops)
+11. `ab-test-planner-analyzer` (Measurement / Experimentation)
+
+## New in v0.2 alpha
+
+- `ai-output-eval-scorecard`
+- `cross-channel-budget-pacing-agent`
+- `ab-test-planner-analyzer`
 
 ## Definition of done for each skill
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -87,6 +87,51 @@ p {
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
 }
 
+.featured-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-bottom: 1.5rem;
+}
+
+.featured-section {
+  margin-bottom: 0.9rem;
+}
+
+.section-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem 0.9rem;
+}
+
+.section-head h2 {
+  margin: 0;
+}
+
+.new-alpha {
+  margin-top: 0.9rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid var(--line);
+}
+
+.new-alpha ul {
+  margin: 0.35rem 0 0;
+  padding-left: 1.05rem;
+}
+
+.new-alpha li + li {
+  margin-top: 0.22rem;
+}
+
+.new-alpha a {
+  color: #b6e5c9;
+}
+
+.new-alpha a:hover,
+.new-alpha a:focus-visible {
+  color: #dcffe9;
+  text-decoration: underline;
+}
+
 .card {
   background: var(--paper);
   border: 1px solid var(--line);
@@ -344,6 +389,10 @@ p {
 
 @media (max-width: 820px) {
   .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .featured-grid {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,11 +1,18 @@
 import Link from "next/link";
 import { loadRegistry, uniqueValues } from "@/lib/registry";
+import { FEATURED_SKILL_IDS, NEW_ALPHA_SKILL_IDS } from "@/lib/home";
 
 export default async function HomePage() {
   const registry = await loadRegistry();
   const skills = registry.skills;
   const categories = uniqueValues(skills.map((s) => s.category));
   const tags = uniqueValues(skills.flatMap((s) => s.tags));
+  const featuredSkills = FEATURED_SKILL_IDS
+    .map((id) => skills.find((skill) => skill.id === id))
+    .filter((skill): skill is (typeof skills)[number] => Boolean(skill));
+  const newAlphaSkills = NEW_ALPHA_SKILL_IDS
+    .map((id) => skills.find((skill) => skill.id === id))
+    .filter((skill): skill is (typeof skills)[number] => Boolean(skill));
 
   return (
     <main>
@@ -55,11 +62,31 @@ export default async function HomePage() {
             <span className="tag">Registry v{registry.registry_version}</span>
             <span className="tag">Generated {registry.generated_at.slice(0, 10)}</span>
           </div>
+          <div className="new-alpha">
+            <p className="meta">New in v0.2 alpha</p>
+            <ul>
+              {newAlphaSkills.map((skill) => (
+                <li key={skill.id}>
+                  <Link href={`/skills/${skill.id}`}>{skill.name}</Link>
+                </li>
+              ))}
+            </ul>
+          </div>
         </article>
       </section>
 
-      <section className="grid">
-        {skills.slice(0, 6).map((skill) => (
+      <section className="featured-section">
+        <div className="section-head">
+          <h2>Featured Skills</h2>
+          <p className="meta">Sample cards from the full catalog.</p>
+          <Link href="/skills" className="button button--secondary">
+            View all {skills.length} skills
+          </Link>
+        </div>
+      </section>
+
+      <section className="grid featured-grid">
+        {featuredSkills.map((skill) => (
           <Link key={skill.id} href={`/skills/${skill.id}`} className="card">
             <p className="meta">{skill.category}</p>
             <h3>{skill.name}</h3>

--- a/apps/web/lib/home.ts
+++ b/apps/web/lib/home.ts
@@ -1,0 +1,12 @@
+export const FEATURED_SKILL_IDS = [
+  "marketing/ai-output-eval-scorecard",
+  "marketing/cross-channel-budget-pacing-agent",
+  "marketing/ab-test-planner-analyzer",
+  "marketing/meta-google-weekly-performance-review"
+];
+
+export const NEW_ALPHA_SKILL_IDS = [
+  "marketing/ai-output-eval-scorecard",
+  "marketing/cross-channel-budget-pacing-agent",
+  "marketing/ab-test-planner-analyzer"
+];


### PR DESCRIPTION
## Summary
This PR improves homepage clarity and makes featured catalog curation maintainable, while aligning README with the current catalog scope.

## What Changed

### Homepage UX cleanup
- Replaced ambiguous multi-row sample grid behavior with a clearly labeled **Featured Skills** section.
- Reduced homepage sample to a single curated row (desktop) to avoid confusion with the full catalog.
- Added explicit context: “Sample cards from the full catalog.”
- Added direct CTA to full catalog (`View all X skills`).

### “New in v0.2 alpha” callout
- Added a right-panel callout linking to new Wave 1 skills:
  - AI Output Eval Scorecard
  - Cross-Channel Budget Pacing Agent
  - A/B Test Planner + Analyzer

### Configurable homepage curation
- Added centralized config file:
  - `apps/web/lib/home.ts`
- Moved curated IDs into constants:
  - `FEATURED_SKILL_IDS`
  - `NEW_ALPHA_SKILL_IDS`
- Homepage now resolves featured/callout skills from this config + registry.

### README updates
- Updated scope to **11 practical skills**.
- Added **New in v0.2 alpha** section.
- Kept positioning copy aligned with site messaging.

## Why
- Prevents users from misreading homepage samples as the full catalog.
- Makes featured/new-alpha curation a one-file change.
- Keeps public docs in sync with the actual catalog maturity.