### PR TITLE
dashboard generator

### DIFF
--- a/docs/deploy-web-vercel.md
+++ b/docs/deploy-web-vercel.md
@@ -20,7 +20,7 @@ This repo is a monorepo. The web app lives at `apps/web`.
 
 Attach custom domain:
 
-- `hub.ai-knowledge-hub.org`
+- `skills.ai-knowledge-hub.org`
 
 Then set DNS records in your DNS provider as instructed by Vercel.
 

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-const baseURL = "https://hub.ai-knowledge-hub.org"
+const baseURL = "https://skills.ai-knowledge-hub.org"
 
 func BuildIndex(root string) (Index, error) {
 	manifests, err := findManifests(filepath.Join(root, "skills"))

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,6 +1,6 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-02-23T00:00:00Z",
+  "generated_at": "2026-02-27T00:00:00Z",
   "skills": [
     {
       "id": "adtech/analyst-copilot-bigquery-redshift",
@@ -12,8 +12,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/adtech/analyst-copilot-bigquery-redshift/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/adtech/analyst-copilot-bigquery-redshift/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/analyst-copilot-bigquery-redshift/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/analyst-copilot-bigquery-redshift/0.1.0.tar.gz",
           "sha256": "5f71bceb61e489bb69104d690ec0eb863056b8bdd6b886587306f99d5cba58ca"
         }
       ],
@@ -40,8 +40,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/adtech/brand-rag-memory-bootstrap/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/adtech/brand-rag-memory-bootstrap/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/brand-rag-memory-bootstrap/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/brand-rag-memory-bootstrap/0.1.0.tar.gz",
           "sha256": "05de3932e35bfd3b52a58332624d69502847f1a2c2f71d74eb0427fcc3f125be"
         }
       ],
@@ -60,6 +60,90 @@
       "deprecated": false
     },
     {
+      "id": "adtech/dashboard-generator",
+      "name": "Dashboard Generator",
+      "description": "Generate deterministic weekly marketing dashboard outputs from normalized performance tables for BI publishing.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/dashboard-generator/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/dashboard-generator/0.1.0.tar.gz",
+          "sha256": "e08ba5c6eeeea0093bac7600b4c386b39e2ccbb361984718a70adb2f67bcc660"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "dashboard",
+        "bi",
+        "weekly-reporting",
+        "marketing-analytics"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "adtech/dashboard-qa-checker",
+      "name": "Dashboard QA Checker",
+      "description": "Validate dashboard datasets with freshness, completeness, reconciliation, anomaly, and schema drift checks before publish.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/dashboard-qa-checker/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/dashboard-qa-checker/0.1.0.tar.gz",
+          "sha256": "af17084525dc6ac7c29cf2f3fbab3882841b1d9cf6415230f06082aa908a807f"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "qa",
+        "dashboard",
+        "data-quality",
+        "anomaly-detection"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "adtech/executive-narrative-writer",
+      "name": "Executive Narrative Writer",
+      "description": "Convert validated BI performance outputs into concise executive narratives with actions and risks.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/executive-narrative-writer/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/executive-narrative-writer/0.1.0.tar.gz",
+          "sha256": "6f9676ad4b76dc9884ac554a4033eb56dab805eeeefc729513cac35831fd2240"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "executive-reporting",
+        "narrative",
+        "dashboard",
+        "marketing-analytics"
+      ],
+      "deprecated": false
+    },
+    {
       "id": "adtech/playwright-agentic-e2e",
       "name": "Playwright Agentic E2E QA",
       "description": "Build and maintain reusable Playwright smoke tests with planner, generator, and healer loops for web app regression checks.",
@@ -69,8 +153,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/adtech/playwright-agentic-e2e/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/adtech/playwright-agentic-e2e/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/playwright-agentic-e2e/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/playwright-agentic-e2e/0.1.0.tar.gz",
           "sha256": "d3d52ad5a6aab365b24dfdaf99dac9e40ae8758b83c6b577ac97bc57c3d2d6fa"
         }
       ],
@@ -98,8 +182,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/adtech/playwright-vscode-loop-codex/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/adtech/playwright-vscode-loop-codex/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/playwright-vscode-loop-codex/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/playwright-vscode-loop-codex/0.1.0.tar.gz",
           "sha256": "93ef3df77fd46d685ae4f49524807bc350e7dd954c57c4306760f3a98e76dba4"
         }
       ],
