### PR TITLE
2nd wave skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ same automations in silos.
 - Community references:
   [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)
 
-## Current Scope (11 practical skills)
+## Current Scope (14 practical skills)
 
 1. `meta-google-weekly-performance-review` (Beginner)
 2. `creative-workshop-pmax-reels` (Intermediate)
@@ -36,12 +36,18 @@ same automations in silos.
 9. `ai-output-eval-scorecard` (Governance / Evaluation)
 10. `cross-channel-budget-pacing-agent` (Ads Ops)
 11. `ab-test-planner-analyzer` (Measurement / Experimentation)
+12. `lifecycle-journey-trigger-designer` (Lifecycle CRM)
+13. `dynamic-creative-rules-engine` (Creative Ops / Personalization)
+14. `brand-rag-memory-bootstrap` (Analytics Engineering / RAG)
 
 ## New in v0.2 alpha
 
 - `ai-output-eval-scorecard`
 - `cross-channel-budget-pacing-agent`
 - `ab-test-planner-analyzer`
+- `lifecycle-journey-trigger-designer`
+- `dynamic-creative-rules-engine`
+- `brand-rag-memory-bootstrap`
 
 ## Definition of done for each skill
 

--- a/registry/index.json
+++ b/registry/index.json
@@ -31,6 +31,35 @@
       "deprecated": false
     },
     {
+      "id": "adtech/brand-rag-memory-bootstrap",
+      "name": "Brand RAG Memory Bootstrap",
+      "description": "Build a private retrieval-ready brand memory from product, campaign, and policy context for downstream agent skills.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/adtech/brand-rag-memory-bootstrap/skill.yaml",
+          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/adtech/brand-rag-memory-bootstrap/0.1.0.tar.gz",
+          "sha256": "05de3932e35bfd3b52a58332624d69502847f1a2c2f71d74eb0427fcc3f125be"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "rag",
+        "brand-memory",
+        "knowledge-base",
+        "retrieval",
+        "governance"
+      ],
+      "deprecated": false
+    },
+    {
       "id": "adtech/playwright-agentic-e2e",
       "name": "Playwright Agentic E2E QA",
       "description": "Build and maintain reusable Playwright smoke tests with planner, generator, and healer loops for web app regression checks.",
@@ -232,6 +261,35 @@
       "deprecated": false
     },
     {
+      "id": "marketing/dynamic-creative-rules-engine",
+      "name": "Dynamic Creative Rules Engine",
+      "description": "Define dynamic creative assembly rules per audience and context while enforcing brand and policy constraints.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/marketing/dynamic-creative-rules-engine/skill.yaml",
+          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/marketing/dynamic-creative-rules-engine/0.1.0.tar.gz",
+          "sha256": "e15dfe6bb25335f6061f78222fef48a8bd7c97e571e19d23790fd9c9c057590e"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "personalization",
+        "creative-ops",
+        "dynamic-creative",
+        "brand-safety",
+        "experimentation"
+      ],
+      "deprecated": false
+    },
+    {
       "id": "marketing/lifecycle-experiment-planner",
       "name": "Lifecycle Experiment Planner",
       "description": "Design lifecycle A/B tests with hypothesis checks, sample-size guidance, and stopping criteria.",
@@ -256,6 +314,35 @@
         "ab-testing",
         "lifecycle",
         "statistics"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "marketing/lifecycle-journey-trigger-designer",
+      "name": "Lifecycle Journey Trigger Designer",
+      "description": "Design lifecycle triggers and channel sequencing for CRM journeys with measurable guardrails and rollout rules.",
+      "category": "marketing-tools/lifecycle-crm",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/marketing/lifecycle-journey-trigger-designer/skill.yaml",
+          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/marketing/lifecycle-journey-trigger-designer/0.1.0.tar.gz",
+          "sha256": "276a554d450d20db68f66116718e7bd9ea73b5e5b8b380587660b981c09151c5"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "lifecycle",
+        "crm",
+        "journey-design",
+        "triggers",
+        "retention"
       ],
       "deprecated": false
     },

--- a/skills/adtech/brand-rag-memory-bootstrap/README.md
+++ b/skills/adtech/brand-rag-memory-bootstrap/README.md
@@ -1,0 +1,3 @@
+# Brand RAG Memory Bootstrap
+
+Bootstraps a private brand and campaign memory structure that agent skills can query before generating outputs.

