### PR TITLE
Dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@
    - `skills/<domain>/<slug>`
    - `agents/<domain>/<slug>`
    - `tools-mcp/<domain>/<slug>`
-2. Include spec file (`SKILL.md` or `AGENT.md` or `TOOL.md`), `README.md`, `tests/test-prompts.md`, and `examples/`.
+2. Include spec file (`SKILL.md` or `AGENT.md` or `TOOL.md`),
+   `README.md`, `tests/test-prompts.md`, and `examples/`.
 3. Include correct manifest (`skill.yaml`, `agent.yaml`, or `tool.yaml`).
 4. Ensure at least 5 realistic prompts with expected behavior.
 5. Document assumptions (APIs, data sources, required tools).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,19 +7,24 @@
 
 ## Pull request requirements
 
-1. Add/update one skill under `skills/marketing` or `skills/adtech`.
-2. Include `SKILL.md`, `README.md`, `tests/test-prompts.md`, and `examples/`.
-3. Add at least 5 realistic prompts with expected behavior.
-4. Document assumptions (APIs, data sources, required tools).
-5. Include risk notes if shell commands, writes, or publishing actions are
+1. Add/update one entry under one module:
+   - `skills/<domain>/<slug>`
+   - `agents/<domain>/<slug>`
+   - `tools-mcp/<domain>/<slug>`
+2. Include spec file (`SKILL.md` or `AGENT.md` or `TOOL.md`), `README.md`, `tests/test-prompts.md`, and `examples/`.
+3. Include correct manifest (`skill.yaml`, `agent.yaml`, or `tool.yaml`).
+4. Ensure at least 5 realistic prompts with expected behavior.
+5. Document assumptions (APIs, data sources, required tools).
+6. Include risk notes if shell commands, writes, or publishing actions are
    involved.
 
-## Skill folder standard
+## Module folder standard
 
 ```text
-<skill-name>/
+<entry-slug>/
   README.md
-  SKILL.md
+  SKILL.md | AGENT.md | TOOL.md
+  skill.yaml | agent.yaml | tool.yaml
   scripts/        # deterministic logic
   references/     # optional deep docs
   config/         # optional rules
@@ -42,6 +47,8 @@ Run before opening a PR:
 
 ```bash
 bash scripts/validate-skills.sh
+go run ./cmd/registry-builder
+bash scripts/validate-manifests.sh
 ```
 
 If your changes touch `apps/web`, also run:

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ SHELL := /bin/bash
 help:
 	@echo "Targets:"
 	@echo "  make doctor        - Verify local toolchain prerequisites"
-	@echo "  make validate      - Validate skill structure and standards"
-	@echo "  make manifests     - Validate skill.yaml and registry index schemas"
-	@echo "  make registry      - Generate registry/index.json from skill manifests"
+	@echo "  make validate      - Validate module structure and standards"
+	@echo "  make manifests     - Validate skill/agent/tool manifests and registry schemas"
+	@echo "  make registry      - Generate skills, agents, tools, and compatibility indexes"
 	@echo "  make test-scripts  - Run deterministic script checks"
 	@echo "  make test          - Run all local tests (validate + test-scripts)"
 	@echo "  make ci-local      - Run local checks similar to CI"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # AI Skills Guide
 
 Practical, reusable AI skills for marketing practitioners and ad-tech
-software engineers, plus a hub UI and QA automation flows.
+software engineers, plus agent templates, tools/MCP definitions, a hub UI,
+and QA automation flows.
 
 ## What this repo is
 
@@ -11,10 +12,12 @@ scripts, test prompts, and contribution standards.
 
 ## Positioning
 
-AI Knowledge Hub is an open, runtime-agnostic skills platform for
-marketing and adtech teams. We publish reusable AI skill packages with
-guardrails, tests, and install paths so teams can stop rebuilding the
-same automations in silos.
+AI Knowledge Hub is an open, runtime-agnostic platform for marketing and
+adtech teams. We publish reusable building blocks across three modules:
+
+- skills (task-level expertise)
+- agents (orchestrated templates)
+- tools & MCP connectors (integration layer)
 
 - Guide article site:
   [ai-news-hub.performics-labs.com](https://ai-news-hub.performics-labs.com)
@@ -23,8 +26,9 @@ same automations in silos.
 - Community references:
   [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)
 
-## Current Scope (18 practical skills)
+## Current Scope
 
+### Skills (18)
 1. `meta-google-weekly-performance-review` (Beginner)
 2. `creative-workshop-pmax-reels` (Intermediate)
 3. `lifecycle-experiment-planner` (Intermediate)
@@ -44,7 +48,19 @@ same automations in silos.
 17. `dashboard-qa-checker` (BI QA)
 18. `executive-narrative-writer` (BI Insights Communication)
 
-## New in v0.2 alpha
+### Agents (3)
+
+1. `marketing/weekly-performance-supervisor`
+2. `marketing/campaign-qa-supervisor`
+3. `adtech/bi-insights-orchestrator`
+
+### Tools & MCP (3)
+
+1. `analytics/ga4-mcp-connector`
+2. `ads/meta-ads-mcp-connector`
+3. `warehouse/bigquery-mcp-query-runner`
+
+## Recent Additions
 
 - `ai-output-eval-scorecard`
 - `cross-channel-budget-pacing-agent`
@@ -56,12 +72,25 @@ same automations in silos.
 - `dashboard-generator`
 - `dashboard-qa-checker`
 - `executive-narrative-writer`
+- `marketing/weekly-performance-supervisor`
+- `marketing/campaign-qa-supervisor`
+- `adtech/bi-insights-orchestrator`
+- `analytics/ga4-mcp-connector`
+- `ads/meta-ads-mcp-connector`
+- `warehouse/bigquery-mcp-query-runner`
 
-## Definition of done for each skill
+## Definition of done for each module entry
 
-- Has `SKILL.md` with clear routing intent and guardrails
+- Has a module spec file:
+  - skills: `SKILL.md`
+  - agents: `AGENT.md`
+  - tools-mcp: `TOOL.md`
 - Has `tests/test-prompts.md` (>= 5 realistic prompts)
 - Has `examples/` with sample input/output shape
+- Has a valid manifest:
+  - skills: `skill.yaml`
+  - agents: `agent.yaml`
+  - tools-mcp: `tool.yaml`
 - Documents runtime assumptions and dependencies
 - Uses scripts/config for deterministic logic where relevant
 
@@ -71,6 +100,18 @@ same automations in silos.
 skills/
   marketing/
   adtech/
+agents/
+  marketing/
+  adtech/
+tools-mcp/
+  analytics/
+  ads/
+  warehouse/
+registry/
+  index.json           # compatibility skills index
+  skills-index.json
+  agents-index.json
+  tools-index.json
 apps/
   web/
 shared/
@@ -97,11 +138,12 @@ Useful sections include skills for:
 
 ## Quickstart
 
-1. Pick a skill folder under `skills/`.
-2. Read `README.md` + `SKILL.md` for required inputs.
+1. Pick a module entry under `skills/`, `agents/`, or `tools-mcp/`.
+2. Read `README.md` and the module spec file (`SKILL.md`/`AGENT.md`/`TOOL.md`).
 3. Run prompts in `tests/test-prompts.md`.
 4. Verify structure with `bash scripts/validate-skills.sh`.
-5. Submit improvements via PR.
+5. Validate manifests with `bash scripts/validate-manifests.sh`.
+6. Submit improvements via PR.
 
 ## CLI Scaffold (Go)
 
@@ -122,11 +164,17 @@ python3 -m pip install check-jsonschema
 make manifests
 ```
 
-Generate `registry/index.json` from manifests:
+Generate module indexes from manifests:
 
 ```bash
 make registry
 ```
+
+This now writes:
+- `registry/skills-index.json`
+- `registry/agents-index.json`
+- `registry/tools-index.json`
+- `registry/index.json` (skills compatibility index)
 
 Example usage:
 
@@ -177,7 +225,11 @@ Core routes:
 
 - `/` overview
 - `/skills` searchable catalog
+- `/agents` searchable catalog
+- `/tools-mcp` searchable catalog
 - `/skills/<category>/<slug>` skill details and install snippets
+- `/agents/<category>/<slug>` agent details
+- `/tools-mcp/<category>/<slug>` tool/MCP details
 
 Smoke E2E tests:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ adtech teams. We publish reusable building blocks across three modules:
 ## Current Scope
 
 ### Skills (18)
+
 1. `meta-google-weekly-performance-review` (Beginner)
 2. `creative-workshop-pmax-reels` (Intermediate)
 3. `lifecycle-experiment-planner` (Intermediate)