@@ -127,8 +211,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/adtech/policy-brand-compliance-checker/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/adtech/policy-brand-compliance-checker/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/policy-brand-compliance-checker/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/policy-brand-compliance-checker/0.1.0.tar.gz",
           "sha256": "288d5795725c8348d2ff02a553d00142a88ef9027e4244d7d86354645b52d9ac"
         }
       ],
@@ -146,6 +230,35 @@
       "deprecated": false
     },
     {
+      "id": "adtech/weekly-performance-review-bi",
+      "name": "Weekly Performance Review BI",
+      "description": "Chain dashboard generation, QA gating, and executive narrative writing for deterministic weekly BI reporting.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/weekly-performance-review-bi/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/weekly-performance-review-bi/0.1.0.tar.gz",
+          "sha256": "4c45ca487b0ef4167c6be77d57e89037c63238b7c4b602b57001ff7f57baa6a2"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "bi",
+        "orchestration",
+        "weekly-reporting",
+        "qa-gating",
+        "dashboard"
+      ],
+      "deprecated": false
+    },
+    {
       "id": "marketing/ab-test-planner-analyzer",
       "name": "A/B Test Planner + Analyzer",
       "description": "Plan and analyze A/B tests with explicit hypotheses, sample sizing assumptions, and decision rules.",
@@ -155,8 +268,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/marketing/ab-test-planner-analyzer/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/marketing/ab-test-planner-analyzer/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ab-test-planner-analyzer/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ab-test-planner-analyzer/0.1.0.tar.gz",
           "sha256": "774114da87c62eac1cda68ca379c2d87241287cfdadcfafee968358d222f0e3c"
         }
       ],
@@ -184,8 +297,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/marketing/ai-output-eval-scorecard/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/marketing/ai-output-eval-scorecard/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ai-output-eval-scorecard/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ai-output-eval-scorecard/0.1.0.tar.gz",
           "sha256": "5a1b8950e7914ebdfeb6864f137d5b117c1fddb3a68b8093e7569e363c2ffe05"
         }
       ],
@@ -213,8 +326,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/marketing/creative-workshop-pmax-reels/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/marketing/creative-workshop-pmax-reels/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/creative-workshop-pmax-reels/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creative-workshop-pmax-reels/0.1.0.tar.gz",
           "sha256": "64e981fc44af92bbb6a6aff0baefc3229771a0a59aa50cc270b1a09535c34a75"
         }
       ],
@@ -241,8 +354,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/marketing/cross-channel-budget-pacing-agent/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/marketing/cross-channel-budget-pacing-agent/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/cross-channel-budget-pacing-agent/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/cross-channel-budget-pacing-agent/0.1.0.tar.gz",
           "sha256": "7ac6b0350925f9c53e875abf8c57d5bbfe9e5721eba2acb2ea58d6079dee04f8"
         }
       ],
@@ -270,8 +383,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/marketing/dynamic-creative-rules-engine/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/marketing/dynamic-creative-rules-engine/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/dynamic-creative-rules-engine/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/dynamic-creative-rules-engine/0.1.0.tar.gz",
           "sha256": "e15dfe6bb25335f6061f78222fef48a8bd7c97e571e19d23790fd9c9c057590e"
         }
       ],
@@ -299,8 +412,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/marketing/lifecycle-experiment-planner/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/marketing/lifecycle-experiment-planner/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/lifecycle-experiment-planner/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/lifecycle-experiment-planner/0.1.0.tar.gz",
           "sha256": "a59868da91877823558670707e8f32531bef2c77049dcfaa6e9e3d426d4f91a6"
         }
       ],
@@ -327,8 +440,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/marketing/lifecycle-journey-trigger-designer/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/marketing/lifecycle-journey-trigger-designer/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/lifecycle-journey-trigger-designer/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/lifecycle-journey-trigger-designer/0.1.0.tar.gz",
           "sha256": "276a554d450d20db68f66116718e7bd9ea73b5e5b8b380587660b981c09151c5"
         }
       ],
@@ -356,8 +469,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/marketing/meta-google-weekly-performance-review/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/marketing/meta-google-weekly-performance-review/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/meta-google-weekly-performance-review/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/meta-google-weekly-performance-review/0.1.0.tar.gz",
           "sha256": "b4c90869ffab316f78f9439a1c96c021921249de5eb974a4e595c632ef8da057"
         }
       ],