--- a/skills/adtech/brand-rag-memory-bootstrap/SKILL.md
+++ b/skills/adtech/brand-rag-memory-bootstrap/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: brand-rag-memory-bootstrap
+description: Bootstrap private brand memory and retrieval structure so AI skills answer from approved campaign and policy context.
+---
+
+# Brand RAG Memory Bootstrap
+
+## When to use
+Use when setting up or refreshing a private knowledge base that agent skills must query before drafting strategy or creative.
+
+## Inputs required
+- source_docs
+- brand_taxonomy
+- policy_documents
+- campaign_history
+- chunking_strategy
+- retrieval_requirements
+
+## Workflow
+1. Audit and classify source documents.
+2. Normalize metadata (product, audience, channel, date, policy tags).
+3. Define chunking and citation rules.
+4. Build retrieval index structure and quality checks.
+5. Return ingestion and refresh plan.
+
+## Output format
+- source_inventory
+- metadata_schema
+- chunking_plan
+- retrieval_eval_plan
+- refresh_schedule
+
+## Guardrails
+- Restrict memory to approved private sources.
+- Require citation paths for generated claims.
+- Flag stale or conflicting sources before publishing guidance.

--- a/skills/adtech/brand-rag-memory-bootstrap/examples/output.json
+++ b/skills/adtech/brand-rag-memory-bootstrap/examples/output.json
@@ -1,0 +1,35 @@
+{
+  "source_inventory": {
+    "product_docs": 42,
+    "policy_docs": 9,
+    "campaign_reports": 31
+  },
+  "metadata_schema": {
+    "required_fields": [
+      "doc_type",
+      "brand",
+      "product",
+      "audience",
+      "channel",
+      "effective_date"
+    ]
+  },
+  "chunking_plan": {
+    "max_tokens": 600,
+    "overlap_tokens": 80,
+    "citation_required": true
+  },
+  "retrieval_eval_plan": {
+    "golden_questions": 25,
+    "metrics": [
+      "citation_coverage",
+      "answer_relevance",
+      "policy_conflict_rate"
+    ]
+  },
+  "refresh_schedule": {
+    "policy_docs": "weekly",
+    "campaign_reports": "bi-weekly",
+    "product_docs": "monthly"
+  }
+}

--- a/skills/adtech/brand-rag-memory-bootstrap/skill.yaml
+++ b/skills/adtech/brand-rag-memory-bootstrap/skill.yaml
@@ -1,0 +1,34 @@
+id: adtech/brand-rag-memory-bootstrap
+name: Brand RAG Memory Bootstrap
+description: Build a private retrieval-ready brand memory from product, campaign, and policy context for downstream agent skills.
+version: 0.1.0
+released_at: "2026-02-23T00:00:00Z"
+category: adtech/analytics-engineering
+tags:
+  - rag
+  - brand-memory
+  - knowledge-base
+  - retrieval
+  - governance
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools:
+    - python3
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/adtech/brand-rag-memory-bootstrap/tests/test-prompts.md
+++ b/skills/adtech/brand-rag-memory-bootstrap/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Bootstrap a brand memory from product pages, policy docs, and campaign playbooks.
+2. Define metadata schema so downstream skills can retrieve by audience, channel, and product.
+3. Propose chunking and citation rules for safe strategy generation.
+4. Design retrieval evaluation checks for accuracy and hallucination risk.
+5. Return structured JSON with inventory, schema, and refresh plan.

--- a/skills/marketing/dynamic-creative-rules-engine/README.md
+++ b/skills/marketing/dynamic-creative-rules-engine/README.md
@@ -1,0 +1,3 @@
+# Dynamic Creative Rules Engine
+
+Defines audience-aware creative assembly rules with brand and policy constraints for scalable personalization.