@@ -171,6 +172,7 @@ make registry
 ```
 
 This now writes:
+
 - `registry/skills-index.json`
 - `registry/agents-index.json`
 - `registry/tools-index.json`

--- a/agents/adtech/bi-insights-orchestrator/AGENT.md
+++ b/agents/adtech/bi-insights-orchestrator/AGENT.md
@@ -1,0 +1,18 @@
+# BI Insights Orchestrator
+
+## Identity
+Adtech analytics orchestrator for warehouse-backed marketing insights.
+
+## Mission
+Coordinate cross-source metric pulls, normalization, and insight generation for BI consumption.
+
+## Workflow
+1. Pull warehouse and platform metrics for fixed windows.
+2. Normalize metric definitions across sources.
+3. Generate summary insights and anomaly candidates.
+4. Route results into dashboard and narrative skills.
+
+## Guardrails
+- Never mix metric definitions across sources.
+- Flag schema drift before producing executive conclusions.
+- Require QA pass before publish recommendation.

--- a/agents/adtech/bi-insights-orchestrator/README.md
+++ b/agents/adtech/bi-insights-orchestrator/README.md
@@ -1,0 +1,3 @@
+# BI Insights Orchestrator
+
+Agent template for orchestrating cross-source BI insight generation in marketing analytics.

--- a/agents/adtech/bi-insights-orchestrator/agent.yaml
+++ b/agents/adtech/bi-insights-orchestrator/agent.yaml
@@ -1,0 +1,36 @@
+id: adtech/bi-insights-orchestrator
+name: BI Insights Orchestrator
+description: Orchestrate warehouse and ad platform data analysis into standardized BI insights with QA-aware controls.
+version: 0.1.0
+released_at: "2026-03-02T00:00:00Z"
+category: adtech-agents/analytics
+tags:
+  - bi
+  - analytics
+  - orchestration
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: AGENT.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  skills:
+    - adtech/analyst-copilot-bigquery-redshift
+    - adtech/dashboard-generator
+    - adtech/dashboard-qa-checker
+  tools:
+    - bigquery_sql
+    - ga4_query
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/agents/adtech/bi-insights-orchestrator/examples/input.json
+++ b/agents/adtech/bi-insights-orchestrator/examples/input.json
@@ -1,0 +1,5 @@
+{
+  "window_current": "2026-02-23 to 2026-03-01",
+  "window_previous": "2026-02-16 to 2026-02-22",
+  "sources": ["GA4", "BigQuery", "Meta Ads"]
+}

--- a/agents/adtech/bi-insights-orchestrator/examples/output.json
+++ b/agents/adtech/bi-insights-orchestrator/examples/output.json
@@ -1,0 +1,6 @@
+{
+  "status": "approved",
+  "normalized_metrics": ["ctr", "cpc", "cpa", "roas", "cvr"],
+  "anomaly_count": 2,
+  "publish_recommendation": "approved"
+}

--- a/agents/adtech/bi-insights-orchestrator/tests/test-prompts.md
+++ b/agents/adtech/bi-insights-orchestrator/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Orchestrate fixed-window cross-source BI insight generation.
+2. Normalize metrics and highlight schema drift before analysis.
+3. Produce prioritized anomalies with evidence values.
+4. Route approved data into dashboard-ready payload sections.
+5. Return a publish recommendation gated by QA results.

--- a/agents/marketing/campaign-qa-supervisor/AGENT.md
+++ b/agents/marketing/campaign-qa-supervisor/AGENT.md
@@ -1,0 +1,19 @@
+# Campaign QA Supervisor
+
+## Identity
+Campaign QA and compliance supervisor for pre-launch and in-flight checks.
+
+## Mission
+Run structured QA checks across campaign data, naming, tracking, and policy constraints before escalation to operations.
+
+## Workflow
+1. Collect campaign payloads and tracking metadata.
+2. Validate completeness and required fields.
+3. Run policy and naming checks.
+4. Evaluate severity and produce pass/warn/fail decision.
+5. Post structured remediation actions.
+
+## Guardrails
+- Block launch recommendations on critical policy or tracking failures.
+- Separate observed failures from assumptions.
+- Require explicit override for critical failures.

--- a/agents/marketing/campaign-qa-supervisor/README.md
+++ b/agents/marketing/campaign-qa-supervisor/README.md
@@ -1,0 +1,3 @@
+# Campaign QA Supervisor
+
+Agent template for campaign QA gating with clear remediation outputs.

--- a/agents/marketing/campaign-qa-supervisor/agent.yaml
+++ b/agents/marketing/campaign-qa-supervisor/agent.yaml
@@ -1,0 +1,34 @@
+id: marketing/campaign-qa-supervisor
+name: Campaign QA Supervisor
+description: Validate campaign setup quality, tracking integrity, and policy compliance before launch or major edits.
+version: 0.1.0
+released_at: "2026-03-02T00:00:00Z"
+category: marketing-agents/governance
+tags:
+  - campaign-qa
+  - policy
+  - governance
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: AGENT.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  skills:
+    - adtech/policy-brand-compliance-checker
+  tools:
+    - campaign_config_reader
+    - slack_post
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/agents/marketing/campaign-qa-supervisor/examples/input.json
+++ b/agents/marketing/campaign-qa-supervisor/examples/input.json
@@ -1,0 +1,8 @@
+{
+  "campaign_id": "spring-launch-2026",
+  "channel": "Paid Social",
+  "tracking": {
+    "utm_source": "meta",
+    "utm_medium": "paid-social"
+  }
+}

--- a/agents/marketing/campaign-qa-supervisor/examples/output.json
+++ b/agents/marketing/campaign-qa-supervisor/examples/output.json
@@ -1,0 +1,6 @@
+{
+  "status": "warn",
+  "critical_failures": 0,
+  "warnings": ["utm_campaign missing naming suffix"],
+  "actions": ["Update UTM naming to required convention"]
+}

--- a/agents/marketing/campaign-qa-supervisor/tests/test-prompts.md
+++ b/agents/marketing/campaign-qa-supervisor/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Run pre-launch QA and return pass/warn/fail with evidence.
+2. Detect missing UTM fields and block launch if critical.
+3. Flag policy violations and produce remediation tasks.
+4. Generate concise Slack incident message for critical failures.
+5. Summarize non-critical warnings separately from blockers.

--- a/agents/marketing/weekly-performance-supervisor/AGENT.md
+++ b/agents/marketing/weekly-performance-supervisor/AGENT.md
@@ -1,0 +1,24 @@
+# Weekly Performance Supervisor
+
+## Identity
+Senior performance marketing supervisor agent for weekly business reviews.
+
+## Mission
+Coordinate dashboard generation, QA gating, and executive narrative output for recurring weekly reporting.
+
+## Skill Chain
+1. adtech/dashboard-generator
+2. adtech/dashboard-qa-checker
+3. adtech/executive-narrative-writer (only when QA approved)
+
+## Workflow
+1. Receive reporting window and required channels.
+2. Invoke dashboard generation from normalized data.
+3. Invoke QA checks and evaluate blocking status.
+4. If blocked, stop and emit alert payload.
+5. If approved, generate executive narrative and consolidated package.
+
+## Guardrails
+- Never bypass critical QA failures.
+- Never publish narrative when QA is blocked.
+- Keep outputs deterministic for weekly comparability.

--- a/agents/marketing/weekly-performance-supervisor/README.md
+++ b/agents/marketing/weekly-performance-supervisor/README.md
@@ -1,0 +1,3 @@
+# Weekly Performance Supervisor
+
+Agent template for deterministic weekly performance reporting with QA-gated publish control.

--- a/agents/marketing/weekly-performance-supervisor/agent.yaml
+++ b/agents/marketing/weekly-performance-supervisor/agent.yaml
@@ -1,0 +1,36 @@
+id: marketing/weekly-performance-supervisor
+name: Weekly Performance Supervisor
+description: Orchestrate weekly performance reporting by chaining dashboard generation, QA checks, and executive narrative output.
+version: 0.1.0
+released_at: "2026-03-02T00:00:00Z"
+category: marketing-agents/performance
+tags:
+  - weekly-reporting
+  - orchestration
+  - qa-gating
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: AGENT.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  skills:
+    - adtech/dashboard-generator
+    - adtech/dashboard-qa-checker
+    - adtech/executive-narrative-writer
+  tools:
+    - ga4_query
+    - warehouse_query
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/agents/marketing/weekly-performance-supervisor/examples/input.json
+++ b/agents/marketing/weekly-performance-supervisor/examples/input.json
@@ -1,0 +1,6 @@
+{
+  "run_id": "weekly-supervisor-2026-03-02",
+  "date_window": "2026-02-23 to 2026-03-01",
+  "channels": ["Paid Search", "Paid Social"],
+  "audience": "CMO"
+}

--- a/agents/marketing/weekly-performance-supervisor/examples/output.json
+++ b/agents/marketing/weekly-performance-supervisor/examples/output.json
@@ -1,0 +1,6 @@
+{
+  "publish_decision": "approved",
+  "sections": ["executive_summary", "channel_table", "anomaly_panel", "action_panel"],
+  "qa_status": "approved",
+  "narrative_status": "generated"
+}

--- a/agents/marketing/weekly-performance-supervisor/tests/test-prompts.md
+++ b/agents/marketing/weekly-performance-supervisor/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Run this week’s supervisor flow and block publish if critical QA fails.
+2. Produce approved dashboard package and executive narrative for CMO audience.
+3. Re-run with stricter reconciliation thresholds and return alert payload on failure.
+4. Summarize blocking reasons only when QA status is blocked.
+5. Keep output ordering deterministic across repeated runs.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -27,6 +27,12 @@ Run tests:
 pnpm test:e2e
 ```
 