@@ -384,8 +497,8 @@
         {
           "version": "0.1.0",
           "released_at": "2026-02-23T00:00:00Z",
-          "manifest_url": "https://hub.ai-knowledge-hub.org/skills/marketing/seo-paid-search-synergy/skill.yaml",
-          "artifact_url": "https://hub.ai-knowledge-hub.org/artifacts/marketing/seo-paid-search-synergy/0.1.0.tar.gz",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/seo-paid-search-synergy/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/seo-paid-search-synergy/0.1.0.tar.gz",
           "sha256": "b4496217276d81c17ace07a41f1f526388cae5b51192ea7bc7bd5f28cd16b9f7"
         }
       ],

--- a/shared/schemas/registry-index.schema.json
+++ b/shared/schemas/registry-index.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://hub.ai-knowledge-hub.org/schemas/registry-index.schema.json",
+  "$id": "https://skills.ai-knowledge-hub.org/schemas/registry-index.schema.json",
   "title": "Skills Registry Index",
   "type": "object",
   "additionalProperties": false,

--- a/shared/schemas/skill.schema.json
+++ b/shared/schemas/skill.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://hub.ai-knowledge-hub.org/schemas/skill.schema.json",
+  "$id": "https://skills.ai-knowledge-hub.org/schemas/skill.schema.json",
   "title": "Skill Manifest",
   "type": "object",
   "additionalProperties": false,

--- a/skills/adtech/dashboard-generator/README.md
+++ b/skills/adtech/dashboard-generator/README.md
@@ -1,0 +1,15 @@
+# Dashboard Generator
+
+Generates deterministic weekly performance dashboard sections and a publish-ready payload from normalized marketing data.
+
+## Inputs
+- normalized table
+- current and previous date windows
+- optional anomaly thresholds
+
+## Outputs
+- executive summary
+- channel table
+- anomaly panel
+- action panel
+- stable publish payload

--- a/skills/adtech/dashboard-generator/SKILL.md
+++ b/skills/adtech/dashboard-generator/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: dashboard-generator
+description: Build or refresh deterministic weekly performance dashboard outputs from standardized marketing tables for BI tools like Looker, Power BI, or Tableau. Use when asked to generate channel summaries, anomaly panels, action panels, or a fixed reporting layout for recurring performance reviews.
+---
+
+# Dashboard Generator
+
+## When to use
+- Use for recurring dashboard builds from cleaned performance datasets.
+- Use when stakeholders require the same weekly panel order and structure.
+- Use when asked to output both machine-ready dataset slices and human-readable dashboard sections.
+
+## Inputs required
+- normalized_performance_table with date, channel, campaign, spend, clicks, impressions, conversions, revenue.
+- date_window_current and date_window_previous.
+- output_contract (default): executive summary, channel table, anomaly panel, action panel.
+- optional thresholds for highlighting changes.
+
+## Workflow
+1. Validate required columns before any transformation.
+2. Aggregate by requested grain: channel first, then campaign when requested.
+3. Compute canonical metrics: CTR, CPC, CVR, CPA, ROAS.
+4. Compute period deltas using the same grain and metric definitions.
+5. Build deterministic dashboard payload sections in fixed order.
+6. Return both section content and a compact publish-ready data object.
+
+## Output format
+- Executive Summary: 3 to 5 bullets with largest business-impact changes.
+- Channel Table: channel, spend, conversions, CPA, ROAS, week-over-week deltas.
+- Anomaly Panel: metric, segment, observed delta, threshold, severity, likely cause hypothesis.
+- Action Panel: ranked actions with expected impact and confidence.
+- Publish Payload: stable JSON keys for BI layer ingestion.
+
+## Guardrails
+- Never fabricate data for missing channels or campaigns.
+- Preserve metric definitions exactly as provided by upstream dictionary.
+- Keep section order deterministic across runs.
+- Flag low confidence when previous period volume is below threshold.

--- a/skills/adtech/dashboard-generator/examples/input.json
+++ b/skills/adtech/dashboard-generator/examples/input.json
@@ -1,0 +1,15 @@
+{
+  "date_window_current": "2026-02-16 to 2026-02-22",
+  "date_window_previous": "2026-02-09 to 2026-02-15",
+  "rows": [
+    {
+      "channel": "Paid Search",
+      "campaign": "Brand",
+      "spend": 3200,
+      "impressions": 210000,
+      "clicks": 8400,
+      "conversions": 370,
+      "revenue": 17600
+    }
+  ]
+}