--- a/skills/marketing/dynamic-creative-rules-engine/SKILL.md
+++ b/skills/marketing/dynamic-creative-rules-engine/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: dynamic-creative-rules-engine
+description: Build dynamic creative personalization rules based on audience signals with policy and brand guardrails.
+---
+
+# Dynamic Creative Rules Engine
+
+## When to use
+Use for personalized ad or lifecycle creative systems where message components need to vary by segment and context.
+
+## Inputs required
+- audience_segments
+- context_signals
+- creative_components
+- brand_constraints
+- policy_constraints
+- objective_metric
+
+## Workflow
+1. Map segment and context signal hierarchy.
+2. Define creative component matrix (headline, body, CTA, visual hook).
+3. Apply brand and policy constraints to each combination.
+4. Rank candidate assemblies by objective fit.
+5. Return deployable rules and test matrix.
+
+## Output format
+- segmentation_logic
+- creative_rules
+- blocked_combinations
+- test_matrix
+- monitoring_metrics
+
+## Guardrails
+- Never allow combinations that violate policy constraints.
+- Enforce hard brand constraints before optimization.
+- Keep a human-review checkpoint for high-risk segments.

--- a/skills/marketing/dynamic-creative-rules-engine/examples/output.json
+++ b/skills/marketing/dynamic-creative-rules-engine/examples/output.json
@@ -1,0 +1,34 @@
+{
+  "segmentation_logic": [
+    "new_visitors",
+    "cart_abandoners",
+    "repeat_buyers"
+  ],
+  "creative_rules": [
+    {
+      "segment": "cart_abandoners",
+      "headline": "Complete your order in 2 minutes",
+      "cta": "Return to cart",
+      "context": "mobile"
+    }
+  ],
+  "blocked_combinations": [
+    {
+      "headline": "Guaranteed results",
+      "cta": "Claim now",
+      "reason": "Unqualified claim risk"
+    }
+  ],
+  "test_matrix": [
+    {
+      "rule_id": "cart-mobile-01",
+      "priority": 1,
+      "hypothesis": "Urgency CTA improves completion rate"
+    }
+  ],
+  "monitoring_metrics": [
+    "ctr",
+    "cvr",
+    "policy_violation_rate"
+  ]
+}

--- a/skills/marketing/dynamic-creative-rules-engine/skill.yaml
+++ b/skills/marketing/dynamic-creative-rules-engine/skill.yaml
@@ -1,0 +1,34 @@
+id: marketing/dynamic-creative-rules-engine
+name: Dynamic Creative Rules Engine
+description: Define dynamic creative assembly rules per audience and context while enforcing brand and policy constraints.
+version: 0.1.0
+released_at: "2026-02-23T00:00:00Z"
+category: marketing-tools/creative-ops
+tags:
+  - personalization
+  - creative-ops
+  - dynamic-creative
+  - brand-safety
+  - experimentation
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools:
+    - python3
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/marketing/dynamic-creative-rules-engine/tests/test-prompts.md
+++ b/skills/marketing/dynamic-creative-rules-engine/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Build dynamic creative rules for three prospecting audience segments.
+2. Block unsafe headline + CTA combinations using brand and policy constraints.
+3. Produce a test matrix for creative assemblies ranked by expected conversion fit.
+4. Add monitoring metrics for creative fatigue and policy risk drift.
+5. Return structured JSON with rules, blocked combos, and test plan.

--- a/skills/marketing/lifecycle-journey-trigger-designer/README.md
+++ b/skills/marketing/lifecycle-journey-trigger-designer/README.md
@@ -1,0 +1,3 @@
+# Lifecycle Journey Trigger Designer
+
+Designs lifecycle journey triggers, channel sequencing, and measurement plans from customer behavior signals.

--- a/skills/marketing/lifecycle-journey-trigger-designer/SKILL.md
+++ b/skills/marketing/lifecycle-journey-trigger-designer/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: lifecycle-journey-trigger-designer
+description: Design lifecycle journey triggers, channel sequencing, and measurement plans from behavior and audience signals.
+---
+
+# Lifecycle Journey Trigger Designer
+
+## When to use
+Use when creating or refactoring lifecycle programs across email, push, and in-app channels with event-based triggers.
+
+## Inputs required
+- journey_goal
+- audience_definition
+- trigger_events
+- channel_constraints
+- frequency_caps
+- success_metrics
+
+## Workflow
+1. Validate journey objective and audience boundary.
+2. Map entry, progression, and exit triggers.
+3. Define channel sequence and timing windows.
+4. Add suppression rules and frequency controls.
+5. Return rollout plan with success metrics.
+
+## Output format
+- journey_blueprint
+- trigger_rules
+- channel_sequence
+- suppression_rules
+- measurement_plan
+
+## Guardrails
+- Avoid overlapping trigger logic that can double-send.
+- Respect channel frequency and legal communication constraints.
+- Mark dependencies on missing event instrumentation.

