### PR TITLE
package agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
         run: make registry
       - name: Validate manifests and registry schemas
         run: bash scripts/validate-manifests.sh
-      - name: Ensure registry index is committed
-        run: git diff --exit-code registry/index.json
+      - name: Ensure registry indexes are committed
+        run: git diff --exit-code registry/index.json registry/skills-index.json registry/agents-index.json registry/tools-index.json
 
   markdown:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -196,6 +196,18 @@ Example usage:
   marketing/meta-google-weekly-performance-review@0.1.0 \
   --runtime generic \
   --target ./my-agent/skills
+./bin/skills-hub info \
+  --module agents \
+  --entry adtech/bi-insights-orchestrator@latest
+./bin/skills-hub install \
+  --module agents \
+  --entry marketing/weekly-performance-supervisor@latest \
+  --runtime codex
+./bin/skills-hub install \
+  --module tools \
+  --entry analytics/ga4-mcp-connector@latest \
+  --runtime generic \
+  --target ./my-agent/tools-mcp
 ```
 
 Runtime target defaults:
@@ -240,3 +252,14 @@ cd apps/web
 pnpm test:e2e:setup
 pnpm test:e2e
 ```
+
+Static manifest/artifact URLs:
+
+- During web build, `pnpm prepare:assets` generates static files under
+  `apps/web/public`.
+- This makes registry `manifest_url` and `artifact_url` resolvable on
+  production routes like:
+  - `/skills/.../skill.yaml`
+  - `/agents/.../agent.yaml`
+  - `/tools-mcp/.../tool.yaml`
+  - `/artifacts/<id>/<version>.tar.gz`

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -3,3 +3,8 @@ out/
 node_modules/
 playwright-report/
 test-results/
+public/skills/
+public/agents/
+public/tools-mcp/
+public/artifacts/
+public/registry/

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -28,6 +28,7 @@ pnpm test:e2e
 ```
 
 Current smoke coverage:
+
 - home module navigation
 - skills catalog and skill detail
 - agents catalog and agent detail
@@ -36,9 +37,14 @@ Current smoke coverage:
 ## Build
 
 ```bash