--- a/skills/adtech/dashboard-generator/examples/output.json
+++ b/skills/adtech/dashboard-generator/examples/output.json
@@ -1,0 +1,31 @@
+{
+  "executive_summary": [
+    "Paid Search ROAS improved week over week with stable CPA."
+  ],
+  "channel_table": [
+    {
+      "channel": "Paid Search",
+      "spend": 3200,
+      "conversions": 370,
+      "cpa": 8.65,
+      "roas": 5.5
+    }
+  ],
+  "anomaly_panel": [],
+  "action_panel": [
+    {
+      "priority": 1,
+      "action": "Scale high-ROAS Paid Search campaigns by 10% budget",
+      "confidence": "medium"
+    }
+  ],
+  "publish_payload": {
+    "schema_version": "1.0",
+    "sections": [
+      "executive_summary",
+      "channel_table",
+      "anomaly_panel",
+      "action_panel"
+    ]
+  }
+}

--- a/skills/adtech/dashboard-generator/skill.yaml
+++ b/skills/adtech/dashboard-generator/skill.yaml
@@ -1,0 +1,34 @@
+id: adtech/dashboard-generator
+name: Dashboard Generator
+description: Generate deterministic weekly marketing dashboard outputs from normalized performance tables for BI publishing.
+version: 0.1.0
+released_at: "2026-02-27T00:00:00Z"
+category: adtech/analytics-engineering
+tags:
+  - dashboard
+  - bi
+  - weekly-reporting
+  - marketing-analytics
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  scripts_dir: scripts
+  examples_dir: examples
+dependencies:
+  tools:
+    - python3
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/adtech/dashboard-generator/tests/test-prompts.md
+++ b/skills/adtech/dashboard-generator/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Build this week’s dashboard output sections from the normalized performance table.
+2. Regenerate the channel table with week-over-week deltas and keep the fixed layout.
+3. Create the anomaly panel using threshold rules and explain each flagged delta.
+4. Produce a publish payload for Looker with deterministic key ordering.
+5. Rebuild the dashboard for only Paid Search and Paid Social while preserving schema.

--- a/skills/adtech/dashboard-qa-checker/README.md
+++ b/skills/adtech/dashboard-qa-checker/README.md
@@ -1,0 +1,17 @@
+# Dashboard QA Checker
+
+Runs a fixed set of pre-publish QA validations for marketing dashboard data and returns a clear publish decision.
+
+## Checks
+- freshness
+- completeness
+- reconciliation
+- anomaly thresholds
+- schema drift
+
+## Outputs
+- QA summary
+- check-level evidence
+- blocking reasons
+- alert payload
+- publish decision

--- a/skills/adtech/dashboard-qa-checker/SKILL.md
+++ b/skills/adtech/dashboard-qa-checker/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: dashboard-qa-checker
+description: Run pre-publish QA checks for performance marketing dashboards, including freshness, completeness, reconciliation, anomaly thresholds, and schema drift. Use when validating BI-ready data or deciding whether to block dashboard publication and send incident alerts.
+---
+
+# Dashboard QA Checker
+
+## When to use
+- Use before publishing scheduled or ad hoc dashboard updates.
+- Use when validating whether source totals reconcile with dashboard aggregates.
+- Use when teams need explicit pass/fail checks and block-publish behavior.
+
+## Inputs required
+- source_totals by platform and date.
+- dashboard_dataset totals and field map.
+- check configuration with thresholds and criticality by rule.
+- latest data timestamps by source.
+
+## Workflow
+1. Run freshness check against expected ingest SLA.
+2. Run completeness check for required channels and campaigns.
+3. Run reconciliation check comparing spend and conversions to source totals.
+4. Run anomaly checks for unexpected period-over-period deltas.
+5. Run schema drift checks for added, removed, or renamed fields.
+6. Assign pass, warning, or fail for each check and aggregate publish status.
+7. If any critical check fails, set publish_status to blocked and emit alert payload.
+
+## Output format
+- QA Summary: overall status, failed checks count, warnings count.
+- Check Results Table: check_name, severity, status, evidence, suggested fix.
+- Blocking Reasons: list of critical failures and impacted outputs.
+- Alert Payload: channel, title, concise incident text, run identifier.
+- Publish Decision: approved or blocked.
+
+## Guardrails
+- Do not silently downgrade critical failures.
+- Do not pass reconciliation if tolerance is exceeded.
+- Include evidence values for every failed rule.
+- Require explicit user override before recommending publish on critical fail.