--- a/skills/marketing/lifecycle-journey-trigger-designer/examples/output.json
+++ b/skills/marketing/lifecycle-journey-trigger-designer/examples/output.json
@@ -1,0 +1,30 @@
+{
+  "journey_blueprint": {
+    "goal": "Increase 60-day repeat purchase rate",
+    "audience": "Customers with first purchase in last 14 days",
+    "entry_condition": "purchase_completed"
+  },
+  "trigger_rules": [
+    {
+      "stage": "post-purchase day 3",
+      "trigger": "no_second_purchase",
+      "action": "send_email_education"
+    }
+  ],
+  "channel_sequence": [
+    "email_day3",
+    "push_day6",
+    "email_day10"
+  ],
+  "suppression_rules": [
+    "suppress_if_unsubscribed",
+    "max_2_messages_per_7_days"
+  ],
+  "measurement_plan": {
+    "primary_metric": "repeat_purchase_rate_60d",
+    "guardrails": [
+      "unsubscribe_rate",
+      "push_optout_rate"
+    ]
+  }
+}

--- a/skills/marketing/lifecycle-journey-trigger-designer/skill.yaml
+++ b/skills/marketing/lifecycle-journey-trigger-designer/skill.yaml
@@ -1,0 +1,34 @@
+id: marketing/lifecycle-journey-trigger-designer
+name: Lifecycle Journey Trigger Designer
+description: Design lifecycle triggers and channel sequencing for CRM journeys with measurable guardrails and rollout rules.
+version: 0.1.0
+released_at: "2026-02-23T00:00:00Z"
+category: marketing-tools/lifecycle-crm
+tags:
+  - lifecycle
+  - crm
+  - journey-design
+  - triggers
+  - retention
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools:
+    - python3
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/marketing/lifecycle-journey-trigger-designer/tests/test-prompts.md
+++ b/skills/marketing/lifecycle-journey-trigger-designer/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Design a reactivation journey for users inactive for 30 days.
+2. Map trigger logic for onboarding users from first purchase to second purchase.
+3. Build suppression rules to avoid over-messaging across email and push.
+4. Create a rollout and KPI plan for a churn-prevention lifecycle flow.
+5. Output structured JSON for journey blueprint and trigger rules.


### PR DESCRIPTION
## Summary
This PR delivers **Wave 2** skill expansion for lifecycle automation, dynamic creative personalization, and brand RAG memory setup, and updates registry/docs accordingly.

## What Changed

### New skills added

1. `marketing/lifecycle-journey-trigger-designer`
- Category: `marketing-tools/lifecycle-crm`
- Focus: event-triggered lifecycle journey design, channel sequencing, suppression/frequency rules, KPI planning.

2. `marketing/dynamic-creative-rules-engine`
- Category: `marketing-tools/creative-ops`
- Focus: dynamic creative assembly rules by segment/context with brand and policy constraints.

3. `adtech/brand-rag-memory-bootstrap`
- Category: `adtech/analytics-engineering`
- Focus: private brand/campaign/policy memory bootstrap for retrieval-first skill workflows.

Each skill includes:
- `SKILL.md`
- `skill.yaml`
- `README.md`
- `tests/test-prompts.md` (>=5 prompts)
- `examples/output.json`

## Registry + Docs
- Regenerated `registry/index.json` to include the new skills.
- Updated `README.md`:
  - scope count from 11 -> 14
  - added Wave 2 skills to the list
  - expanded “New in v0.2 alpha” section

## Validation
- `bash scripts/validate-skills.sh`
- `go run ./cmd/registry-builder`

## Why
- Extends the catalog from Wave 1 decision/eval skills into full workflow execution:
  - lifecycle orchestration,
  - creative personalization systems,
  - retrieval-ready memory infrastructure.
- Keeps taxonomy and contribution standards consistent with existing repo patterns.
