### PR TITLE
update documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@
 2. Include `SKILL.md`, `README.md`, `tests/test-prompts.md`, and `examples/`.
 3. Add at least 5 realistic prompts with expected behavior.
 4. Document assumptions (APIs, data sources, required tools).
-5. Include risk notes if shell commands, writes, or publishing actions are involved.
+5. Include risk notes if shell commands, writes, or publishing actions are
+   involved.
 
 ## Skill folder standard
 
@@ -55,5 +56,6 @@ first (see `apps/web/README.md`).
 
 ## Branch and commit guidance
 
-- Use short feature branches prefixed with `codex/` (e.g., `codex/skill-utm-linter`).
+- Default flow in this repo is `dev` -> `main`.
+- Keep commits on `dev` focused and reviewable; merge into `main` via PR.
 - Use scoped commit messages (e.g., `feat(skill): add pmax creative workshop`).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ same automations in silos.
 - Community references:
   [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)
 
-## Current Scope (14 practical skills)
+## Current Scope (18 practical skills)
 
 1. `meta-google-weekly-performance-review` (Beginner)
 2. `creative-workshop-pmax-reels` (Intermediate)
@@ -39,6 +39,10 @@ same automations in silos.
 12. `lifecycle-journey-trigger-designer` (Lifecycle CRM)
 13. `dynamic-creative-rules-engine` (Creative Ops / Personalization)
 14. `brand-rag-memory-bootstrap` (Analytics Engineering / RAG)
+15. `weekly-performance-review-bi` (BI Reporting)
+16. `dashboard-generator` (BI Dashboard Build)
+17. `dashboard-qa-checker` (BI QA)
+18. `executive-narrative-writer` (BI Insights Communication)
 
 ## New in v0.2 alpha
 
@@ -48,6 +52,10 @@ same automations in silos.
 - `lifecycle-journey-trigger-designer`
 - `dynamic-creative-rules-engine`
 - `brand-rag-memory-bootstrap`
+- `weekly-performance-review-bi`
+- `dashboard-generator`
+- `dashboard-qa-checker`
+- `executive-narrative-writer`
 
 ## Definition of done for each skill
 

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -14,9 +14,10 @@ into a public skills hub while staying on free-tier infrastructure.
   - lower operational overhead for a small core team
 - Initial modules:
   - `apps/web`
-  - `apps/cli`
-  - `packages/schemas`
-  - `packages/registry-builder`
+  - `cmd/skills-hub`
+  - `cmd/registry-builder`
+  - `shared/schemas`
+  - `internal/*` shared logic
 
 ## Decision 2: Frontend and Hosting
 
@@ -102,18 +103,17 @@ into a public skills hub while staying on free-tier infrastructure.
 ## Vercel Deployment Notes (Web MVP)
 
 - Deploy target: `apps/web`.
-- Build command: `npm run build`.
-- Install command: `npm install`.
+- Build command: `pnpm build`.
+- Install command: `pnpm install --frozen-lockfile`.
 - Output: standard Next.js deployment on Vercel.
 - Environment assumptions:
   - app reads `registry/index.json` from repository at build/runtime
   - no database or auth dependency required for MVP
 - Domain plan:
-  - production custom domain on Vercel
+  - production custom domain on Vercel: `skills.ai-knowledge-hub.org`
   - preview deployments from pull requests
 
 ## Open Questions
 
-- Final public name for the hub website.
 - Whether to split monorepo into multiple repos after beta.
 - Whether verified badge issuance should require signed artifacts.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,11 +6,23 @@
   - 6 practical skills from the guide
   - shared conventions and validation
   - CI and contribution templates
-- v0.3 in progress:
-  - Hub website MVP routes are live in `apps/web`
-  - Playwright smoke E2E is wired into CI
-  - reusable `adtech/playwright-agentic-e2e` QA skill added
-- Current focus: evolve from companion repo to public skills hub.
+- v0.2 delivered:
+  - stable `skill.yaml` and `registry/index.json` contracts
+  - deterministic registry generation and validation in CI
+  - runtime-aware CLI install paths (`codex`, `claude`, `generic`)
+- v0.3 delivered (Hub POC):
+  - public catalog is live at `https://skills.ai-knowledge-hub.org`
+  - Next.js hub routes and install UX are live in `apps/web`
+  - web lint/build + Playwright smoke checks are in CI
+  - release-cut and tag-publish automation are in place
+- Catalog expansion in progress:
+  - current catalog includes marketing, adtech, QA, and BI-oriented skills
+  - BI-related additions now include:
+    - `adtech/weekly-performance-review-bi`
+    - `adtech/dashboard-generator`
+    - `adtech/dashboard-qa-checker`
+    - `adtech/executive-narrative-writer`
+- Current focus: v0.4 trust, governance, and release maturity.
 
 ## v0.2 (Foundation)
 
@@ -62,6 +74,7 @@
 - Users can discover skills and copy install commands.
 - Registry updates are visible on the website after publish.
 - External contributor can submit a skill PR end-to-end.
+- Status: Delivered.
 
 ## v0.4 (Hub Beta)
 
@@ -75,12 +88,17 @@
 - Verified badges and quality scoring signals.
 - Version history and deprecation migration UX.
 - CLI remote install/update from registry URL.
+- BI workflows hardening:
+  - dashboard generation quality checks
+  - executive narrative consistency checks
+  - weekly BI review reliability baselines
 - Optional backend + database only if product needs exceed static flow.
 
 ### Exit Criteria
 
 - Stable release workflow for skills and CLI.
 - Clear governance for review, deprecation, and compatibility.
+- Consistent release cadence with milestone-quality tags.
 
 ## Decision Gates
 


### PR DESCRIPTION
## Summary
This PR performs a documentation synchronization pass after recent BI skill additions, domain migration, and release-process updates.

## What Changed

### 1) Roadmap alignment with current state
Updated `docs/roadmap.md` to reflect:
- `v0.2` delivered
- `v0.3` delivered (hub live)
- current production domain: `https://skills.ai-knowledge-hub.org`
- BI-oriented catalog expansion status
- current focus on `v0.4` trust/governance/release maturity

### 2) README scope + catalog updates
Updated `README.md`:
- scope count from 14 -> 18 skills
- added BI skill additions to scope list:
  - `adtech/weekly-performance-review-bi`
  - `adtech/dashboard-generator`
  - `adtech/dashboard-qa-checker`
  - `adtech/executive-narrative-writer`
- expanded `New in v0.2 alpha` list accordingly

### 3) Architecture decisions doc refresh
Updated `docs/architecture-decisions.md`:
- corrected module references to current repo layout (`cmd/*`, `shared/schemas`, `internal/*`)
- updated Vercel commands to `pnpm` and frozen lockfile
- set production domain explicitly to `skills.ai-knowledge-hub.org`
- removed obsolete “final public name” open question

### 4) Contributing flow correction
Updated `CONTRIBUTING.md`:
- branch guidance now matches actual team flow (`dev -> main`)
- wrapped a long line to keep markdownlint-safe formatting

## Why
- Prevents contributor confusion caused by stale docs.
- Keeps public project positioning and internal process docs consistent with actual operations.
- Aligns documentation with current release and deployment reality.

## Notes
This PR is documentation-only and intended as a synchronization checkpoint after multiple feature/skill waves.