--- a/skills/adtech/dashboard-qa-checker/examples/input.json
+++ b/skills/adtech/dashboard-qa-checker/examples/input.json
@@ -1,0 +1,14 @@
+{
+  "run_id": "weekly-2026-02-22",
+  "freshness_sla_hours": 8,
+  "latest_source_timestamp": "2026-02-22T05:00:00Z",
+  "required_channels": ["Paid Search", "Paid Social"],
+  "source_totals": {
+    "spend": 25100,
+    "conversions": 1420
+  },
+  "dashboard_totals": {
+    "spend": 24780,
+    "conversions": 1409
+  }
+}

--- a/skills/adtech/dashboard-qa-checker/examples/output.json
+++ b/skills/adtech/dashboard-qa-checker/examples/output.json
@@ -1,0 +1,24 @@
+{
+  "qa_summary": {
+    "status": "blocked",
+    "failed_checks": 1,
+    "warnings": 1
+  },
+  "check_results": [
+    {
+      "check_name": "reconciliation",
+      "severity": "critical",
+      "status": "fail",
+      "evidence": "spend delta 1.27% exceeds 1.00% tolerance"
+    }
+  ],
+  "blocking_reasons": [
+    "Critical reconciliation failure on spend totals"
+  ],
+  "alert_payload": {
+    "channel": "slack",
+    "title": "Dashboard publish blocked",
+    "message": "Run weekly-2026-02-22 blocked due to critical reconciliation mismatch"
+  },
+  "publish_decision": "blocked"
+}

--- a/skills/adtech/dashboard-qa-checker/skill.yaml
+++ b/skills/adtech/dashboard-qa-checker/skill.yaml
@@ -1,0 +1,34 @@
+id: adtech/dashboard-qa-checker
+name: Dashboard QA Checker
+description: Validate dashboard datasets with freshness, completeness, reconciliation, anomaly, and schema drift checks before publish.
+version: 0.1.0
+released_at: "2026-02-27T00:00:00Z"
+category: adtech/analytics-engineering
+tags:
+  - qa
+  - dashboard
+  - data-quality
+  - anomaly-detection
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  scripts_dir: scripts
+  examples_dir: examples
+dependencies:
+  tools:
+    - python3
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/adtech/dashboard-qa-checker/tests/test-prompts.md
+++ b/skills/adtech/dashboard-qa-checker/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Run full pre-publish QA and decide if this dashboard run should be blocked.
+2. Validate freshness and completeness for weekly channel reporting.
+3. Reconcile spend and conversions versus source totals and report mismatches.
+4. Detect schema drift from last week and classify severity.
+5. Generate Slack alert text for all critical QA failures in this run.

--- a/skills/adtech/executive-narrative-writer/README.md
+++ b/skills/adtech/executive-narrative-writer/README.md
@@ -1,0 +1,15 @@
+# Executive Narrative Writer
+
+Turns QA-approved dashboard outputs into short leadership-ready narratives with clear actions.
+
+## Inputs
+- validated dashboard sections
+- KPI deltas and anomalies
+- business goals and constraints
+
+## Outputs
+- headline
+- executive summary
+- driver breakdown
+- risks and unknowns
+- next actions with owners

--- a/skills/adtech/executive-narrative-writer/SKILL.md
+++ b/skills/adtech/executive-narrative-writer/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: executive-narrative-writer
+description: Convert validated performance dashboard outputs into concise executive narratives with business impact framing, drivers, risks, and next actions. Use when stakeholders need leadership-ready summaries from BI outputs without changing underlying metrics.
+---
+
+# Executive Narrative Writer
+
+## When to use
+- Use after QA-approved dashboard datasets are available.
+- Use for weekly or monthly leadership updates.
+- Use when teams need concise explanation of what changed, why it changed, and what to do next.
+
+## Inputs required
+- qa_approved_dashboard_output.
+- top KPI deltas and anomaly findings.
+- business context: goals, budget constraints, and priority channels.
+- optional audience profile: CMO, performance lead, finance partner.
+
+## Workflow
+1. Extract largest positive and negative KPI movements.
+2. Attribute movements to channel, campaign, or efficiency drivers where evidence exists.
+3. Separate observed facts from hypotheses.
+4. Convert findings into a short executive summary with ranked recommendations.
+5. Add risks and required decisions with owners and timing.
+
+## Output format
+- Headline: one-sentence performance direction.
+- Executive Summary: 4 to 6 bullets with material shifts only.
+- Driver Breakdown: winners, underperformers, and quantified impact.
+- Risks and Unknowns: data gaps, confidence notes, and dependency risks.
+- Next Actions: prioritized actions with owner, expected impact, and target date.
+
+## Guardrails
+- Never rewrite or reinterpret metric definitions.
+- Avoid causal claims unless supported by data evidence.
+- Keep language concise and decision-oriented.
+- Explicitly mark assumptions and unresolved questions.

