### PR TITLE
Dev

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,22 @@
+name: Release On Tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          target_commitish: main
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help doctor validate manifests registry test-scripts test ci-local cli-build cli-test web-dev web-build web-lint web-e2e
+.PHONY: help doctor validate manifests registry test-scripts test ci-local cli-build cli-test web-dev web-build web-lint web-e2e release-cut
 
 help:
 	@echo "Targets:"
@@ -17,6 +17,7 @@ help:
 	@echo "  make web-build     - Build Next.js hub app"
 	@echo "  make web-lint      - Lint Next.js hub app"
 	@echo "  make web-e2e       - Run Playwright smoke tests for web app"
+	@echo "  make release-cut VERSION=vX.Y.Z[-alpha.N] - Validate and push release tag from main"
 
 doctor:
 	@echo "[check] go"
@@ -63,3 +64,7 @@ web-lint:
 
 web-e2e:
 	cd apps/web && pnpm test:e2e
+
+release-cut:
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make release-cut VERSION=vX.Y.Z[-alpha.N]"; exit 1; fi
+	bash scripts/release-cut.sh "$(VERSION)"

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { loadRegistry, uniqueValues } from "@/lib/registry";
-import { FEATURED_SKILL_IDS, NEW_ALPHA_SKILL_IDS } from "@/lib/home";
+import { FEATURED_SKILL_IDS } from "@/lib/home";
 
 export default async function HomePage() {
   const registry = await loadRegistry();
@@ -10,9 +10,22 @@ export default async function HomePage() {
   const featuredSkills = FEATURED_SKILL_IDS
     .map((id) => skills.find((skill) => skill.id === id))
     .filter((skill): skill is (typeof skills)[number] => Boolean(skill));
-  const newAlphaSkills = NEW_ALPHA_SKILL_IDS
-    .map((id) => skills.find((skill) => skill.id === id))
-    .filter((skill): skill is (typeof skills)[number] => Boolean(skill));
+  const newestSkills = [...skills]
+    .sort((a, b) => {
+      const aDate = new Date(
+        a.versions.find((version) => version.version === a.latest)?.released_at ?? 0
+      ).getTime();
+      const bDate = new Date(
+        b.versions.find((version) => version.version === b.latest)?.released_at ?? 0
+      ).getTime();
+
+      if (bDate !== aDate) {
+        return bDate - aDate;
+      }
+
+      return a.id.localeCompare(b.id);
+    })
+    .slice(0, 3);
 
   return (
     <main>
@@ -63,9 +76,9 @@ export default async function HomePage() {
             <span className="tag">Generated {registry.generated_at.slice(0, 10)}</span>
           </div>
           <div className="new-alpha">
-            <p className="meta">New in v0.2 alpha</p>
+            <p className="meta">Newest skills</p>
             <ul>
-              {newAlphaSkills.map((skill) => (
+              {newestSkills.map((skill) => (
                 <li key={skill.id}>
                   <Link href={`/skills/${skill.id}`}>{skill.name}</Link>
                 </li>

--- a/apps/web/lib/home.ts
+++ b/apps/web/lib/home.ts
@@ -4,9 +4,3 @@ export const FEATURED_SKILL_IDS = [
   "marketing/ab-test-planner-analyzer",
   "marketing/meta-google-weekly-performance-review"
 ];
-
-export const NEW_ALPHA_SKILL_IDS = [
-  "marketing/ai-output-eval-scorecard",
-  "marketing/cross-channel-budget-pacing-agent",
-  "marketing/ab-test-planner-analyzer"
-];

--- a/docs/versioning-and-release.md
+++ b/docs/versioning-and-release.md
@@ -28,6 +28,63 @@ git tag v0.2.0-alpha.1
 git push origin v0.2.0-alpha.1
 ```
 
+## Automated release cut (recommended)
+
+From a clean `main` branch, run:
+
+```bash
+make release-cut VERSION=v0.2.0-alpha.2
+```
+
+What this does:
+- verifies clean working tree and `main` branch
+- fast-forwards `main` from `origin/main`
+- runs skill validation and registry generation checks
+- runs web install, lint, and build checks
+- creates and pushes the tag
+
+Optional:
+
+```bash
+RUN_E2E=1 make release-cut VERSION=v0.2.0-alpha.2
+```
+
+to include local Playwright smoke tests before tagging.
+
+## Automated GitHub release publishing
+
+When a `v*` tag is pushed, GitHub Actions workflow
+`.github/workflows/release-on-tag.yml` automatically publishes a release
+entry with generated notes.
+
+Tags containing `-alpha`, `-beta`, or `-rc` are marked as prerelease.
+
+## When to cut a release
+
+Use two tracks:
+
+- **Deploy track**: merge to `main` whenever changes are ready.
+- **Release track**: push a `v*` tag only for meaningful milestones.
+
+Cut a release when at least one applies:
+
+- new skills are added (especially a grouped wave)
+- user-facing behavior changes in web UI, install flow, or registry
+- compatibility or governance changes need explicit communication
+- external announcement or changelog checkpoint is needed
+
+Do not cut a release for:
+
+- typo-only or formatting-only changes
+- small internal refactors with no user-facing impact
+- routine maintenance commits that are not milestone-grade
+
+Suggested cadence:
+
+- continue frequent `dev -> main` merges
+- cut prereleases (`vX.Y.Z-alpha.N`) on a fixed rhythm (for example every
+  1-2 weeks) or when a feature wave is complete
+
 ## Release notes template
 
 - Scope: CLI + registry baseline and hub web MVP.

--- a/scripts/release-cut.sh
+++ b/scripts/release-cut.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION="${1:-}"
+RUN_E2E="${RUN_E2E:-0}"
+
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: bash scripts/release-cut.sh vX.Y.Z[-alpha.N]"
+  exit 1
+fi
+
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$ ]]; then
+  echo "[ERROR] Version must match vX.Y.Z or vX.Y.Z-alpha.N"
+  exit 1
+fi
+
+cd "$ROOT"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "[ERROR] Working tree is not clean. Commit or stash changes first."
+  exit 1
+fi
+
+current_branch="$(git branch --show-current)"
+if [[ "$current_branch" != "main" ]]; then
+  echo "[ERROR] Release cut must run from main. Current branch: $current_branch"
+  exit 1
+fi
+
+echo "[check] syncing main"
+git fetch origin
+git pull --ff-only origin main
+
+if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+  echo "[ERROR] Tag $VERSION already exists locally."
+  exit 1
+fi
+
+if git ls-remote --tags origin | grep -q "refs/tags/$VERSION$"; then
+  echo "[ERROR] Tag $VERSION already exists on origin."
+  exit 1
+fi
+
+echo "[check] validate skills"
+bash scripts/validate-skills.sh
+
+echo "[check] rebuild registry"
+go run ./cmd/registry-builder
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "[ERROR] Generated files changed (for example registry/index.json). Commit before release."
+  git status --short
+  exit 1
+fi
+
+echo "[check] web lint/build"
+(
+  cd apps/web
+  pnpm install --frozen-lockfile
+  pnpm lint
+  pnpm build
+
+  if [[ "$RUN_E2E" == "1" ]]; then
+    pnpm test:e2e
+  fi
+)
+
+echo "[release] creating and pushing tag $VERSION"
+git tag "$VERSION"
+git push origin "$VERSION"
+
+echo "[done] Tag pushed: $VERSION"
+echo "GitHub Actions will publish the release via .github/workflows/release-on-tag.yml"


### PR DESCRIPTION
## Summary
This PR introduces release-cut automation, clarifies release policy, improves homepage catalog clarity, and adds Wave 2 skills to the registry.

## What Changed

### Release automation + policy
- Added release helper script:
  - `scripts/release-cut.sh`
- Added tag-driven release workflow:
  - `.github/workflows/release-on-tag.yml`
- Added Make target for release cut:
  - `Makefile` (`make release-cut VERSION=...`)
- Expanded release docs:
  - `docs/versioning-and-release.md`
  - Includes:
    - automated release flow
    - tag-triggered GitHub release behavior
    - “when to cut a release” policy (deploy track vs release track)


## Why
- Standardizes release management without forcing release-per-merge.