+pnpm prepare:assets
 pnpm build
 pnpm start
 ```
+
+`pnpm prepare:assets` copies module manifests and packages tarball artifacts
+from repository source into `apps/web/public` so `manifest_url` and
+`artifact_url` links resolve in production.
 
 ## Routes
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "prepare:assets": "node scripts/prepare-public-assets.mjs",
+    "build": "pnpm prepare:assets && next build",
     "start": "next start",
     "lint": "next lint",
     "test:e2e:setup": "playwright install chromium",

--- a/apps/web/scripts/prepare-public-assets.mjs
+++ b/apps/web/scripts/prepare-public-assets.mjs
@@ -1,0 +1,111 @@
+import { spawnSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(process.cwd(), "..", "..");
+const publicRoot = path.resolve(process.cwd(), "public");
+
+const modules = [
+  { dir: "skills", manifest: "skill.yaml" },
+  { dir: "agents", manifest: "agent.yaml" },
+  { dir: "tools-mcp", manifest: "tool.yaml" }
+];
+
+async function main() {
+  await fs.mkdir(publicRoot, { recursive: true });
+
+  // Rebuild generated static directories so manifest/artifact URLs stay in sync.
+  for (const generatedDir of ["skills", "agents", "tools-mcp", "artifacts", "registry"]) {
+    await fs.rm(path.join(publicRoot, generatedDir), { recursive: true, force: true });
+  }
+
+  for (const moduleConfig of modules) {
+    await publishModuleManifests(moduleConfig);
+  }
+  await publishRegistryIndexes();
+}
+
+async function publishModuleManifests({ dir, manifest }) {
+  const moduleRoot = path.join(repoRoot, dir);
+  try {
+    await fs.access(moduleRoot);
+  } catch {
+    return;
+  }
+
+  const manifestPaths = [];
+  await walk(moduleRoot, async (filePath) => {
+    if (path.basename(filePath) === manifest) {
+      manifestPaths.push(filePath);
+    }
+  });
+
+  for (const manifestPath of manifestPaths) {
+    const entryDir = path.dirname(manifestPath);
+    const relManifestPath = path.relative(repoRoot, manifestPath);
+    const outManifestPath = path.join(publicRoot, relManifestPath);
+
+    await fs.mkdir(path.dirname(outManifestPath), { recursive: true });
+    await fs.copyFile(manifestPath, outManifestPath);
+
+    const manifestRaw = await fs.readFile(manifestPath, "utf-8");
+    const id = extractScalar(manifestRaw, "id");
+    const version = extractScalar(manifestRaw, "version");
+    if (!id || !version) {
+      throw new Error(`Missing id/version in manifest: ${manifestPath}`);
+    }
+
+    const artifactPath = path.join(publicRoot, "artifacts", ...id.split("/"), `${version}.tar.gz`);
+    await fs.mkdir(path.dirname(artifactPath), { recursive: true });
+    createTarball(entryDir, artifactPath);
+  }
+}
+
+async function publishRegistryIndexes() {
+  const registryRoot = path.join(repoRoot, "registry");
+  const outRegistryRoot = path.join(publicRoot, "registry");
+  await fs.mkdir(outRegistryRoot, { recursive: true });
+
+  for (const fileName of ["index.json", "skills-index.json", "agents-index.json", "tools-index.json"]) {
+    const inPath = path.join(registryRoot, fileName);
+    try {
+      await fs.access(inPath);
+    } catch {
+      continue;
+    }
+    await fs.copyFile(inPath, path.join(outRegistryRoot, fileName));
+  }
+}
+
+async function walk(root, onFile) {
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      await walk(fullPath, onFile);
+      continue;
+    }
+    await onFile(fullPath);
+  }
+}
+
+function extractScalar(raw, key) {
+  const regex = new RegExp(`^${key}:\\s*(.+)\\s*$`, "m");
+  const match = raw.match(regex);
+  if (!match) {
+    return "";
+  }
+  return match[1].trim().replace(/^['"]|['"]$/g, "");
+}
+
+function createTarball(sourceDir, outputPath) {
+  const result = spawnSync("tar", ["-czf", outputPath, "-C", sourceDir, "."], {
+    stdio: "pipe"
+  });
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString("utf-8") ?? "";
+    throw new Error(`tar failed for ${sourceDir}: ${stderr}`);
+  }
+}
+
+await main();

--- a/cmd/skills-hub/main.go
+++ b/cmd/skills-hub/main.go
@@ -50,12 +50,17 @@ func main() {
 
 func runList(args []string) error {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	registryPath := fs.String("registry", "registry/index.json", "registry index path")
+	module := fs.String("module", "skills", "module: skills|agents|tools")
+	registryPath := fs.String("registry", "", "registry index path (defaults by module)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	moduleName, err := normalizeModule(*module)
+	if err != nil {
+		return err
+	}
 
-	idx, err := registry.LoadIndex(*registryPath)
+	idx, err := registry.LoadIndex(resolveRegistryPath(*registryPath, moduleName))
 	if err != nil {
 		return err
 	}
@@ -71,7 +76,8 @@ func runList(args []string) error {
 
 func runSearch(args []string) error {
 	fs := flag.NewFlagSet("search", flag.ContinueOnError)
-	registryPath := fs.String("registry", "registry/index.json", "registry index path")
+	module := fs.String("module", "skills", "module: skills|agents|tools")
+	registryPath := fs.String("registry", "", "registry index path (defaults by module)")
 	text := fs.String("q", "", "free text search against id/name/description")
 	tag := fs.String("tag", "", "filter by tag")
 	category := fs.String("category", "", "filter by category")
@@ -79,8 +85,12 @@ func runSearch(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	moduleName, err := normalizeModule(*module)
+	if err != nil {
+		return err
+	}
 
-	idx, err := registry.LoadIndex(*registryPath)
+	idx, err := registry.LoadIndex(resolveRegistryPath(*registryPath, moduleName))
 	if err != nil {
 		return err
 	}
@@ -99,28 +109,38 @@ func runSearch(args []string) error {
 
 func runInfo(args []string) error {
 	fs := flag.NewFlagSet("info", flag.ContinueOnError)
-	registryPath := fs.String("registry", "registry/index.json", "registry index path")
-	skillsRoot := fs.String("root", "skills", "skills root directory")
+	module := fs.String("module", "skills", "module: skills|agents|tools")
+	registryPath := fs.String("registry", "", "registry index path (defaults by module)")
+	entriesRoot := fs.String("root", "", "module root directory (defaults by module)")
 	skillSpec := fs.String("skill", "", "skill id, optionally with @version")
+	entrySpec := fs.String("entry", "", "entry id, optionally with @version")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *skillSpec == "" {
-		return errors.New("--skill is required")
+	moduleName, err := normalizeModule(*module)
+	if err != nil {
+		return err
+	}
+	selectedSpec := strings.TrimSpace(*entrySpec)
+	if selectedSpec == "" {
+		selectedSpec = strings.TrimSpace(*skillSpec)
+	}
+	if selectedSpec == "" {
+		return errors.New("--entry is required (or use legacy --skill)")
 	}
 
-	id, requestedVersion, err := parseSkillSpec(*skillSpec)
+	id, requestedVersion, err := parseSkillSpec(selectedSpec)
 	if err != nil {
 		return err
 	}
 
-	idx, err := registry.LoadIndex(*registryPath)
+	idx, err := registry.LoadIndex(resolveRegistryPath(*registryPath, moduleName))
 	if err != nil {
 		return err
 	}
 	skill, ok := registry.FindSkill(idx, id)
 	if !ok {
-		return fmt.Errorf("skill not found in registry: %s", id)
+		return fmt.Errorf("entry not found in registry: %s", id)
 	}
 	resolvedVersion, err := registry.ResolveVersion(skill, requestedVersion)
 	if err != nil {
@@ -134,7 +154,7 @@ func runInfo(args []string) error {
 	sort.Strings(versions)
 
 	fmt.Printf("id: %s\n", skill.ID)
-	fmt.Printf("path: %s\n", filepath.Join(*skillsRoot, filepath.FromSlash(skill.ID)))
+	fmt.Printf("path: %s\n", filepath.Join(resolveModuleRoot(*entriesRoot, moduleName), filepath.FromSlash(skill.ID)))
 	fmt.Printf("name: %s\n", skill.Name)
 	fmt.Printf("description: %s\n", skill.Description)
 	fmt.Printf("category: %s\n", skill.Category)
@@ -180,22 +200,31 @@ func runInstall(args []string) error {
 	}
 
 	fs := flag.NewFlagSet("install", flag.ContinueOnError)
-	skillsRoot := fs.String("root", "skills", "skills root directory")
-	registryPath := fs.String("registry", "registry/index.json", "registry index path")
+	module := fs.String("module", "skills", "module: skills|agents|tools")
+	entriesRoot := fs.String("root", "", "module root directory (defaults by module)")
+	registryPath := fs.String("registry", "", "registry index path (defaults by module)")
 	runtimeName := fs.String("runtime", "generic", "runtime adapter: codex|claude|generic")
-	target := fs.String("target", "", "destination skills directory (optional for codex/claude)")
+	target := fs.String("target", "", "destination module directory (optional for codex/claude)")
 	skillSpecFlag := fs.String("skill", "", "skill id, optionally with @version")
+	entrySpecFlag := fs.String("entry", "", "entry id, optionally with @version")
 	force := fs.Bool("force", false, "overwrite destination if it already exists")
 	if err := fs.Parse(parsedArgs); err != nil {
 		return err
 	}
+	moduleName, err := normalizeModule(*module)
+	if err != nil {
+		return err
+	}
 
-	skillSpec := strings.TrimSpace(*skillSpecFlag)
+	skillSpec := strings.TrimSpace(*entrySpecFlag)
+	if skillSpec == "" {
+		skillSpec = strings.TrimSpace(*skillSpecFlag)
+	}
 	if skillSpec == "" {
 		skillSpec = positionalSpec
 	}
 	if skillSpec == "" {
-		return errors.New("skill is required (use --skill <id[@version]> or positional <id[@version]>)")
+		return errors.New("entry is required (use --entry <id[@version]>, --skill, or positional <id[@version]>)")
 	}
 
 	id, requestedVersion, err := parseSkillSpec(skillSpec)
@@ -203,13 +232,13 @@ func runInstall(args []string) error {
 		return err
 	}
 
-	idx, err := registry.LoadIndex(*registryPath)
+	idx, err := registry.LoadIndex(resolveRegistryPath(*registryPath, moduleName))
 	if err != nil {
 		return err
 	}
 	skill, ok := registry.FindSkill(idx, id)
 	if !ok {
-		return fmt.Errorf("skill not found in registry: %s", id)
+		return fmt.Errorf("entry not found in registry: %s", id)
 	}
 	resolvedVersion, err := registry.ResolveVersion(skill, requestedVersion)
 	if err != nil {
@@ -224,12 +253,12 @@ func runInstall(args []string) error {
 		fmt.Fprintln(os.Stderr)
 	}
 
-	sourceDir := filepath.Join(*skillsRoot, filepath.FromSlash(skill.ID))
+	sourceDir := filepath.Join(resolveModuleRoot(*entriesRoot, moduleName), filepath.FromSlash(skill.ID))
 	if stat, statErr := os.Stat(sourceDir); statErr != nil || !stat.IsDir() {
 		return fmt.Errorf("local source not found for %s at %s", skill.ID, sourceDir)
 	}
 
-	rt, err := installer.ResolveRuntimeTarget(*runtimeName, *target)
+	rt, err := installer.ResolveRuntimeTargetForModule(*runtimeName, moduleName, *target)
 	if err != nil {
 		return err
 	}
@@ -265,25 +294,76 @@ func parseSkillSpec(spec string) (string, string, error) {
 
 func printUsage() {
 	lines := []string{
-		"skills-hub: manage local marketing/adtech skill packages",
+		"skills-hub: manage local marketing/adtech skill, agent, and tool packages",
 		"",
 		"Usage:",
 		"  skills-hub <command> [flags]",
 		"",
 		"Commands:",
-		"  list      List skills from registry/index.json",
-		"  search    Search skills by text/tag/category/runtime",
-		"  info      Show details for one skill",
+		"  list      List entries from module registry index",
+		"  search    Search entries by text/tag/category/runtime",
+		"  info      Show details for one entry",
 		"  validate  Validate local skill structure and prompt coverage",
-		"  install   Install a local skill package resolved from registry metadata",
+		"  install   Install a local module entry resolved from registry metadata",
 		"",
 		"Examples:",
 		"  skills-hub list",
 		"  skills-hub search --tag paid-media --runtime codex",
 		"  skills-hub info --skill marketing/meta-google-weekly-performance-review@latest",
+		"  skills-hub info --module agents --entry marketing/weekly-performance-supervisor@latest",
 		"  skills-hub validate",
 		"  skills-hub install marketing/meta-google-weekly-performance-review@latest --runtime codex",
+		"  skills-hub install --module agents --entry marketing/weekly-performance-supervisor@latest --runtime codex",
 		"  skills-hub install --skill marketing/meta-google-weekly-performance-review@0.1.0 --runtime generic --target ./my-agent/skills",
 	}
 	fmt.Println(strings.Join(lines, "\n"))
+}
+
+func normalizeModule(raw string) (string, error) {
+	module := strings.ToLower(strings.TrimSpace(raw))
+	if module == "" {
+		module = "skills"
+	}
+	switch module {
+	case "skills", "skill":
+		return "skills", nil
+	case "agents", "agent":
+		return "agents", nil
+	case "tools", "tool", "tools-mcp":
+		return "tools", nil
+	default:
+		return "", fmt.Errorf("unsupported module: %s (supported: skills, agents, tools)", raw)
+	}
+}
+
+func resolveRegistryPath(explicit, module string) string {
+	if strings.TrimSpace(explicit) != "" {
+		return explicit
+	}
+	switch module {
+	case "skills":
+		return "registry/skills-index.json"
+	case "agents":
+		return "registry/agents-index.json"
+	case "tools":
+		return "registry/tools-index.json"
+	default:
+		return "registry/index.json"
+	}
+}
+
+func resolveModuleRoot(explicit, module string) string {
+	if strings.TrimSpace(explicit) != "" {
+		return explicit
+	}
+	switch module {
+	case "skills":
+		return "skills"
+	case "agents":
+		return "agents"
+	case "tools":
+		return "tools-mcp"
+	default:
+		return "skills"
+	}
 }

--- a/internal/installer/runtime.go
+++ b/internal/installer/runtime.go
@@ -14,9 +14,17 @@ type RuntimeTarget struct {
 }
 
 func ResolveRuntimeTarget(runtimeName, explicitTarget string) (RuntimeTarget, error) {
+	return ResolveRuntimeTargetForModule(runtimeName, "skills", explicitTarget)
+}
+
+func ResolveRuntimeTargetForModule(runtimeName, moduleName, explicitTarget string) (RuntimeTarget, error) {
 	runtime := strings.ToLower(strings.TrimSpace(runtimeName))
 	if runtime == "" {
 		runtime = "generic"
+	}
+	moduleDir, err := normalizeModuleDir(moduleName)
+	if err != nil {
+		return RuntimeTarget{}, err
 	}
 
 	if strings.TrimSpace(explicitTarget) != "" {
@@ -29,9 +37,9 @@ func ResolveRuntimeTarget(runtimeName, explicitTarget string) (RuntimeTarget, er
 
 	switch runtime {
 	case "codex":
-		return RuntimeTarget{Runtime: runtime, TargetPath: codexDefaultSkillsDir()}, nil
+		return RuntimeTarget{Runtime: runtime, TargetPath: codexDefaultDir(moduleDir)}, nil
 	case "claude":
-		return RuntimeTarget{Runtime: runtime, TargetPath: claudeDefaultSkillsDir()}, nil
+		return RuntimeTarget{Runtime: runtime, TargetPath: claudeDefaultDir(moduleDir)}, nil
 	case "generic", "custom", "other":
 		return RuntimeTarget{}, errors.New("--target is required for generic/custom runtimes")
 	default:
@@ -39,27 +47,44 @@ func ResolveRuntimeTarget(runtimeName, explicitTarget string) (RuntimeTarget, er
 	}
 }
 
-func codexDefaultSkillsDir() string {
+func codexDefaultDir(moduleDir string) string {
 	if codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME")); codexHome != "" {
-		return filepath.Join(codexHome, "skills")
+		return filepath.Join(codexHome, moduleDir)
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ".codex/skills"
+		return filepath.Join(".codex", moduleDir)
 	}
-	return filepath.Join(home, ".codex", "skills")
+	return filepath.Join(home, ".codex", moduleDir)
 }
 
-func claudeDefaultSkillsDir() string {
+func claudeDefaultDir(moduleDir string) string {
 	if claudeHome := strings.TrimSpace(os.Getenv("CLAUDE_HOME")); claudeHome != "" {
-		return filepath.Join(claudeHome, "skills")
+		return filepath.Join(claudeHome, moduleDir)
 	}
 	if claudeCodeHome := strings.TrimSpace(os.Getenv("CLAUDE_CODE_HOME")); claudeCodeHome != "" {
-		return filepath.Join(claudeCodeHome, "skills")
+		return filepath.Join(claudeCodeHome, moduleDir)
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ".claude/skills"
+		return filepath.Join(".claude", moduleDir)
 	}
-	return filepath.Join(home, ".claude", "skills")
+	return filepath.Join(home, ".claude", moduleDir)
+}
+
+func normalizeModuleDir(moduleName string) (string, error) {
+	module := strings.ToLower(strings.TrimSpace(moduleName))
+	if module == "" {
+		module = "skills"
+	}
+	switch module {
+	case "skills", "skill":
+		return "skills", nil
+	case "agents", "agent":
+		return "agents", nil
+	case "tools", "tool", "tools-mcp":
+		return "tools-mcp", nil
+	default:
+		return "", fmt.Errorf("unsupported module: %s (supported: skills, agents, tools)", moduleName)
+	}
 }

--- a/internal/installer/runtime_test.go
+++ b/internal/installer/runtime_test.go
@@ -48,3 +48,27 @@ func TestResolveRuntimeTargetGenericNeedsTarget(t *testing.T) {
 		t.Fatalf("expected error for missing target")
 	}
 }
+
+func TestResolveRuntimeTargetForModuleAgents(t *testing.T) {
+	t.Setenv("CODEX_HOME", "/tmp/codex-home")
+	target, err := ResolveRuntimeTargetForModule("codex", "agents", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join("/tmp/codex-home", "agents")
+	if target.TargetPath != expected {
+		t.Fatalf("expected %s, got %s", expected, target.TargetPath)
+	}
+}
+
+func TestResolveRuntimeTargetForModuleToolsMcp(t *testing.T) {
+	t.Setenv("CLAUDE_HOME", "/tmp/claude-home")
+	target, err := ResolveRuntimeTargetForModule("claude", "tools", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join("/tmp/claude-home", "tools-mcp")
+	if target.TargetPath != expected {
+		t.Fatalf("expected %s, got %s", expected, target.TargetPath)
+	}
+}


### PR DESCRIPTION
## Summary

This PR closes the gap between registry metadata and deploy reality by making manifest/artifact URLs actually resolvable in production, and by enabling module-aware install flows for `agents` and `tools`.

---

## What Changed

### 1. Build-time publishing of manifests + artifacts for web deploy

Added a build prep script that generates static files under `apps/web/public` from repo source:

- [[apps/web/scripts/prepare-public-assets.mjs](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/scripts/prepare-public-assets.mjs)](apps/web/scripts/prepare-public-assets.mjs)

It now:

1. Copies manifests to URL-matching paths:
- `public/skills/**/skill.yaml`
- `public/agents/**/agent.yaml`
- `public/tools-mcp/**/tool.yaml`

2. Creates tarball artifacts for each entry:
- `public/artifacts/<id>/<version>.tar.gz`

3. Copies registry indexes for static hosting:
- `public/registry/index.json`
- `public/registry/skills-index.json`
- `public/registry/agents-index.json`
- `public/registry/tools-index.json`

Wired into web build:

- [[apps/web/package.json](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/package.json)](apps/web/package.json)
  - `build` now runs `pnpm prepare:assets && next build`

Ignored generated output paths:

- [[apps/web/.gitignore](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/.gitignore)](apps/web/.gitignore)

---

### 2. Module-aware CLI support for install/info/list/search

Extended `skills-hub` to support all modules:

- [[cmd/skills-hub/main.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/cmd/skills-hub/main.go)](cmd/skills-hub/main.go)

Added:

- `--module skills|agents|tools`
- `--entry <id>@<version>` (with legacy `--skill` preserved)

Default registry paths now resolve by module:
- `registry/skills-index.json`
- `registry/agents-index.json`
- `registry/tools-index.json`

This makes agents/tools installable via CLI in the same workflow model as skills.

---

### 3. Module-aware runtime target resolution

Added module-specific install destination defaults:

- [[internal/installer/runtime.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/internal/installer/runtime.go)](internal/installer/runtime.go)
- [[internal/installer/runtime_test.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/internal/installer/runtime_test.go)](internal/installer/runtime_test.go)

Examples:
- Codex defaults to `~/.codex/<module-dir>`
- Claude defaults to `~/.claude/<module-dir>`
- Module dirs: `skills`, `agents`, `tools-mcp`

---

### 4. CI guardrail update

Updated registry freshness check to include all index files:

- [\[.github/workflows/ci.yml](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/.github/workflows/ci.yml)](.github/workflows/ci.yml)

Now checks:
- `registry/index.json`
- `registry/skills-index.json`
- `registry/agents-index.json`
- `registry/tools-index.json`

---

### 5. Documentation updates

Updated docs to reflect new asset publishing + module install behavior:

- [[README.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/README.md)](README.md)
- [[apps/web/README.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/README.md)](apps/web/README.md)

---

## Why this matters

This PR turns catalog metadata into a real deployable contract:

- `manifest_url` now points to files that exist in production.
- `artifact_url` now points to downloadable packages that exist in production.
- Agents/tools are now installable with first-class CLI module support.
- This aligns the platform with the “Agent = Model + Memory + Tools + Skills + Role” practical direction by enabling agent package distribution, not just listing.

---

## Verification

- `pnpm prepare:assets` generated expected files under `apps/web/public`
- `go test ./cmd/skills-hub ./internal/installer` passed
- `skills-hub info/install` validated for `--module agents` and `--module tools`
- `cd apps/web && pnpm exec tsc --noEmit` passed

---

## Post-merge / deploy note

A web redeploy is required for production URLs to resolve.  
After deploy, URLs like `/agents/.../agent.yaml` and `/artifacts/...` should be live.