--- a/skills/adtech/executive-narrative-writer/examples/input.json
+++ b/skills/adtech/executive-narrative-writer/examples/input.json
@@ -1,0 +1,15 @@
+{
+  "qa_status": "approved",
+  "headline_metrics": {
+    "spend_delta_pct": 5.2,
+    "conversions_delta_pct": 8.1,
+    "roas_delta_pct": 4.4
+  },
+  "top_drivers": [
+    {
+      "channel": "Paid Search",
+      "impact": "positive",
+      "note": "Brand campaigns increased conversion efficiency"
+    }
+  ]
+}

--- a/skills/adtech/executive-narrative-writer/examples/output.md
+++ b/skills/adtech/executive-narrative-writer/examples/output.md
@@ -1,0 +1,17 @@
+# Headline
+Performance improved week over week with stronger conversion efficiency and higher ROAS.
+
+## Executive Summary
+- Conversions increased faster than spend, lifting overall efficiency.
+- Paid Search drove the largest incremental return.
+- No critical QA blockers were present in this reporting run.
+
+## Driver Breakdown
+- Paid Search: Brand campaigns delivered the largest positive impact.
+
+## Risks and Unknowns
+- Attribution lag may affect late-week conversion counts.
+
+## Next Actions
+1. Scale top-performing Paid Search campaigns by 10% next week.
+2. Monitor attribution lag and recheck ROAS in 72 hours.

--- a/skills/adtech/executive-narrative-writer/skill.yaml
+++ b/skills/adtech/executive-narrative-writer/skill.yaml
@@ -1,0 +1,34 @@
+id: adtech/executive-narrative-writer
+name: Executive Narrative Writer
+description: Convert validated BI performance outputs into concise executive narratives with actions and risks.
+version: 0.1.0
+released_at: "2026-02-27T00:00:00Z"
+category: adtech/analytics-engineering
+tags:
+  - executive-reporting
+  - narrative
+  - dashboard
+  - marketing-analytics
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  scripts_dir: scripts
+  examples_dir: examples
+dependencies:
+  tools:
+    - python3
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/adtech/executive-narrative-writer/tests/test-prompts.md
+++ b/skills/adtech/executive-narrative-writer/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Write a CMO-ready weekly narrative from this QA-approved dashboard output.
+2. Summarize the top growth and efficiency drivers in five bullets.
+3. Turn anomaly findings into a concise risks-and-actions section.
+4. Draft a leadership update with explicit assumptions and unknowns.
+5. Produce next actions with owner, target date, and expected impact.

--- a/skills/adtech/weekly-performance-review-bi/README.md
+++ b/skills/adtech/weekly-performance-review-bi/README.md
@@ -1,0 +1,17 @@
+# Weekly Performance Review BI
+
+Orchestrates three BI skills in one deterministic weekly reporting run.
+
+## Skill chain
+1. dashboard-generator
+2. dashboard-qa-checker
+3. executive-narrative-writer (only if QA approved)
+
+## Outputs
+- publish decision
+- dashboard package
+- QA package
+- executive narrative (conditional on QA pass)
+
+## Starter prompt
+- See [examples/starter-prompt.md](examples/starter-prompt.md) for a copy/paste weekly run template with fixed BI contract and QA thresholds.