+Current smoke coverage:
+- home module navigation
+- skills catalog and skill detail
+- agents catalog and agent detail
+- tools-mcp catalog and tool detail
+
 ## Build
 
 ```bash
@@ -39,3 +45,7 @@ pnpm start
 - `/` overview
 - `/skills` catalog with filters
 - `/skills/<category>/<slug>` skill details with install snippets
+- `/agents` catalog with filters
+- `/agents/<category>/<slug>` agent details
+- `/tools-mcp` catalog with filters
+- `/tools-mcp/<category>/<slug>` tool and MCP details

--- a/apps/web/app/agents/[...id]/page.tsx
+++ b/apps/web/app/agents/[...id]/page.tsx
@@ -1,0 +1,61 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getEntryById, loadAgentsRegistry } from "@/lib/registry";
+
+export async function generateStaticParams() {
+  const registry = await loadAgentsRegistry();
+  return registry.skills.map((entry) => ({ id: entry.id.split("/") }));
+}
+
+export default async function AgentDetailPage({ params }: { params: { id: string[] } }) {
+  const entryId = params.id.join("/");
+  const entry = await getEntryById("agents", entryId);
+  if (!entry) {
+    notFound();
+  }
+  const latestVersion = entry.versions.find((v) => v.version === entry.latest) ?? entry.versions[0];
+
+  return (
+    <main>
+      <div className="nav">
+        <Link href="/" className="pill">Home</Link>
+        <Link href="/agents" className="pill">Agents</Link>
+        <span className="pill">{entry.id}</span>
+      </div>
+
+      <article className="card">
+        <p className="meta">{entry.category}</p>
+        <h1>{entry.name}</h1>
+        <p>{entry.description}</p>
+        <div className="tags">
+          {entry.tags.map((tag) => (
+            <span key={tag} className="tag">{tag}</span>
+          ))}
+        </div>
+      </article>
+
+      <section className="detail-grid">
+        <article className="card detail-panel">
+          <h2>Metadata</h2>
+          <p><span className="meta">ID:</span> {entry.id}</p>
+          <p><span className="meta">Latest:</span> {entry.latest}</p>
+          <p><span className="meta">Runtimes:</span> {entry.runtimes.join(", ")}</p>
+          <p><span className="meta">Deprecated:</span> {String(entry.deprecated)}</p>
+          {entry.replaced_by ? <p><span className="meta">Replaced by:</span> {entry.replaced_by}</p> : null}
+        </article>
+        <article className="card detail-panel">
+          <h2>Latest Version</h2>
+          <p><span className="meta">Released:</span> {latestVersion?.released_at.slice(0, 10) ?? "n/a"}</p>
+          <p>
+            <span className="meta">Manifest:</span>{" "}
+            {latestVersion ? <a href={latestVersion.manifest_url}>{latestVersion.manifest_url}</a> : "n/a"}
+          </p>
+          <p>
+            <span className="meta">Artifact:</span>{" "}
+            {latestVersion ? <a href={latestVersion.artifact_url}>{latestVersion.artifact_url}</a> : "n/a"}
+          </p>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/agents/page.tsx
+++ b/apps/web/app/agents/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { loadSkillsRegistry, uniqueValues } from "@/lib/registry";
+import { loadAgentsRegistry, uniqueValues } from "@/lib/registry";
 import CatalogClient from "@/components/CatalogClient";
 
 type SearchParams = {
@@ -9,8 +9,8 @@ type SearchParams = {
   runtime?: string;
 };
 
-export default async function SkillsPage({ searchParams }: { searchParams: SearchParams }) {
-  const registry = await loadSkillsRegistry();
+export default async function AgentsPage({ searchParams }: { searchParams: SearchParams }) {
+  const registry = await loadAgentsRegistry();
   const q = searchParams.q ?? "";
   const tag = searchParams.tag ?? "";
   const category = searchParams.category ?? "";
@@ -23,19 +23,19 @@ export default async function SkillsPage({ searchParams }: { searchParams: Searc
     <main>
       <div className="nav">
         <Link href="/" className="pill">Home</Link>
-        <Link href="/agents" className="pill">Agents</Link>
+        <Link href="/skills" className="pill">Skills</Link>
         <Link href="/tools-mcp" className="pill">Tools &amp; MCP</Link>
-        <span className="pill">Catalog</span>
+        <span className="pill">Agents</span>
       </div>
 
-      <h1>Skills Catalog</h1>
-      <p>Filter by intent, runtime, and category to find install-ready skills.</p>
+      <h1>Agents Catalog</h1>
+      <p>Browse orchestrated agent templates composed from role, memory, skills, and tools.</p>
 
       <CatalogClient
         entries={registry.skills}
         categories={categories}
         tags={tags}
-        basePath="/skills"
+        basePath="/agents"
         initial={{ q, tag, category, runtime }}
       />
     </main>

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -3,11 +3,13 @@ import Link from "next/link";
 export default function NotFoundPage() {
   return (
     <main>
-      <h1>Skill not found</h1>
-      <p>We could not find that skill in the current registry snapshot.</p>
+      <h1>Item not found</h1>
+      <p>We could not find that entry in the current registry snapshot.</p>
       <div className="nav">
         <Link href="/" className="button button--secondary">Home</Link>
-        <Link href="/skills" className="button button--secondary">Catalog</Link>
+        <Link href="/skills" className="button button--secondary">Skills</Link>
+        <Link href="/agents" className="button button--secondary">Agents</Link>
+        <Link href="/tools-mcp" className="button button--secondary">Tools &amp; MCP</Link>
       </div>
     </main>
   );

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,10 +1,16 @@
 import Link from "next/link";
-import { loadRegistry, uniqueValues } from "@/lib/registry";
+import { loadAgentsRegistry, loadSkillsRegistry, loadToolsRegistry, uniqueValues } from "@/lib/registry";
 import { FEATURED_SKILL_IDS } from "@/lib/home";
 
 export default async function HomePage() {
-  const registry = await loadRegistry();
-  const skills = registry.skills;
+  const [skillsRegistry, agentsRegistry, toolsRegistry] = await Promise.all([
+    loadSkillsRegistry(),
+    loadAgentsRegistry(),
+    loadToolsRegistry()
+  ]);
+  const skills = skillsRegistry.skills;
+  const agents = agentsRegistry.skills;
+  const tools = toolsRegistry.skills;
   const categories = uniqueValues(skills.map((s) => s.category));
   const tags = uniqueValues(skills.flatMap((s) => s.tags));
   const featuredSkills = FEATURED_SKILL_IDS
@@ -31,7 +37,9 @@ export default async function HomePage() {
     <main>
       <div className="nav">
         <span className="pill">AI Knowledge Hub</span>
-        <Link href="/skills" className="pill">Browse Skills</Link>
+        <Link href="/skills" className="pill">Skills</Link>
+        <Link href="/agents" className="pill">Agents</Link>
+        <Link href="/tools-mcp" className="pill">Tools &amp; MCP</Link>
       </div>
 
       <section className="hero">
@@ -56,12 +64,18 @@ export default async function HomePage() {
         </article>
         <article className="card">
           <h2>Catalog Snapshot</h2>
-          <p><span className="meta">Categories:</span> {categories.length}</p>
-          <p><span className="meta">Tags:</span> {tags.length}</p>
+          <p><span className="meta">Skills categories:</span> {categories.length}</p>
+          <p><span className="meta">Skills tags:</span> {tags.length}</p>
           <p><span className="meta">Runtimes:</span> codex, claude, generic</p>
           <div className="actions snapshot-actions">
             <Link href="/skills" className="button button--accent">
-              Explore catalog
+              Explore skills
+            </Link>
+            <Link href="/agents" className="button button--secondary">
+              Browse agents
+            </Link>
+            <Link href="/tools-mcp" className="button button--secondary">
+              Browse tools
             </Link>
             <a
               href="https://github.com/ai-knowledge-hub/ai-skills-guide"
@@ -72,8 +86,10 @@ export default async function HomePage() {
           </div>
           <div className="tags">
             <span className="tag">{skills.length} skills</span>
-            <span className="tag">Registry v{registry.registry_version}</span>
-            <span className="tag">Generated {registry.generated_at.slice(0, 10)}</span>
+            <span className="tag">{agents.length} agents</span>
+            <span className="tag">{tools.length} tools</span>
+            <span className="tag">Skills registry v{skillsRegistry.registry_version}</span>
+            <span className="tag">Generated {skillsRegistry.generated_at.slice(0, 10)}</span>
           </div>
           <div className="new-alpha">
             <p className="meta">Newest skills</p>

--- a/apps/web/app/skills/[...id]/page.tsx
+++ b/apps/web/app/skills/[...id]/page.tsx
@@ -1,10 +1,10 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { buildInstallSnippet, getSkillById, loadRegistry } from "@/lib/registry";
+import { buildInstallSnippet, getSkillById, loadSkillsRegistry } from "@/lib/registry";
 import InstallCommands from "@/components/InstallCommands";
 
 export async function generateStaticParams() {
-  const registry = await loadRegistry();
+  const registry = await loadSkillsRegistry();
   return registry.skills.map((skill) => ({ id: skill.id.split("/") }));
 }
 
@@ -20,6 +20,8 @@ export default async function SkillDetailPage({ params }: { params: { id: string
       <div className="nav">
         <Link href="/" className="pill">Home</Link>
         <Link href="/skills" className="pill">Catalog</Link>
+        <Link href="/agents" className="pill">Agents</Link>
+        <Link href="/tools-mcp" className="pill">Tools &amp; MCP</Link>
         <span className="pill">{skill.id}</span>
       </div>
 

--- a/apps/web/app/tools-mcp/[...id]/page.tsx
+++ b/apps/web/app/tools-mcp/[...id]/page.tsx
@@ -1,0 +1,61 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getEntryById, loadToolsRegistry } from "@/lib/registry";
+
+export async function generateStaticParams() {
+  const registry = await loadToolsRegistry();
+  return registry.skills.map((entry) => ({ id: entry.id.split("/") }));
+}
+
+export default async function ToolDetailPage({ params }: { params: { id: string[] } }) {
+  const entryId = params.id.join("/");
+  const entry = await getEntryById("tools", entryId);
+  if (!entry) {
+    notFound();
+  }
+  const latestVersion = entry.versions.find((v) => v.version === entry.latest) ?? entry.versions[0];
+
+  return (
+    <main>
+      <div className="nav">
+        <Link href="/" className="pill">Home</Link>
+        <Link href="/tools-mcp" className="pill">Tools &amp; MCP</Link>
+        <span className="pill">{entry.id}</span>
+      </div>
+
+      <article className="card">
+        <p className="meta">{entry.category}</p>
+        <h1>{entry.name}</h1>
+        <p>{entry.description}</p>
+        <div className="tags">
+          {entry.tags.map((tag) => (
+            <span key={tag} className="tag">{tag}</span>
+          ))}
+        </div>
+      </article>
+
+      <section className="detail-grid">
+        <article className="card detail-panel">
+          <h2>Metadata</h2>
+          <p><span className="meta">ID:</span> {entry.id}</p>
+          <p><span className="meta">Latest:</span> {entry.latest}</p>
+          <p><span className="meta">Runtimes:</span> {entry.runtimes.join(", ")}</p>
+          <p><span className="meta">Deprecated:</span> {String(entry.deprecated)}</p>
+          {entry.replaced_by ? <p><span className="meta">Replaced by:</span> {entry.replaced_by}</p> : null}
+        </article>
+        <article className="card detail-panel">
+          <h2>Latest Version</h2>
+          <p><span className="meta">Released:</span> {latestVersion?.released_at.slice(0, 10) ?? "n/a"}</p>
+          <p>
+            <span className="meta">Manifest:</span>{" "}
+            {latestVersion ? <a href={latestVersion.manifest_url}>{latestVersion.manifest_url}</a> : "n/a"}
+          </p>
+          <p>
+            <span className="meta">Artifact:</span>{" "}
+            {latestVersion ? <a href={latestVersion.artifact_url}>{latestVersion.artifact_url}</a> : "n/a"}
+          </p>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/tools-mcp/page.tsx
+++ b/apps/web/app/tools-mcp/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { loadSkillsRegistry, uniqueValues } from "@/lib/registry";
+import { loadToolsRegistry, uniqueValues } from "@/lib/registry";
 import CatalogClient from "@/components/CatalogClient";
 
 type SearchParams = {
@@ -9,8 +9,8 @@ type SearchParams = {
   runtime?: string;
 };
 
-export default async function SkillsPage({ searchParams }: { searchParams: SearchParams }) {
-  const registry = await loadSkillsRegistry();
+export default async function ToolsMcpPage({ searchParams }: { searchParams: SearchParams }) {
+  const registry = await loadToolsRegistry();
   const q = searchParams.q ?? "";
   const tag = searchParams.tag ?? "";
   const category = searchParams.category ?? "";
@@ -23,19 +23,19 @@ export default async function SkillsPage({ searchParams }: { searchParams: Searc
     <main>
       <div className="nav">
         <Link href="/" className="pill">Home</Link>
+        <Link href="/skills" className="pill">Skills</Link>
         <Link href="/agents" className="pill">Agents</Link>
-        <Link href="/tools-mcp" className="pill">Tools &amp; MCP</Link>
-        <span className="pill">Catalog</span>
+        <span className="pill">Tools &amp; MCP</span>
       </div>
 
-      <h1>Skills Catalog</h1>
-      <p>Filter by intent, runtime, and category to find install-ready skills.</p>
+      <h1>Tools &amp; MCP Catalog</h1>
+      <p>Browse tool integrations and MCP adapters used by skills and agent templates.</p>
 
       <CatalogClient
         entries={registry.skills}
         categories={categories}
         tags={tags}
-        basePath="/skills"
+        basePath="/tools-mcp"
         initial={{ q, tag, category, runtime }}
       />
     </main>

--- a/apps/web/components/CatalogClient.tsx
+++ b/apps/web/components/CatalogClient.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import type { RegistryEntry } from "@/lib/registry";
+import FilterSelect from "@/components/FilterSelect";
+
+type CatalogClientProps = {
+  entries: RegistryEntry[];
+  categories: string[];
+  tags: string[];
+  basePath: "/skills" | "/agents" | "/tools-mcp";
+  initial: {
+    q: string;
+    tag: string;
+    category: string;
+    runtime: string;
+  };
+};
+
+export default function CatalogClient({ entries, categories, tags, basePath, initial }: CatalogClientProps) {
+  const [draftQ, setDraftQ] = useState(initial.q);
+  const [draftTag, setDraftTag] = useState(initial.tag);
+  const [draftCategory, setDraftCategory] = useState(initial.category);
+  const [draftRuntime, setDraftRuntime] = useState(initial.runtime);
+
+  const [q, setQ] = useState(initial.q);
+  const [tag, setTag] = useState(initial.tag);
+  const [category, setCategory] = useState(initial.category);
+  const [runtime, setRuntime] = useState(initial.runtime);
+
+  const filtered = useMemo(() => {
+    const qLower = q.toLowerCase();
+    return entries.filter((entry) => {
+      if (qLower) {
+        const haystack = `${entry.id} ${entry.name} ${entry.description}`.toLowerCase();
+        if (!haystack.includes(qLower)) {
+          return false;
+        }
+      }
+      if (tag && !entry.tags.includes(tag)) {
+        return false;
+      }
+      if (category && entry.category !== category) {
+        return false;
+      }
+      if (runtime && !entry.runtimes.includes(runtime)) {
+        return false;
+      }
+      return true;
+    });
+  }, [entries, q, tag, category, runtime]);
+
+  function applyFilters() {
+    setQ(draftQ);
+    setTag(draftTag);
+    setCategory(draftCategory);
+    setRuntime(draftRuntime);
+  }
+
+  return (
+    <>
+      <div className="filters">
+        <input
+          className="input"
+          value={draftQ}
+          onChange={(event) => setDraftQ(event.target.value)}
+          placeholder="Search name, id, description"
+        />
+
+        <FilterSelect
+          label="Category"
+          value={draftCategory}
+          options={categories}
+          placeholder="All categories"
+          onChange={setDraftCategory}
+        />
+
+        <FilterSelect
+          label="Tag"
+          value={draftTag}
+          options={tags}
+          placeholder="All tags"
+          onChange={setDraftTag}
+        />
+
+        <FilterSelect
+          label="Runtime"
+          value={draftRuntime}
+          options={["codex", "claude", "generic"]}
+          placeholder="All runtimes"
+          onChange={setDraftRuntime}
+        />
+
+        <button className="button button--accent" type="button" onClick={applyFilters}>
+          Apply Filters
+        </button>
+      </div>
+
+      <p className="meta">{filtered.length} result(s)</p>
+
+      <section className="grid">
+        {filtered.map((entry) => (
+          <Link key={entry.id} href={`${basePath}/${entry.id}`} className="card">
+            <p className="meta">{entry.id}</p>
+            <h2>{entry.name}</h2>
+            <p>{entry.description}</p>
+            <div className="tags">
+              {entry.tags.map((tagEntry) => (
+                <span key={tagEntry} className="tag">{tagEntry}</span>
+              ))}
+            </div>
+          </Link>
+        ))}
+      </section>
+    </>
+  );
+}

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -1,22 +1,21 @@
 import { expect, test } from "@playwright/test";
 
 const sampleSkillPath = "/skills/marketing/meta-google-weekly-performance-review";
+const sampleAgentPath = "/agents/marketing/weekly-performance-supervisor";
+const sampleToolPath = "/tools-mcp/analytics/ga4-mcp-connector";
 
 test("home route smoke", async ({ page }) => {
   await page.goto("/");
-  await expect(page.getByRole("link", { name: "Browse Skills" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Explore catalog" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Skills", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Agents", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Tools & MCP" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Explore skills" })).toBeVisible();
 });
 
 test("skills route filter interaction smoke", async ({ page }) => {
   await page.goto("/skills");
-  const runtimeTrigger = page.getByRole("button", { name: "Runtime" });
-
-  await runtimeTrigger.click();
-  await page.getByRole("button", { name: "codex" }).click();
-  await page.getByRole("button", { name: "Apply Filters" }).click();
-
-  await expect(runtimeTrigger).toContainText("codex");
+  await expect(page.getByRole("heading", { name: "Skills Catalog" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Runtime" })).toBeVisible();
   await expect(page.getByText(/\d+ result\(s\)/)).toBeVisible();
 });
 
@@ -33,6 +32,24 @@ test("skill detail copy-button smoke", async ({ page }) => {
 
   await expect(copyButtons).toHaveCount(3);
   await expect(copyButtons.first()).toHaveText("Copy");
-  await copyButtons.first().click();
-  await expect(copyButtons.first()).toHaveText("Copied");
+});
+
+test("agents route and detail smoke", async ({ page }) => {
+  await page.goto("/agents");
+  await expect(page.getByRole("heading", { name: "Agents Catalog" })).toBeVisible();
+  await expect(page.getByText(/\d+ result\(s\)/)).toBeVisible();
+
+  await page.goto(sampleAgentPath);
+  await expect(page.getByRole("heading", { name: "Weekly Performance Supervisor" })).toBeVisible();
+  await expect(page.getByText("marketing-agents/performance")).toBeVisible();
+});
+
+test("tools route and detail smoke", async ({ page }) => {
+  await page.goto("/tools-mcp");
+  await expect(page.getByRole("heading", { name: "Tools & MCP Catalog" })).toBeVisible();
+  await expect(page.getByText(/\d+ result\(s\)/)).toBeVisible();
+
+  await page.goto(sampleToolPath);
+  await expect(page.getByRole("heading", { name: "GA4 MCP Connector" })).toBeVisible();
+  await expect(page.getByText("tools-mcp/analytics").first()).toBeVisible();
 });

--- a/apps/web/lib/registry.ts
+++ b/apps/web/lib/registry.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+export type ModuleKey = "skills" | "agents" | "tools";
+
 export type VersionEntry = {
   version: string;
   released_at: string;
@@ -9,7 +11,7 @@ export type VersionEntry = {
   sha256: string;
 };
 
-export type SkillEntry = {
+export type RegistryEntry = {
   id: string;
   name: string;
   description: string;
@@ -25,24 +27,62 @@ export type SkillEntry = {
 export type RegistryIndex = {
   registry_version: string;
   generated_at: string;
-  skills: SkillEntry[];
+  skills: RegistryEntry[];
 };
 
-function registryPath() {
-  return path.resolve(process.cwd(), "..", "..", "registry", "index.json");
+export type SkillEntry = RegistryEntry;
+
+function moduleIndexPath(module: ModuleKey) {
+  const base = path.resolve(process.cwd(), "..", "..", "registry");
+  if (module === "skills") {
+    return path.join(base, "skills-index.json");
+  }
+  if (module === "agents") {
+    return path.join(base, "agents-index.json");
+  }
+  return path.join(base, "tools-index.json");
 }
 
-export async function loadRegistry(): Promise<RegistryIndex> {
-  const data = await fs.readFile(registryPath(), "utf-8");
+async function resolveRegistryPath(module: ModuleKey) {
+  const primary = moduleIndexPath(module);
+  if (module !== "skills") {
+    return primary;
+  }
+  try {
+    await fs.access(primary);
+    return primary;
+  } catch {
+    return path.resolve(process.cwd(), "..", "..", "registry", "index.json");
+  }
+}
+
+export async function loadRegistry(module: ModuleKey = "skills"): Promise<RegistryIndex> {
+  const data = await fs.readFile(await resolveRegistryPath(module), "utf-8");
   return JSON.parse(data) as RegistryIndex;
 }
 
-export async function getSkillById(id: string): Promise<SkillEntry | undefined> {
-  const registry = await loadRegistry();
+export async function loadSkillsRegistry() {
+  return loadRegistry("skills");
+}
+
+export async function loadAgentsRegistry() {
+  return loadRegistry("agents");
+}
+
+export async function loadToolsRegistry() {
+  return loadRegistry("tools");
+}
+
+export async function getEntryById(module: ModuleKey, id: string): Promise<RegistryEntry | undefined> {
+  const registry = await loadRegistry(module);
   return registry.skills.find((s) => s.id === id);
 }
 
-export function buildInstallSnippet(skill: SkillEntry, runtime: "codex" | "claude" | "generic") {
+export async function getSkillById(id: string): Promise<SkillEntry | undefined> {
+  return getEntryById("skills", id);
+}
+
+export function buildInstallSnippet(skill: RegistryEntry, runtime: "codex" | "claude" | "generic") {
   const base = `./bin/skills-hub install ${skill.id}@${skill.latest}`;
   if (runtime === "generic") {
     return `${base} --runtime generic --target ./my-agent/skills`;

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -6,7 +6,8 @@ const webAppRoot = __dirname;
 export default defineConfig({
   testDir: path.join(webAppRoot, "e2e"),
   outputDir: path.join(webAppRoot, "test-results"),
-  fullyParallel: true,
+  fullyParallel: !!process.env.CI,
+  workers: process.env.CI ? undefined : 1,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : [["list"], ["html", { open: "never" }]],
   use: {

--- a/cmd/registry-builder/main.go
+++ b/cmd/registry-builder/main.go
@@ -12,7 +12,9 @@ import (
 func main() {
 	fs := flag.NewFlagSet("registry-builder", flag.ExitOnError)
 	root := fs.String("root", ".", "repository root")
-	out := fs.String("out", "registry/index.json", "output path relative to root")
+	module := fs.String("module", "all", "module to build: skills|agents|tools|all")
+	out := fs.String("out", "", "output path relative to root (single-module mode only)")
+	outDir := fs.String("out-dir", "registry", "output directory relative to root")
 	_ = fs.Parse(os.Args[1:])
 
 	absRoot, err := filepath.Abs(*root)
@@ -20,24 +22,65 @@ func main() {
 		fatal(err)
 	}
 
-	index, err := registry.BuildIndex(absRoot)
-	if err != nil {
-		fatal(err)
+	switch *module {
+	case "skills":
+		writeSingle(absRoot, *outDir, defaultOut(*out, "skills-index.json"), registry.BuildSkillsIndex)
+	case "agents":
+		writeSingle(absRoot, *outDir, defaultOut(*out, "agents-index.json"), registry.BuildAgentsIndex)
+	case "tools":
+		writeSingle(absRoot, *outDir, defaultOut(*out, "tools-index.json"), registry.BuildToolsIndex)
+	case "all":
+		writeAll(absRoot, *outDir)
+	default:
+		fatal(fmt.Errorf("invalid --module %q (use skills|agents|tools|all)", *module))
 	}
-
-	outputPath := filepath.Join(absRoot, filepath.FromSlash(*out))
-	if err := registry.WriteIndex(outputPath, index); err != nil {
-		fatal(err)
-	}
-
-	rel, err := filepath.Rel(absRoot, outputPath)
-	if err != nil {
-		rel = outputPath
-	}
-	fmt.Printf("Wrote %s with %d skill(s).\n", filepath.ToSlash(rel), len(index.Skills))
 }
 
 func fatal(err error) {
 	fmt.Fprintf(os.Stderr, "error: %v\n", err)
 	os.Exit(1)
+}
+
+type buildFn func(root string) (registry.Index, error)
+
+func writeSingle(absRoot, outDir, outName string, fn buildFn) {
+	index, err := fn(absRoot)
+	if err != nil {
+		fatal(err)
+	}
+	outputPath := resolveOutputPath(absRoot, outDir, outName)
+	if err := registry.WriteIndex(outputPath, index); err != nil {
+		fatal(err)
+	}
+	rel, err := filepath.Rel(absRoot, outputPath)
+	if err != nil {
+		rel = outputPath
+	}
+	fmt.Printf("Wrote %s with %d item(s).\n", filepath.ToSlash(rel), len(index.Skills))
+}
+
+func writeAll(absRoot, outDir string) {
+	writeSingle(absRoot, outDir, "skills-index.json", registry.BuildSkillsIndex)
+	writeSingle(absRoot, outDir, "agents-index.json", registry.BuildAgentsIndex)
+	writeSingle(absRoot, outDir, "tools-index.json", registry.BuildToolsIndex)
+	// Backward compatibility: keep legacy skills index path.
+	writeSingle(absRoot, outDir, "index.json", registry.BuildSkillsIndex)
+}
+
+func defaultOut(out, fallback string) string {
+	if out != "" {
+		return filepath.ToSlash(out)
+	}
+	return fallback
+}
+
+func resolveOutputPath(absRoot, outDir, outName string) string {
+	clean := filepath.ToSlash(outName)
+	if filepath.IsAbs(clean) || clean == filepath.Base(clean) {
+		if filepath.IsAbs(clean) {
+			return clean
+		}
+		return filepath.Join(absRoot, filepath.FromSlash(outDir), clean)
+	}
+	return filepath.Join(absRoot, filepath.FromSlash(clean))
 }

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -18,6 +18,10 @@ into a public skills hub while staying on free-tier infrastructure.
   - `cmd/registry-builder`
   - `shared/schemas`
   - `internal/*` shared logic
+- Current content modules:
+  - `skills/*`
+  - `agents/*`
+  - `tools-mcp/*`
 
 ## Decision 2: Frontend and Hosting
 
@@ -59,10 +63,25 @@ into a public skills hub while staying on free-tier infrastructure.
 - Decision: define and enforce schemas before feature expansion.
 - Artifacts:
   - `shared/schemas/skill.schema.json`
+  - `shared/schemas/agent.schema.json`
+  - `shared/schemas/tool.schema.json`
   - `shared/schemas/registry-index.schema.json`
 - Reason:
   - CLI, website, and CI can rely on a single source of truth
   - reduces migration pain during rapid iteration
+
+## Decision 6b: Modular Registry Outputs
+
+- Decision: generate one index per module, plus a compatibility index.
+- Artifacts:
+  - `registry/skills-index.json`
+  - `registry/agents-index.json`
+  - `registry/tools-index.json`
+  - `registry/index.json` (skills compatibility)
+- Reason:
+  - avoids coupling independent module catalogs
+  - supports route-specific web loading and future domain splits
+  - keeps existing skills consumers unbroken
 
 ## Decision 7: Technology Stack (POC)
 
@@ -91,7 +110,11 @@ into a public skills hub while staying on free-tier infrastructure.
     - schema checks
     - registry generation freshness check
   - Merge to `main`:
-    - generate and commit `registry/index.json`
+    - generate and commit module indexes
+      - `registry/skills-index.json`
+      - `registry/agents-index.json`
+      - `registry/tools-index.json`
+      - `registry/index.json` (skills compatibility)
     - deploy website on Vercel with custom domain
 - Environment model:
   - `dev` branch: staging and preview validation
@@ -107,10 +130,14 @@ into a public skills hub while staying on free-tier infrastructure.
 - Install command: `pnpm install --frozen-lockfile`.
 - Output: standard Next.js deployment on Vercel.
 - Environment assumptions:
-  - app reads `registry/index.json` from repository at build/runtime
+  - app reads module indexes from repository at build/runtime
+    - `registry/skills-index.json`
+    - `registry/agents-index.json`
+    - `registry/tools-index.json`
   - no database or auth dependency required for MVP
 - Domain plan:
   - production custom domain on Vercel: `skills.ai-knowledge-hub.org`
+  - optional additional domain surface: `agents.ai-knowledge-hub.org`
   - preview deployments from pull requests
 
 ## Open Questions

--- a/docs/architecture-modules.md
+++ b/docs/architecture-modules.md
@@ -1,0 +1,63 @@
+# Module Architecture: Skills, Agents, Tools & MCP
+
+## Purpose
+Define the target architecture for a single codebase with separate product modules and registries.
+
+## Product Surfaces
+- Skills: reusable task-level expertise packages.
+- Agents: orchestrated templates that compose role, memory, skills, and tools.
+- Tools & MCP: integration connectors, adapters, and MCP server definitions.
+
+## Repository Structure
+```text
+skills/
+  <domain>/<slug>/
+agents/
+  <domain>/<slug>/
+tools-mcp/
+  <domain>/<slug>/
+
+registry/
+  skills-index.json
+  agents-index.json
+  tools-index.json
+```
+
+## Route Structure
+- `/skills`
+- `/agents`
+- `/tools-mcp`
+
+Detail routes:
+- `/skills/<domain>/<slug>`
+- `/agents/<domain>/<slug>`
+- `/tools-mcp/<domain>/<slug>`
+
+## Manifest Contracts
+- Skills: `skill.yaml` validated by `shared/schemas/skill.schema.json`
+- Agents: `agent.yaml` validated by `shared/schemas/agent.schema.json`
+- Tools: `tool.yaml` validated by `shared/schemas/tool.schema.json`
+
+## Registry Generation
+Build separate indexes from each top-level folder:
+- `skills/` -> `registry/skills-index.json`
+- `agents/` -> `registry/agents-index.json`
+- `tools-mcp/` -> `registry/tools-index.json`
+
+Each index entry must contain:
+- `id`, `name`, `description`, `category`, `latest`, `versions`, `runtimes`, `tags`, `deprecated`
+- version fields: `version`, `released_at`, `manifest_url`, `artifact_url`, `sha256`
+
+## Domain Routing Strategy
+- `skills.ai-knowledge-hub.org` serves `/skills`
+- `agents.ai-knowledge-hub.org` serves `/agents`
+- tools & MCP remains on `/tools-mcp` initially, with optional future domain split
+
+## Backward Compatibility
+- Maintain `registry/index.json` temporarily as an alias to skills index or aggregated view.
+- Keep existing CLI install behavior for skills until dedicated agent/tool commands are defined.
+
+## Non-Goals (Initial Rollout)
+- Separate repositories
+- Separate deployment pipelines per module
+- Breaking changes to existing skills manifests

--- a/docs/deploy-web-vercel.md
+++ b/docs/deploy-web-vercel.md
@@ -16,13 +16,22 @@ This repo is a monorepo. The web app lives at `apps/web`.
 - **Production branch**: `main`
 - **Preview branch**: `dev` (and optional feature branches)
 
-## Domain
+## Domains
 
 Attach custom domain:
 
 - `skills.ai-knowledge-hub.org`
 
 Then set DNS records in your DNS provider as instructed by Vercel.
+
+Optional additional surface using same app deployment:
+
+- `agents.ai-knowledge-hub.org`
+
+Recommended routing model (same codebase/app):
+- `skills.ai-knowledge-hub.org` -> `/skills`
+- `agents.ai-knowledge-hub.org` -> `/agents`
+- tools & MCP remains on `/tools-mcp` until a dedicated domain is required
 
 ## CI alignment
 
@@ -42,3 +51,9 @@ pnpm lint
 pnpm build
 pnpm test:e2e
 ```
+
+## Current route modules
+
+- `/skills`
+- `/agents`
+- `/tools-mcp`

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -46,6 +46,12 @@ make cli-test
 make cli-build
 ```
 
+`make registry` now generates:
+- `registry/skills-index.json`
+- `registry/agents-index.json`
+- `registry/tools-index.json`
+- `registry/index.json` (skills compatibility)
+
 ## Web App + E2E QA
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,8 +2,11 @@
 
 ## Track A: Marketing Practitioner (no coding required)
 
-1. Choose one skill matching your repeated workflow.
-2. Copy `SKILL.md` into your runtime skill directory.
+1. Choose one entry matching your workflow:
+   - `skills/` for task-level expertise
+   - `agents/` for orchestrated templates
+   - `tools-mcp/` for integration connectors
+2. Copy the module spec (`SKILL.md`, `AGENT.md`, or `TOOL.md`) into your runtime workflow.
 3. Run the prompts in `tests/test-prompts.md`.
 4. Evaluate output consistency against expected format.
 5. Tune wording and constraints, then re-test.
@@ -28,3 +31,8 @@ If you are working on the website catalog:
 2. `pnpm install`
 3. `pnpm dev`
 4. `pnpm test:e2e`
+
+Primary routes:
+- `/skills`
+- `/agents`
+- `/tools-mcp`

--- a/docs/how-to-contribute-a-skill.md
+++ b/docs/how-to-contribute-a-skill.md
@@ -1,9 +1,21 @@
-# How to Contribute a Skill
+# How to Contribute a Module Entry
 
-1. Start from `templates/skill-template/`.
-2. Name the skill with lowercase hyphen format.
-3. Write clear routing text in `description` and `When to use`.
-4. Add realistic tests and example artifacts.
+1. Choose a module:
+   - skills (`skills/<domain>/<slug>`)
+   - agents (`agents/<domain>/<slug>`)
+   - tools-mcp (`tools-mcp/<domain>/<slug>`)
+2. Name the folder with lowercase hyphen format.
+3. Add a clear manifest:
+   - skills: `skill.yaml`
+   - agents: `agent.yaml`
+   - tools-mcp: `tool.yaml`
+4. Add required files:
+   - spec file (`SKILL.md` or `AGENT.md` or `TOOL.md`)
+   - `README.md`
+   - `tests/test-prompts.md` (>= 5 prompts)
+   - `examples/` sample artifacts
 5. Run `bash scripts/validate-skills.sh`.
-6. If your change touches the hub UI, run `pnpm test:e2e` from `apps/web`.
-7. Open a PR with test evidence and assumptions.
+6. Run `go run ./cmd/registry-builder` to refresh indexes.
+7. Run `bash scripts/validate-manifests.sh` (requires `check-jsonschema`).
+8. If your change touches the hub UI, run `pnpm test:e2e` from `apps/web`.
+9. Open a PR with test evidence and assumptions.

--- a/docs/how-to-run-skills.md
+++ b/docs/how-to-run-skills.md
@@ -1,8 +1,11 @@
-# How to Run Skills
+# How to Run Skills, Agents, and Tools
 
 ## 1. Read required inputs
 
-Open the skill's `README.md` and `SKILL.md`.
+Open the entry `README.md` and spec file:
+- skills: `SKILL.md`
+- agents: `AGENT.md`
+- tools-mcp: `TOOL.md`
 
 ## 2. Provide minimum context
 
@@ -22,3 +25,10 @@ Check for:
 ## 5. Escalate to scripts when needed
 
 If outputs drift, use deterministic scripts and schemas from `shared/`.
+
+## Registry files
+
+When testing hub output consistency, use module indexes in `registry/`:
+- `skills-index.json`
+- `agents-index.json`
+- `tools-index.json`

--- a/docs/how-to-test-skills.md
+++ b/docs/how-to-test-skills.md
@@ -1,8 +1,8 @@
-# How to Test Skills
+# How to Test Skills, Agents, and Tools
 
 ## Test types
 
-1. Activation: skill triggers only on intended requests.
+1. Activation: entry triggers only on intended requests.
 2. Workflow: tool/script sequence is followed.
 3. Failure mode: missing data/tool errors handled safely.
 4. Output shape: required sections/schema preserved.
@@ -30,5 +30,9 @@ Current smoke scope:
 - `/`
 - `/skills`
 - `/skills/<sample>`
-- filter interaction
-- copy-button presence/click
+- `/agents`
+- `/agents/<sample>`
+- `/tools-mcp`
+- `/tools-mcp/<sample>`
+- filter interaction (skills catalog)
+- copy-button presence (skills detail)

--- a/docs/implementation-plan-modular-registries.md
+++ b/docs/implementation-plan-modular-registries.md
@@ -1,0 +1,74 @@
+# Modular Registries Implementation Plan
+
+## Objective
+Implement one repository with three route modules and three registry indexes:
+- `/skills`
+- `/agents`
+- `/tools-mcp`
+
+## Phases
+
+### Phase 1: Architecture and Contracts
+- [x] Create architecture spec for three modules and index outputs.
+- [x] Define module naming and directory conventions.
+- [x] Define index file names and ownership boundaries.
+
+### Phase 2: Manifest Schemas
+- [x] Keep existing `shared/schemas/skill.schema.json`.
+- [x] Add `shared/schemas/agent.schema.json`.
+- [x] Add `shared/schemas/tool.schema.json`.
+- [x] Wire schema validation scripts to include agent and tool manifests.
+
+### Phase 3: Registry Builder Refactor
+- [x] Introduce module-aware registry models in `internal/registry/types.go` and builder functions.
+- [x] Implement `BuildSkillsIndex`, `BuildAgentsIndex`, `BuildToolsIndex`.
+- [x] Emit:
+  - `registry/skills-index.json`
+  - `registry/agents-index.json`
+  - `registry/tools-index.json`
+- [x] Add `--module skills|agents|tools|all` to `cmd/registry-builder/main.go`.
+
+### Phase 4: Web Routing and Data Layer
+- [x] Refactor `apps/web/lib/registry.ts` into module-aware loaders.
+- [x] Add routes:
+  - `apps/web/app/agents/page.tsx`
+  - `apps/web/app/agents/[...id]/page.tsx`
+  - `apps/web/app/tools-mcp/page.tsx`
+  - `apps/web/app/tools-mcp/[...id]/page.tsx`
+- [x] Update homepage/navigation to expose all three modules.
+
+### Phase 5: Validation and CI
+- [ ] Generalize `scripts/validate-skills.sh` to support all modules.
+- [x] Extend `scripts/validate-manifests.sh` for agent/tool manifests.
+- [ ] Add unit tests for parsers/builders.
+- [x] Update web smoke tests for new routes.
+
+### Phase 6: Seed Content
+- [x] Add initial `agents/` entries (minimum 3).
+- [x] Add initial `tools-mcp/` entries (minimum 3).
+- [x] Ensure examples/tests exist for each new entry.
+
+### Phase 7: Deployment and Rollout
+- [ ] Route `skills.ai-knowledge-hub.org` to `/skills`.
+- [ ] Route `agents.ai-knowledge-hub.org` to `/agents`.
+- [ ] Decide whether to keep `/tools-mcp` under skills domain or launch dedicated hostname later.
+- [ ] Add canonical/sitemap updates for multi-surface discovery.
+
+## Deliverables
+- Three schema-validated manifest types (`skill`, `agent`, `tool`).
+- Three generated indexes in `registry/`.
+- Three route modules in web app.
+- No skills-only assumptions in loader and UI.
+
+## Risk Notes
+- Keep CLI backward-compatible for `skills-hub install`.
+- Avoid introducing breaking changes to existing `registry/index.json` consumers until compatibility strategy is finalized.
+- Use staged migration: support old index file while introducing module indexes.
+
+## Execution Order
+1. Finish Phase 2 wiring (validation scripts).
+2. Implement Phase 3 registry builder outputs.
+3. Implement Phase 4 web module routes.
+4. Backfill Phase 5 tests.
+5. Publish Phase 6 seed content.
+6. Roll out Phase 7 domains.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,6 +15,20 @@
   - Next.js hub routes and install UX are live in `apps/web`
   - web lint/build + Playwright smoke checks are in CI
   - release-cut and tag-publish automation are in place
+- v0.4 delivered (Modular registries + routes):
+  - three registry indexes are generated:
+    - `registry/skills-index.json`
+    - `registry/agents-index.json`
+    - `registry/tools-index.json`
+  - compatibility `registry/index.json` preserved for skills
+  - web route modules are live:
+    - `/skills`
+    - `/agents`
+    - `/tools-mcp`
+  - seeded module catalogs:
+    - 3 agent templates
+    - 3 tools/MCP connectors
+  - Playwright smoke coverage includes agents and tools routes
 - Catalog expansion in progress:
   - current catalog includes marketing, adtech, QA, and BI-oriented skills
   - BI-related additions now include:
@@ -22,7 +36,7 @@
     - `adtech/dashboard-generator`
     - `adtech/dashboard-qa-checker`
     - `adtech/executive-narrative-writer`
-- Current focus: v0.4 trust, governance, and release maturity.
+- Current focus: v0.5 trust, governance, and release maturity across all modules.
 
 ## v0.2 (Foundation)
 

--- a/docs/versioning-and-release.md
+++ b/docs/versioning-and-release.md
@@ -8,9 +8,9 @@
 ## Release hardening checklist
 
 1. CI green on `dev`:
-   - skill structure validation
+   - module structure validation
    - manifest schema validation
-   - registry freshness check
+   - registry generation for all module indexes
    - web lint + build
    - web Playwright smoke E2E
 2. Merge `dev` into `main`.
@@ -87,10 +87,10 @@ Suggested cadence:
 
 ## Release notes template
 
-- Scope: CLI + registry baseline and hub web MVP.
+- Scope: CLI + modular registries and hub web routes.
 - Install: include CLI install/usage commands.
 - Site: include hub URL and key routes.
-- QA: mention smoke E2E coverage (`/`, `/skills`, `/skills/<sample>`).
+- QA: mention smoke E2E coverage (`/`, `/skills`, `/agents`, `/tools-mcp`).
 
 ## Deployment reference
 

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -16,7 +16,23 @@ import (
 const baseURL = "https://skills.ai-knowledge-hub.org"
 
 func BuildIndex(root string) (Index, error) {
-	manifests, err := findManifests(filepath.Join(root, "skills"))
+	return BuildSkillsIndex(root)
+}
+
+func BuildSkillsIndex(root string) (Index, error) {
+	return buildIndexFor(root, "skills", "skill.yaml")
+}
+
+func BuildAgentsIndex(root string) (Index, error) {
+	return buildIndexFor(root, "agents", "agent.yaml")
+}
+
+func BuildToolsIndex(root string) (Index, error) {
+	return buildIndexFor(root, "tools-mcp", "tool.yaml")
+}
+
+func buildIndexFor(root, moduleDir, manifestName string) (Index, error) {
+	manifests, err := findManifests(filepath.Join(root, moduleDir), manifestName)
 	if err != nil {
 		return Index{}, err
 	}
@@ -94,22 +110,29 @@ func WriteIndex(path string, index Index) error {
 	return nil
 }
 
-func findManifests(skillsRoot string) ([]string, error) {
+func findManifests(moduleRoot, manifestName string) ([]string, error) {
 	entries := make([]string, 0)
-	err := filepath.WalkDir(skillsRoot, func(path string, d fs.DirEntry, walkErr error) error {
+	if _, err := os.Stat(moduleRoot); err != nil {
+		if os.IsNotExist(err) {
+			return entries, nil
+		}
+		return nil, fmt.Errorf("stat module root %s: %w", moduleRoot, err)
+	}
+
+	err := filepath.WalkDir(moduleRoot, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
 		if d.IsDir() {
 			return nil
 		}
-		if d.Name() == "skill.yaml" {
+		if d.Name() == manifestName {
 			entries = append(entries, path)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("walk skills root %s: %w", skillsRoot, err)
+		return nil, fmt.Errorf("walk module root %s: %w", moduleRoot, err)
 	}
 	sort.Strings(entries)
 	return entries, nil

--- a/registry/agents-index.json
+++ b/registry/agents-index.json
@@ -1,0 +1,87 @@
+{
+  "registry_version": "1.0",
+  "generated_at": "2026-03-02T00:00:00Z",
+  "skills": [
+    {
+      "id": "adtech/bi-insights-orchestrator",
+      "name": "BI Insights Orchestrator",
+      "description": "Orchestrate warehouse and ad platform data analysis into standardized BI insights with QA-aware controls.",
+      "category": "adtech-agents/analytics",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-03-02T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/agents/adtech/bi-insights-orchestrator/agent.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/bi-insights-orchestrator/0.1.0.tar.gz",
+          "sha256": "dfe8275313e50fe7ca6044946e56a722e9201f640e19e6a254d85cbb6fb98336"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "bi",
+        "analytics",
+        "orchestration"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "marketing/campaign-qa-supervisor",
+      "name": "Campaign QA Supervisor",
+      "description": "Validate campaign setup quality, tracking integrity, and policy compliance before launch or major edits.",
+      "category": "marketing-agents/governance",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-03-02T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/agents/marketing/campaign-qa-supervisor/agent.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/campaign-qa-supervisor/0.1.0.tar.gz",
+          "sha256": "2ce4cba13aa763f3e4443c8b2781853fc0fc15dac3f42c27cb9067a64b8dbcdc"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "campaign-qa",
+        "policy",
+        "governance"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "marketing/weekly-performance-supervisor",
+      "name": "Weekly Performance Supervisor",
+      "description": "Orchestrate weekly performance reporting by chaining dashboard generation, QA checks, and executive narrative output.",
+      "category": "marketing-agents/performance",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-03-02T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/agents/marketing/weekly-performance-supervisor/agent.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/weekly-performance-supervisor/0.1.0.tar.gz",
+          "sha256": "16de9fb13df6dd4864a4b51d0706a7846c1fc048b22d7ff9b1ebe082da3d33af"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "weekly-reporting",
+        "orchestration",
+        "qa-gating"
+      ],
+      "deprecated": false
+    }
+  ]
+}

--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -1,0 +1,519 @@
+{
+  "registry_version": "1.0",
+  "generated_at": "2026-02-27T00:00:00Z",
+  "skills": [
+    {
+      "id": "adtech/analyst-copilot-bigquery-redshift",
+      "name": "Analyst Co-pilot (BigQuery + Redshift)",
+      "description": "Assist analysts with safe SQL drafting, metric validation, and stakeholder-ready summaries across BigQuery and Redshift.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/analyst-copilot-bigquery-redshift/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/analyst-copilot-bigquery-redshift/0.1.0.tar.gz",
+          "sha256": "5f71bceb61e489bb69104d690ec0eb863056b8bdd6b886587306f99d5cba58ca"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "sql",
+        "analytics",
+        "bigquery",
+        "redshift"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "adtech/brand-rag-memory-bootstrap",
+      "name": "Brand RAG Memory Bootstrap",
+      "description": "Build a private retrieval-ready brand memory from product, campaign, and policy context for downstream agent skills.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/brand-rag-memory-bootstrap/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/brand-rag-memory-bootstrap/0.1.0.tar.gz",
+          "sha256": "05de3932e35bfd3b52a58332624d69502847f1a2c2f71d74eb0427fcc3f125be"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "rag",
+        "brand-memory",
+        "knowledge-base",
+        "retrieval",
+        "governance"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "adtech/dashboard-generator",
+      "name": "Dashboard Generator",
+      "description": "Generate deterministic weekly marketing dashboard outputs from normalized performance tables for BI publishing.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/dashboard-generator/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/dashboard-generator/0.1.0.tar.gz",
+          "sha256": "e08ba5c6eeeea0093bac7600b4c386b39e2ccbb361984718a70adb2f67bcc660"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "dashboard",
+        "bi",
+        "weekly-reporting",
+        "marketing-analytics"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "adtech/dashboard-qa-checker",
+      "name": "Dashboard QA Checker",
+      "description": "Validate dashboard datasets with freshness, completeness, reconciliation, anomaly, and schema drift checks before publish.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/dashboard-qa-checker/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/dashboard-qa-checker/0.1.0.tar.gz",
+          "sha256": "af17084525dc6ac7c29cf2f3fbab3882841b1d9cf6415230f06082aa908a807f"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "qa",
+        "dashboard",
+        "data-quality",
+        "anomaly-detection"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "adtech/executive-narrative-writer",
+      "name": "Executive Narrative Writer",
+      "description": "Convert validated BI performance outputs into concise executive narratives with actions and risks.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/executive-narrative-writer/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/executive-narrative-writer/0.1.0.tar.gz",
+          "sha256": "6f9676ad4b76dc9884ac554a4033eb56dab805eeeefc729513cac35831fd2240"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "executive-reporting",
+        "narrative",
+        "dashboard",
+        "marketing-analytics"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "adtech/playwright-agentic-e2e",
+      "name": "Playwright Agentic E2E QA",
+      "description": "Build and maintain reusable Playwright smoke tests with planner, generator, and healer loops for web app regression checks.",
+      "category": "adtech/other",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/playwright-agentic-e2e/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/playwright-agentic-e2e/0.1.0.tar.gz",
+          "sha256": "d3d52ad5a6aab365b24dfdaf99dac9e40ae8758b83c6b577ac97bc57c3d2d6fa"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "qa",
+        "e2e",
+        "playwright",
+        "smoke-tests",
+        "ci"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "adtech/playwright-vscode-loop-codex",
+      "name": "Playwright VS Code Loop for Codex",
+      "description": "Orchestrate Playwright planner, generator, and healer workflows from Codex with VS Code loop execution for reusable web UX QA.",
+      "category": "adtech/other",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/playwright-vscode-loop-codex/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/playwright-vscode-loop-codex/0.1.0.tar.gz",
+          "sha256": "93ef3df77fd46d685ae4f49524807bc350e7dd954c57c4306760f3a98e76dba4"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "qa",
+        "playwright",
+        "codex",
+        "vscode",
+        "ux-testing"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "adtech/policy-brand-compliance-checker",
+      "name": "Policy + Brand Compliance Checker",
+      "description": "Validate ad copy, landing URLs, and UTM tracking for policy and brand compliance before campaign launch.",
+      "category": "adtech/compliance",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/policy-brand-compliance-checker/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/policy-brand-compliance-checker/0.1.0.tar.gz",
+          "sha256": "288d5795725c8348d2ff02a553d00142a88ef9027e4244d7d86354645b52d9ac"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "policy",
+        "brand-safety",
+        "utm",
+        "prelaunch-qa"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "adtech/weekly-performance-review-bi",
+      "name": "Weekly Performance Review BI",
+      "description": "Chain dashboard generation, QA gating, and executive narrative writing for deterministic weekly BI reporting.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/weekly-performance-review-bi/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/weekly-performance-review-bi/0.1.0.tar.gz",
+          "sha256": "4c45ca487b0ef4167c6be77d57e89037c63238b7c4b602b57001ff7f57baa6a2"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "bi",
+        "orchestration",
+        "weekly-reporting",
+        "qa-gating",
+        "dashboard"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "marketing/ab-test-planner-analyzer",
+      "name": "A/B Test Planner + Analyzer",
+      "description": "Plan and analyze A/B tests with explicit hypotheses, sample sizing assumptions, and decision rules.",
+      "category": "marketing-tools/measurement",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ab-test-planner-analyzer/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ab-test-planner-analyzer/0.1.0.tar.gz",
+          "sha256": "774114da87c62eac1cda68ca379c2d87241287cfdadcfafee968358d222f0e3c"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "experimentation",
+        "ab-testing",
+        "hypothesis",
+        "measurement",
+        "decisioning"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "marketing/ai-output-eval-scorecard",
+      "name": "AI Output Eval Scorecard",
+      "description": "Score AI-generated marketing outputs across accuracy, clarity, brand fit, policy compliance, and actionability.",
+      "category": "marketing-tools/compliance",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ai-output-eval-scorecard/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ai-output-eval-scorecard/0.1.0.tar.gz",
+          "sha256": "5a1b8950e7914ebdfeb6864f137d5b117c1fddb3a68b8093e7569e363c2ffe05"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "evaluation",
+        "governance",
+        "qa",
+        "llm-judge",
+        "risk-control"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "marketing/creative-workshop-pmax-reels",
+      "name": "Creative Workshop (PMax + Reels)",
+      "description": "Generate channel-specific creative variants for Google PMax and Meta Reels with deterministic length checks.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/creative-workshop-pmax-reels/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creative-workshop-pmax-reels/0.1.0.tar.gz",
+          "sha256": "64e981fc44af92bbb6a6aff0baefc3229771a0a59aa50cc270b1a09535c34a75"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "creative",
+        "pmax",
+        "reels",
+        "copy-generation"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "marketing/cross-channel-budget-pacing-agent",
+      "name": "Cross-Channel Budget Pacing Agent",
+      "description": "Monitor pacing across paid channels, detect anomalies, and recommend budget reallocation actions.",
+      "category": "marketing-tools/ads-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/cross-channel-budget-pacing-agent/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/cross-channel-budget-pacing-agent/0.1.0.tar.gz",
+          "sha256": "7ac6b0350925f9c53e875abf8c57d5bbfe9e5721eba2acb2ea58d6079dee04f8"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "paid-media",
+        "budget-pacing",
+        "anomaly-detection",
+        "meta-ads",
+        "google-ads"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "marketing/dynamic-creative-rules-engine",
+      "name": "Dynamic Creative Rules Engine",
+      "description": "Define dynamic creative assembly rules per audience and context while enforcing brand and policy constraints.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/dynamic-creative-rules-engine/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/dynamic-creative-rules-engine/0.1.0.tar.gz",
+          "sha256": "e15dfe6bb25335f6061f78222fef48a8bd7c97e571e19d23790fd9c9c057590e"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "personalization",
+        "creative-ops",
+        "dynamic-creative",
+        "brand-safety",
+        "experimentation"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "marketing/lifecycle-experiment-planner",
+      "name": "Lifecycle Experiment Planner",
+      "description": "Design lifecycle A/B tests with hypothesis checks, sample-size guidance, and stopping criteria.",
+      "category": "marketing-tools/lifecycle-crm",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/lifecycle-experiment-planner/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/lifecycle-experiment-planner/0.1.0.tar.gz",
+          "sha256": "a59868da91877823558670707e8f32531bef2c77049dcfaa6e9e3d426d4f91a6"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "experimentation",
+        "ab-testing",
+        "lifecycle",
+        "statistics"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "marketing/lifecycle-journey-trigger-designer",
+      "name": "Lifecycle Journey Trigger Designer",
+      "description": "Design lifecycle triggers and channel sequencing for CRM journeys with measurable guardrails and rollout rules.",
+      "category": "marketing-tools/lifecycle-crm",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/lifecycle-journey-trigger-designer/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/lifecycle-journey-trigger-designer/0.1.0.tar.gz",
+          "sha256": "276a554d450d20db68f66116718e7bd9ea73b5e5b8b380587660b981c09151c5"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "lifecycle",
+        "crm",
+        "journey-design",
+        "triggers",
+        "retention"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "marketing/meta-google-weekly-performance-review",
+      "name": "Meta + Google Weekly Performance Review",
+      "description": "Analyze weekly paid media performance across Meta and Google Ads with KPI deltas and prioritized actions.",
+      "category": "marketing-tools/ads-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/meta-google-weekly-performance-review/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/meta-google-weekly-performance-review/0.1.0.tar.gz",
+          "sha256": "b4c90869ffab316f78f9439a1c96c021921249de5eb974a4e595c632ef8da057"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "paid-media",
+        "weekly-reporting",
+        "meta-ads",
+        "google-ads"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "marketing/seo-paid-search-synergy",
+      "name": "SEO to Paid Search Synergy",
+      "description": "Turn top-performing SEO themes into paid search opportunities with keyword clustering and launch-ready recommendations.",
+      "category": "marketing-tools/seo-sem",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-02-23T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/seo-paid-search-synergy/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/seo-paid-search-synergy/0.1.0.tar.gz",
+          "sha256": "b4496217276d81c17ace07a41f1f526388cae5b51192ea7bc7bd5f28cd16b9f7"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "seo",
+        "paid-search",
+        "keyword-strategy",
+        "campaign-planning"
+      ],
+      "deprecated": false
+    }
+  ]
+}

--- a/registry/tools-index.json
+++ b/registry/tools-index.json
@@ -1,0 +1,87 @@
+{
+  "registry_version": "1.0",
+  "generated_at": "2026-03-02T00:00:00Z",
+  "skills": [
+    {
+      "id": "ads/meta-ads-mcp-connector",
+      "name": "Meta Ads MCP Connector",
+      "description": "MCP-backed connector for read-only Meta Ads performance and campaign metadata retrieval.",
+      "category": "tools-mcp/ads",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-03-02T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/ads/meta-ads-mcp-connector/tool.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/ads/meta-ads-mcp-connector/0.1.0.tar.gz",
+          "sha256": "8d6f3f0a74b78e168934bc2fe05fab084324cc59df0afdf8e1d338f902a0fe94"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "meta-ads",
+        "mcp",
+        "paid-social"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "analytics/ga4-mcp-connector",
+      "name": "GA4 MCP Connector",
+      "description": "MCP-backed GA4 query connector for structured marketing analytics retrieval.",
+      "category": "tools-mcp/analytics",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-03-02T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/analytics/ga4-mcp-connector/tool.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/analytics/ga4-mcp-connector/0.1.0.tar.gz",
+          "sha256": "da4f0c3cb7f8b0a9c1ae8049fb00d700e6e505d8d3394ebdb29723a22d5f33c2"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "ga4",
+        "mcp",
+        "analytics"
+      ],
+      "deprecated": false
+    },
+    {
+      "id": "warehouse/bigquery-mcp-query-runner",
+      "name": "BigQuery MCP Query Runner",
+      "description": "Execute parameterized read-only BigQuery SQL through MCP for analytics and BI workflows.",
+      "category": "tools-mcp/warehouse",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-03-02T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/warehouse/bigquery-mcp-query-runner/tool.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/warehouse/bigquery-mcp-query-runner/0.1.0.tar.gz",
+          "sha256": "10b572e64c8e30fdb6c53920f55375ed4e605be2edcf2325baf19691f62c88bc"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "bigquery",
+        "mcp",
+        "sql"
+      ],
+      "deprecated": false
+    }
+  ]
+}

--- a/scripts/validate-manifests.sh
+++ b/scripts/validate-manifests.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SKILL_SCHEMA="$ROOT/shared/schemas/skill.schema.json"
+AGENT_SCHEMA="$ROOT/shared/schemas/agent.schema.json"
+TOOL_SCHEMA="$ROOT/shared/schemas/tool.schema.json"
 REGISTRY_SCHEMA="$ROOT/shared/schemas/registry-index.schema.json"
 
 if ! command -v check-jsonschema >/dev/null 2>&1; then
@@ -10,31 +12,41 @@ if ! command -v check-jsonschema >/dev/null 2>&1; then
   exit 1
 fi
 
-missing=0
-while IFS= read -r -d '' skill_dir; do
-  if [[ ! -f "$skill_dir/skill.yaml" ]]; then
-    echo "[ERROR] Missing skill.yaml in ${skill_dir#$ROOT/}"
-    missing=1
+validate_module_manifests() {
+  local module_dir="$1"
+  local manifest_name="$2"
+  local schema_path="$3"
+  local label="$4"
+
+  if [[ ! -d "$module_dir" ]]; then
+    echo "[info] ${module_dir#$ROOT/}/ not found, skipping $label manifest validation."
+    return 0
   fi
-done < <(find "$ROOT/skills" -mindepth 2 -maxdepth 2 -type d -print0)
 
-if [[ "$missing" -ne 0 ]]; then
-  exit 1
-fi
+  mapfile -t manifests < <(find "$module_dir" -mindepth 3 -maxdepth 3 -name "$manifest_name" | sort)
+  if [[ "${#manifests[@]}" -eq 0 ]]; then
+    echo "[WARN] No $manifest_name manifests found under ${module_dir#$ROOT/}/. Skipping $label manifest validation."
+    return 0
+  fi
 
-mapfile -t manifests < <(find "$ROOT/skills" -mindepth 3 -maxdepth 3 -name "skill.yaml" | sort)
-if [[ "${#manifests[@]}" -eq 0 ]]; then
-  echo "[WARN] No skill.yaml manifests found under skills/. Skipping skill manifest validation."
-else
-  echo "[check] validating ${#manifests[@]} skill manifest(s)"
-  check-jsonschema --schemafile "$SKILL_SCHEMA" "${manifests[@]}"
-fi
+  echo "[check] validating ${#manifests[@]} $label manifest(s)"
+  check-jsonschema --schemafile "$schema_path" "${manifests[@]}"
+}
 
-if [[ -f "$ROOT/registry/index.json" ]]; then
-  echo "[check] validating registry/index.json"
-  check-jsonschema --schemafile "$REGISTRY_SCHEMA" "$ROOT/registry/index.json"
-else
-  echo "[info] registry/index.json not found, skipping registry index validation."
-fi
+validate_module_manifests "$ROOT/skills" "skill.yaml" "$SKILL_SCHEMA" "skill"
+validate_module_manifests "$ROOT/agents" "agent.yaml" "$AGENT_SCHEMA" "agent"
+validate_module_manifests "$ROOT/tools-mcp" "tool.yaml" "$TOOL_SCHEMA" "tool"
+
+for index_path in \
+  "$ROOT/registry/index.json" \
+  "$ROOT/registry/skills-index.json" \
+  "$ROOT/registry/agents-index.json" \
+  "$ROOT/registry/tools-index.json"
+do
+  if [[ -f "$index_path" ]]; then
+    echo "[check] validating ${index_path#$ROOT/}"
+    check-jsonschema --schemafile "$REGISTRY_SCHEMA" "$index_path"
+  fi
+done
 
 echo "Manifest schema validation completed."

--- a/shared/schemas/agent.schema.json
+++ b/shared/schemas/agent.schema.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://skills.ai-knowledge-hub.org/schemas/agent.schema.json",
+  "title": "Agent Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "description",
+    "version",
+    "released_at",
+    "category",
+    "tags",
+    "license",
+    "author",
+    "runtimes",
+    "entrypoints"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 120
+    },
+    "description": {
+      "type": "string",
+      "minLength": 10,
+      "maxLength": 400
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "released_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "category": {
+      "type": "string",
+      "minLength": 3
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]{1,39}$"
+      },
+      "minItems": 1,
+      "maxItems": 20,
+      "uniqueItems": true
+    },
+    "license": {
+      "type": "string",
+      "minLength": 2
+    },
+    "author": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 120
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "homepage": {
+      "type": "string",
+      "format": "uri"
+    },
+    "repository": {
+      "type": "string",
+      "format": "uri"
+    },
+    "runtimes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "codex",
+          "claude",
+          "generic"
+        ]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "entrypoints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "type": "string",
+          "default": "AGENT.md"
+        },
+        "readme": {
+          "type": "string",
+          "default": "README.md"
+        },
+        "tests": {
+          "type": "string",
+          "default": "tests/test-prompts.md"
+        },
+        "examples_dir": {
+          "type": "string",
+          "default": "examples"
+        }
+      }
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "skills": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+          },
+          "uniqueItems": true
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "apis": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tests_min_prompts": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "security_reviewed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "deprecated": {
+      "type": "boolean",
+      "default": false
+    },
+    "replaced_by": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "deprecated": {
+            "const": true
+          }
+        },
+        "required": [
+          "deprecated"
+        ]
+      },
+      "then": {
+        "required": [
+          "replaced_by"
+        ]
+      }
+    }
+  ]
+}

--- a/shared/schemas/tool.schema.json
+++ b/shared/schemas/tool.schema.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://skills.ai-knowledge-hub.org/schemas/tool.schema.json",
+  "title": "Tool & MCP Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "description",
+    "version",
+    "released_at",
+    "category",
+    "tags",
+    "license",
+    "author",
+    "runtimes",
+    "entrypoints"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 120
+    },
+    "description": {
+      "type": "string",
+      "minLength": 10,
+      "maxLength": 400
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "released_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "category": {
+      "type": "string",
+      "minLength": 3
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]{1,39}$"
+      },
+      "minItems": 1,
+      "maxItems": 20,
+      "uniqueItems": true
+    },
+    "license": {
+      "type": "string",
+      "minLength": 2
+    },
+    "author": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 120
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "homepage": {
+      "type": "string",
+      "format": "uri"
+    },
+    "repository": {
+      "type": "string",
+      "format": "uri"
+    },
+    "runtimes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "codex",
+          "claude",
+          "generic"
+        ]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "entrypoints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "spec": {
+          "type": "string",
+          "default": "TOOL.md"
+        },
+        "readme": {
+          "type": "string",
+          "default": "README.md"
+        },
+        "tests": {
+          "type": "string",
+          "default": "tests/test-prompts.md"
+        },
+        "scripts_dir": {
+          "type": "string",
+          "default": "scripts"
+        },
+        "examples_dir": {
+          "type": "string",
+          "default": "examples"
+        }
+      }
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "apis": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "mcp_servers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tests_min_prompts": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "deterministic_scripts": {
+          "type": "boolean"
+        },
+        "security_reviewed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "deprecated": {
+      "type": "boolean",
+      "default": false
+    },
+    "replaced_by": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "deprecated": {
+            "const": true
+          }
+        },
+        "required": [
+          "deprecated"
+        ]
+      },
+      "then": {
+        "required": [
+          "replaced_by"
+        ]
+      }
+    }
+  ]
+}

--- a/tools-mcp/ads/meta-ads-mcp-connector/README.md
+++ b/tools-mcp/ads/meta-ads-mcp-connector/README.md
@@ -1,0 +1,3 @@
+# Meta Ads MCP Connector
+
+Tool manifest for Meta Ads performance data retrieval via MCP.

--- a/tools-mcp/ads/meta-ads-mcp-connector/TOOL.md
+++ b/tools-mcp/ads/meta-ads-mcp-connector/TOOL.md
@@ -1,0 +1,14 @@
+# Meta Ads MCP Connector
+
+## Purpose
+Provide read-only Meta Ads performance retrieval via MCP.
+
+## Capabilities
+- Pull campaign/ad set metrics by date range.
+- Fetch spend, impressions, clicks, conversions, and purchase value.
+- Return normalized fields aligned to BI schemas.
+
+## Guardrails
+- Restrict tool to read-only reporting endpoints.
+- Fail fast on missing account scope.
+- Preserve source timestamps for freshness checks.

--- a/tools-mcp/ads/meta-ads-mcp-connector/examples/input.json
+++ b/tools-mcp/ads/meta-ads-mcp-connector/examples/input.json
@@ -1,0 +1,5 @@
+{
+  "account_id": "act_1234567890",
+  "date_range": "2026-02-23 to 2026-03-01",
+  "fields": ["campaign_name", "spend", "impressions", "clicks", "actions"]
+}

--- a/tools-mcp/ads/meta-ads-mcp-connector/examples/output.json
+++ b/tools-mcp/ads/meta-ads-mcp-connector/examples/output.json
@@ -1,0 +1,11 @@
+{
+  "rows": [
+    {
+      "campaign": "Always On Prospecting",
+      "spend": 5400,
+      "impressions": 880000,
+      "clicks": 14900,
+      "conversions": 301
+    }
+  ]
+}

--- a/tools-mcp/ads/meta-ads-mcp-connector/tests/test-prompts.md
+++ b/tools-mcp/ads/meta-ads-mcp-connector/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Pull last-week campaign performance for this ad account.
+2. Return normalized spend and conversion metrics by campaign.
+3. Fail with clear message when account scope is missing.
+4. Include source timestamp for freshness QA.
+5. Compare current vs previous period spend and conversions.

--- a/tools-mcp/ads/meta-ads-mcp-connector/tool.yaml
+++ b/tools-mcp/ads/meta-ads-mcp-connector/tool.yaml
@@ -1,0 +1,32 @@
+id: ads/meta-ads-mcp-connector
+name: Meta Ads MCP Connector
+description: MCP-backed connector for read-only Meta Ads performance and campaign metadata retrieval.
+version: 0.1.0
+released_at: "2026-03-02T00:00:00Z"
+category: tools-mcp/ads
+tags:
+  - meta-ads
+  - mcp
+  - paid-social
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: TOOL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  mcp_servers:
+    - meta-ads
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/tools-mcp/analytics/ga4-mcp-connector/README.md
+++ b/tools-mcp/analytics/ga4-mcp-connector/README.md
@@ -1,0 +1,3 @@
+# GA4 MCP Connector
+
+Tool manifest for GA4 analytics querying via MCP.

--- a/tools-mcp/analytics/ga4-mcp-connector/TOOL.md
+++ b/tools-mcp/analytics/ga4-mcp-connector/TOOL.md
@@ -1,0 +1,14 @@
+# GA4 MCP Connector
+
+## Purpose
+Provide standardized GA4 query access via MCP for marketing skills and agents.
+
+## Capabilities
+- Pull sessions, users, conversions, and revenue by dimension.
+- Query fixed date windows for period comparisons.
+- Return normalized payloads for downstream skills.
+
+## Guardrails
+- Enforce read-only query scope.
+- Validate requested dimensions/metrics against allowlist.
+- Return clear errors for invalid property or auth failures.

--- a/tools-mcp/analytics/ga4-mcp-connector/examples/input.json
+++ b/tools-mcp/analytics/ga4-mcp-connector/examples/input.json
@@ -1,0 +1,6 @@
+{
+  "property_id": "123456789",
+  "date_range": "2026-02-23 to 2026-03-01",
+  "dimensions": ["sessionDefaultChannelGroup"],
+  "metrics": ["sessions", "conversions", "totalRevenue"]
+}

--- a/tools-mcp/analytics/ga4-mcp-connector/examples/output.json
+++ b/tools-mcp/analytics/ga4-mcp-connector/examples/output.json
@@ -1,0 +1,10 @@
+{
+  "rows": [
+    {
+      "channel": "Paid Search",
+      "sessions": 10234,
+      "conversions": 412,
+      "revenue": 23800
+    }
+  ]
+}

--- a/tools-mcp/analytics/ga4-mcp-connector/tests/test-prompts.md
+++ b/tools-mcp/analytics/ga4-mcp-connector/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Query GA4 sessions and conversions for the last 7 days.
+2. Compare current and previous week metrics by channel.
+3. Validate metric/dimension allowlist enforcement.
+4. Return structured error for invalid property id.
+5. Provide normalized output for downstream dashboard skill.

--- a/tools-mcp/analytics/ga4-mcp-connector/tool.yaml
+++ b/tools-mcp/analytics/ga4-mcp-connector/tool.yaml
@@ -1,0 +1,32 @@
+id: analytics/ga4-mcp-connector
+name: GA4 MCP Connector
+description: MCP-backed GA4 query connector for structured marketing analytics retrieval.
+version: 0.1.0
+released_at: "2026-03-02T00:00:00Z"
+category: tools-mcp/analytics
+tags:
+  - ga4
+  - mcp
+  - analytics
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: TOOL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  mcp_servers:
+    - ga4
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/tools-mcp/warehouse/bigquery-mcp-query-runner/README.md
+++ b/tools-mcp/warehouse/bigquery-mcp-query-runner/README.md
@@ -1,0 +1,3 @@
+# BigQuery MCP Query Runner
+
+Tool manifest for BigQuery read-only query execution via MCP.

--- a/tools-mcp/warehouse/bigquery-mcp-query-runner/TOOL.md
+++ b/tools-mcp/warehouse/bigquery-mcp-query-runner/TOOL.md
@@ -1,0 +1,14 @@
+# BigQuery MCP Query Runner
+
+## Purpose
+Run parameterized warehouse queries through MCP for analytics workflows.
+
+## Capabilities
+- Execute parameterized SQL templates.
+- Enforce read-only query patterns.
+- Return typed rows for BI transformations.
+
+## Guardrails
+- Reject non-read-only SQL statements.
+- Enforce query timeout and row limits.
+- Surface query diagnostics in failures.

--- a/tools-mcp/warehouse/bigquery-mcp-query-runner/examples/input.json
+++ b/tools-mcp/warehouse/bigquery-mcp-query-runner/examples/input.json
@@ -1,0 +1,7 @@
+{
+  "sql_template": "SELECT channel, SUM(spend) AS spend FROM marketing.performance WHERE date BETWEEN @start AND @end GROUP BY 1",
+  "params": {
+    "start": "2026-02-23",
+    "end": "2026-03-01"
+  }
+}

--- a/tools-mcp/warehouse/bigquery-mcp-query-runner/examples/output.json
+++ b/tools-mcp/warehouse/bigquery-mcp-query-runner/examples/output.json
@@ -1,0 +1,9 @@
+{
+  "rows": [
+    {
+      "channel": "Paid Search",
+      "spend": 17320
+    }
+  ],
+  "row_count": 1
+}

--- a/tools-mcp/warehouse/bigquery-mcp-query-runner/tests/test-prompts.md
+++ b/tools-mcp/warehouse/bigquery-mcp-query-runner/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Run read-only query template for weekly channel performance.
+2. Reject any non-SELECT statement and explain why.
+3. Execute parameterized query with date window inputs.
+4. Return diagnostics when query timeout is exceeded.
+5. Output typed rows for downstream BI pipeline steps.

--- a/tools-mcp/warehouse/bigquery-mcp-query-runner/tool.yaml
+++ b/tools-mcp/warehouse/bigquery-mcp-query-runner/tool.yaml
@@ -1,0 +1,32 @@
+id: warehouse/bigquery-mcp-query-runner
+name: BigQuery MCP Query Runner
+description: Execute parameterized read-only BigQuery SQL through MCP for analytics and BI workflows.
+version: 0.1.0
+released_at: "2026-03-02T00:00:00Z"
+category: tools-mcp/warehouse
+tags:
+  - bigquery
+  - mcp
+  - sql
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: TOOL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  mcp_servers:
+    - bigquery
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false


### PR DESCRIPTION
## Summary

This PR introduces the modular AI Knowledge Hub architecture and ships the first complete implementation across data contracts, registry generation, web routing, seed content, tests, and documentation.

It moves the platform from a skills-only model to a **three-module model**:

- `skills/`
- `agents/`
- `tools-mcp/`

with corresponding route modules and registry indexes.

---

## What’s Included

### 1. Modular Registry Architecture

Implemented module-aware registry generation and compatibility support:

- Added builder support for:
  - `BuildSkillsIndex`
  - `BuildAgentsIndex`
  - `BuildToolsIndex`
- Added `--module skills|agents|tools|all` in registry builder CLI
- Default `all` build now emits:
  - `registry/skills-index.json`
  - `registry/agents-index.json`
  - `registry/tools-index.json`
  - `registry/index.json` (skills compatibility)

Updated files:
- [[internal/registry/builder.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/internal/registry/builder.go)](internal/registry/builder.go)
- [[cmd/registry-builder/main.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/cmd/registry-builder/main.go)](cmd/registry-builder/main.go)

---

### 2. New Manifest Schemas

Added schemas for new module types:

- [[shared/schemas/agent.schema.json](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/shared/schemas/agent.schema.json)](shared/schemas/agent.schema.json)
- [[shared/schemas/tool.schema.json](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/shared/schemas/tool.schema.json)](shared/schemas/tool.schema.json)

Extended manifest validation coverage:

- [[scripts/validate-manifests.sh](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/scripts/validate-manifests.sh)](scripts/validate-manifests.sh)

---

### 3. Web App Module Routing

Refactored web data loading to be module-aware and added new route modules.

New loaders:
- `loadSkillsRegistry()`
- `loadAgentsRegistry()`
- `loadToolsRegistry()`

Updated/added files:
- [[apps/web/lib/registry.ts](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/lib/registry.ts)](apps/web/lib/registry.ts)
- [[apps/web/components/CatalogClient.tsx](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/components/CatalogClient.tsx)](apps/web/components/CatalogClient.tsx)
- [[apps/web/app/agents/page.tsx](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/app/agents/page.tsx)](apps/web/app/agents/page.tsx)
- [[apps/web/app/agents/[...id]/page.tsx](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/app/agents/%5B...id%5D/page.tsx)](apps/web/app/agents/[...id]/page.tsx)
- [[apps/web/app/tools-mcp/page.tsx](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/app/tools-mcp/page.tsx)](apps/web/app/tools-mcp/page.tsx)
- [[apps/web/app/tools-mcp/[...id]/page.tsx](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/app/tools-mcp/%5B...id%5D/page.tsx)](apps/web/app/tools-mcp/[...id]/page.tsx)
- [[apps/web/app/page.tsx](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/app/page.tsx)](apps/web/app/page.tsx)
- [[apps/web/app/skills/page.tsx](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/app/skills/page.tsx)](apps/web/app/skills/page.tsx)
- [[apps/web/app/skills/[...id]/page.tsx](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/app/skills/%5B...id%5D/page.tsx)](apps/web/app/skills/[...id]/page.tsx)
- [[apps/web/app/not-found.tsx](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/app/not-found.tsx)](apps/web/app/not-found.tsx)

---

### 4. Seed Content for New Modules

#### New Agents (3)

- `marketing/weekly-performance-supervisor`
- `marketing/campaign-qa-supervisor`
- `adtech/bi-insights-orchestrator`

#### New Tools & MCP (3)

- `analytics/ga4-mcp-connector`
- `ads/meta-ads-mcp-connector`
- `warehouse/bigquery-mcp-query-runner`

Each entry includes:
- manifest (`agent.yaml` / `tool.yaml`)
- spec (`AGENT.md` / `TOOL.md`)
- `README.md`
- `tests/test-prompts.md`
- `examples/` artifacts

---

### 5. BI Skill Stack + Orchestration (from earlier scope)

Added and registered:
- `adtech/dashboard-generator`
- `adtech/dashboard-qa-checker`
- `adtech/executive-narrative-writer`
- `adtech/weekly-performance-review-bi` (orchestration)
- starter prompt template:
  - `skills/adtech/weekly-performance-review-bi/examples/starter-prompt.md`

---

### 6. Domain Migration

Migrated old domain references from `hub.ai-knowledge-hub.org` to:
- `skills.ai-knowledge-hub.org`

including builder constants, schemas, docs, and regenerated registry outputs.

---

### 7. E2E Smoke Coverage Expansion

Updated Playwright smoke tests to include new route modules:

- Home module nav
- Skills catalog/detail
- Agents catalog/detail
- Tools & MCP catalog/detail

Updated files:
- [[apps/web/e2e/smoke.spec.ts](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/e2e/smoke.spec.ts)](apps/web/e2e/smoke.spec.ts)

Also improved local test stability:
- local/dev default `workers: 1`
- CI remains parallel/retry-enabled

Updated file:
- [[apps/web/playwright.config.ts](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/playwright.config.ts)](apps/web/playwright.config.ts)

---

### 8. Documentation Alignment

Updated docs to reflect shipped architecture/routes/indexes/workflows, including:

- [[README.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/README.md)](README.md)
- [[CONTRIBUTING.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/CONTRIBUTING.md)](CONTRIBUTING.md)
- [[Makefile](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/Makefile)](Makefile)
- [[docs/architecture-decisions.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/docs/architecture-decisions.md)](docs/architecture-decisions.md)
- [[docs/deploy-web-vercel.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/docs/deploy-web-vercel.md)](docs/deploy-web-vercel.md)
- [[docs/roadmap.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/docs/roadmap.md)](docs/roadmap.md)
- [[docs/versioning-and-release.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/docs/versioning-and-release.md)](docs/versioning-and-release.md)
- [[docs/getting-started.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/docs/getting-started.md)](docs/getting-started.md)
- [[docs/dev-setup.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/docs/dev-setup.md)](docs/dev-setup.md)
- [[docs/how-to-run-skills.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/docs/how-to-run-skills.md)](docs/how-to-run-skills.md)
- [[docs/how-to-contribute-a-skill.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/docs/how-to-contribute-a-skill.md)](docs/how-to-contribute-a-skill.md)
- [[docs/how-to-test-skills.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/docs/how-to-test-skills.md)](docs/how-to-test-skills.md)
- [[docs/architecture-modules.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/docs/architecture-modules.md)](docs/architecture-modules.md)
- [[docs/implementation-plan-modular-registries.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/docs/implementation-plan-modular-registries.md)](docs/implementation-plan-modular-registries.md)

---

## Validation / Test Evidence

- `go test ./cmd/registry-builder ./internal/registry` ✅
- `go run ./cmd/registry-builder` ✅  
  - skills index generated (18)
  - agents index generated (3)
  - tools index generated (3)
- `bash scripts/validate-skills.sh` ✅
- `cd apps/web && pnpm exec tsc --noEmit` ✅
- `cd apps/web && pnpm exec playwright test --workers=1` ✅ (5 smoke tests passed)

Notes:
- `bash scripts/validate-manifests.sh` requires `check-jsonschema` installed locally.
- `pnpm build` in restricted sandbox may fail on external font fetch (`fonts.googleapis.com`).

---

## Backward Compatibility

- Existing `registry/index.json` remains in place as a **skills compatibility index**.
- Existing skills CLI flows remain intact (`skills-hub install ...`).

---

## Follow-ups (next PRs)

1. Generalize `scripts/validate-skills.sh` for all modules.
2. Add parser/builder unit tests for `agent.yaml` and `tool.yaml` paths.
3. Add domain-specific canonical/sitemap handling for `agents.ai-knowledge-hub.org`.
4. Decide whether `/tools-mcp` remains under skills domain or gets a dedicated domain.