--- a/skills/adtech/weekly-performance-review-bi/SKILL.md
+++ b/skills/adtech/weekly-performance-review-bi/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: weekly-performance-review-bi
+description: Orchestrate end-to-end weekly BI performance reporting by chaining dashboard generation, QA validation, and executive narrative writing. Use when teams need a deterministic weekly workflow that blocks publish on critical data-quality failures and only produces leadership summaries after QA approval.
+---
+
+# Weekly Performance Review BI
+
+## When to use
+- Use for recurring weekly performance marketing reporting with BI publish gates.
+- Use when output must follow a fixed structure across runs.
+- Use when reporting must stop automatically on critical data-quality failures.
+
+## Inputs required
+- normalized_performance_table with standardized marketing metrics.
+- source_totals and data timestamps for QA.
+- metric_dictionary and QA rule thresholds.
+- audience profile for executive summary tone.
+- reporting windows: current period and comparison period.
+
+## Workflow
+1. Run `dashboard-generator` on normalized data.
+2. Validate `dashboard-generator` output schema and required sections.
+3. Run `dashboard-qa-checker` against source totals, freshness, completeness, reconciliation, anomaly rules, and schema drift.
+4. If QA result is `blocked`, stop workflow and return QA package plus alert payload.
+5. If QA result is `approved`, run `executive-narrative-writer` with QA-approved dashboard output.
+6. Return consolidated package with publish decision, dashboard sections, and executive narrative.
+
+## Output format
+- Run Metadata: run_id, reporting windows, execution timestamp.
+- Publish Decision: approved or blocked with reasons.
+- Dashboard Package: executive summary, channel table, anomaly panel, action panel, publish payload.
+- QA Package: summary, check results, blocking reasons, alert payload.
+- Executive Narrative: headline, concise summary, driver breakdown, risks, next actions.
+
+## Guardrails
+- Never run executive narrative step when QA status is blocked.
+- Never override a critical QA failure without explicit user approval.
+- Preserve metric definitions and output schema contracts across all steps.
+- Keep section order stable so BI consumers receive deterministic outputs.

--- a/skills/adtech/weekly-performance-review-bi/examples/input.json
+++ b/skills/adtech/weekly-performance-review-bi/examples/input.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "wpr-bi-2026-02-22",
+  "date_window_current": "2026-02-16 to 2026-02-22",
+  "date_window_previous": "2026-02-09 to 2026-02-15",
+  "metric_dictionary": ["ctr", "cpc", "cpa", "roas", "cvr"],
+  "qa_thresholds": {
+    "freshness_hours": 8,
+    "reconciliation_tolerance_pct": 1.0,
+    "anomaly_delta_pct": 30
+  },
+  "audience": "CMO"
+}

--- a/skills/adtech/weekly-performance-review-bi/examples/output.json
+++ b/skills/adtech/weekly-performance-review-bi/examples/output.json
@@ -1,0 +1,22 @@
+{
+  "run_metadata": {
+    "run_id": "wpr-bi-2026-02-22",
+    "execution_timestamp": "2026-02-27T12:00:00Z"
+  },
+  "publish_decision": "approved",
+  "dashboard_package": {
+    "sections": [
+      "executive_summary",
+      "channel_table",
+      "anomaly_panel",
+      "action_panel"
+    ]
+  },
+  "qa_package": {
+    "status": "approved",
+    "failed_checks": 0
+  },
+  "executive_narrative": {
+    "headline": "Efficiency improved week over week with positive conversion growth."
+  }
+}

--- a/skills/adtech/weekly-performance-review-bi/examples/starter-prompt.md
+++ b/skills/adtech/weekly-performance-review-bi/examples/starter-prompt.md
@@ -1,0 +1,67 @@
+# Weekly Performance Review BI - Starter Prompt Template
+
+Use `weekly-performance-review-bi` and run the full workflow in this strict order:
+1. `dashboard-generator`
+2. `dashboard-qa-checker`
+3. `executive-narrative-writer` only if QA status is `approved`
+
+Input contract:
+- Date windows:
+  - current_period: `{{CURRENT_PERIOD_START}}` to `{{CURRENT_PERIOD_END}}`
+  - previous_period: `{{PREVIOUS_PERIOD_START}}` to `{{PREVIOUS_PERIOD_END}}`
+- Data sources:
+  - GA4 export/table: `{{GA4_SOURCE}}`
+  - Ad platform export/table: `{{ADS_SOURCE}}`
+  - Warehouse model/table: `{{WAREHOUSE_SOURCE}}`
+- Required normalized columns:
+  - `date`, `channel`, `campaign`, `spend`, `impressions`, `clicks`, `conversions`, `revenue`
+
+Metric dictionary (do not redefine):
+- CTR = clicks / impressions
+- CPC = spend / clicks
+- CPA = spend / conversions
+- ROAS = revenue / spend
+- CVR = conversions / clicks
+
+Fixed output contract (exact section order):
+1. Executive Summary
+2. Channel Table
+3. Anomaly Panel
+4. Action Panel
+
+QA checks (must run before publish):
+- freshness:
+  - fail if latest source timestamp is older than `{{FRESHNESS_SLA_HOURS}}` hours
+- completeness:
+  - fail if required channels are missing: `{{REQUIRED_CHANNELS_CSV}}`
+- reconciliation:
+  - fail if spend delta > `{{RECONCILIATION_SPEND_TOLERANCE_PCT}}%`
+  - fail if conversions delta > `{{RECONCILIATION_CONV_TOLERANCE_PCT}}%`
+- anomaly detection:
+  - flag if week-over-week delta exceeds `{{ANOMALY_DELTA_PCT}}%`
+- schema drift:
+  - fail if required columns are renamed or removed
+
+Publish rule:
+- If any critical QA check fails:
+  - set `publish_decision=blocked`
+  - do not generate executive narrative
+  - produce Slack/Teams alert payload using:
+    - channel: `{{ALERT_CHANNEL}}`
+    - destination: `{{ALERT_DESTINATION}}`
+    - mention group: `{{ALERT_MENTION}}`
+- If all critical checks pass:
+  - set `publish_decision=approved`
+  - generate executive narrative for audience: `{{AUDIENCE}}`
+
+Final response format:
+- Run Metadata: run_id, execution_timestamp, date windows
+- Publish Decision: approved/blocked with reasons
+- Dashboard Package: Executive Summary, Channel Table, Anomaly Panel, Action Panel, publish payload
+- QA Package: check results table with evidence, blocking reasons, alert payload (if blocked)
+- Executive Narrative: include only when publish_decision=approved
+
+Non-negotiable guardrails:
+- Never fabricate numeric values.
+- Never bypass critical QA failures.
+- Keep output schema deterministic across runs.

--- a/skills/adtech/weekly-performance-review-bi/skill.yaml
+++ b/skills/adtech/weekly-performance-review-bi/skill.yaml
@@ -1,0 +1,34 @@
+id: adtech/weekly-performance-review-bi
+name: Weekly Performance Review BI
+description: Chain dashboard generation, QA gating, and executive narrative writing for deterministic weekly BI reporting.
+version: 0.1.0
+released_at: "2026-02-27T00:00:00Z"
+category: adtech/analytics-engineering
+tags:
+  - bi
+  - orchestration
+  - weekly-reporting
+  - qa-gating
+  - dashboard
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools:
+    - python3
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/adtech/weekly-performance-review-bi/tests/test-prompts.md
+++ b/skills/adtech/weekly-performance-review-bi/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Run the weekly BI workflow end to end and block publish if any critical QA check fails.
+2. Generate dashboard outputs, validate QA, and provide executive narrative only when QA passes.
+3. Orchestrate this week's reporting and return publish decision with clear blocking reasons.
+4. Re-run the workflow with strict reconciliation thresholds and include alert payload on failure.
+5. Produce the consolidated output package with deterministic section ordering.


### PR DESCRIPTION
## Summary

This PR updates all Skills Hub domain references from:

- `https://hub.ai-knowledge-hub.org`  
to
- `https://skills.ai-knowledge-hub.org`

and verifies there are no remaining legacy references.

## What Changed

- Updated registry URL base in:
  - [[internal/registry/builder.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/internal/registry/builder.go)](internal/registry/builder.go)
- Updated schema `$id` values in:
  - [[shared/schemas/registry-index.schema.json](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/shared/schemas/registry-index.schema.json)](shared/schemas/registry-index.schema.json)
  - [[shared/schemas/skill.schema.json](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/shared/schemas/skill.schema.json)](shared/schemas/skill.schema.json)
- Updated deployment docs in:
  - [[docs/deploy-web-vercel.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/docs/deploy-web-vercel.md)](docs/deploy-web-vercel.md)
- Regenerated registry index so all hosted URLs use the new domain:
  - [[registry/index.json](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/registry/index.json)](registry/index.json)

## Validation

- Rebuilt registry with:
  - `go run ./cmd/registry-builder`
- Searched repo for legacy domain:
  - `hub.ai-knowledge-hub.org`
- Result:
  - No remaining matches.

## Also Included in This PR

### New BI Skills

- `dashboard-generator`
- `dashboard-qa-checker`
- `executive-narrative-writer`
- `weekly-performance-review-bi` (orchestration skill)

### New Starter Prompt Template

- [[skills/adtech/weekly-performance-review-bi/examples/starter-prompt.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/skills/adtech/weekly-performance-review-bi/examples/starter-prompt.md)](skills/adtech/weekly-performance-review-bi/examples/starter-prompt.md)