### PR TITLE
extend agents to production grade with still missing full tools and M…

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ This follows the agent model from our article:
 ### 1. Pick an agent package
 
 Example:
+
 - `marketing/weekly-performance-supervisor`
 - `adtech/bi-insights-orchestrator`
 
@@ -207,6 +208,7 @@ Install tools/MCP connectors:
 ### 3. Configure Role and Memory
 
 Use project-level instructions:
+
 - role and goals
 - constraints (read-only, approval gates)
 - response style
@@ -218,6 +220,7 @@ For Claude projects, use your project guidance file/workspace instructions.
 ### 4. Connect Tools via MCP
 
 Map your installed tool connectors to real MCP servers and credentials:
+
 - GA4
 - warehouse (BigQuery/Redshift)
 - ads platforms
@@ -228,6 +231,7 @@ Keep tool permissions scoped. Start read-only, then expand.
 ### 5. Run and validate
 
 Run your workflow request and verify:
+
 - deterministic section ordering
 - QA block behavior on critical failures
 - explicit evidence values in failures
@@ -238,6 +242,7 @@ Run your workflow request and verify:
 #### A) Claude Code / Claude Agent SDK
 
 Docs:
+
 - [Claude API Docs](https://platform.claude.com/docs/en/home)
 
 Install to Claude runtime paths:
@@ -262,6 +267,7 @@ for approval gates before live actions.
 #### B) OpenAI Codex
 
 Docs:
+
 - [OpenAI Codex Docs](https://developers.openai.com/codex/)
 
 Install to Codex runtime paths:
@@ -285,6 +291,7 @@ Add an `AGENTS.md` with role, goals, boundaries, and preferred tools.
 #### C) OpenClaw or other generic agent runtimes
 
 Source:
+
 - [OpenClaw](https://github.com/openclaw/openclaw)
 
 Install with explicit targets:

--- a/README.md
+++ b/README.md
@@ -146,6 +146,169 @@ Useful sections include skills for:
 5. Validate manifests with `bash scripts/validate-manifests.sh`.
 6. Submit improvements via PR.
 
+## Use Agent Packages (Step-by-step)
+
+This follows the agent model from our article:
+
+`Agent = Role + Memory + Tools + Skills + Model`
+
+### 1. Pick an agent package
+
+Example:
+- `marketing/weekly-performance-supervisor`
+- `adtech/bi-insights-orchestrator`
+
+Inspect details:
+
+```bash
+./bin/skills-hub info \
+  --module agents \
+  --entry marketing/weekly-performance-supervisor@latest
+```
+
+### 2. Install the agent and required packages
+
+Install the agent:
+
+```bash
+./bin/skills-hub install \
+  --module agents \
+  --entry marketing/weekly-performance-supervisor@latest \
+  --runtime codex
+```
+
+Install dependent skills:
+
+```bash
+./bin/skills-hub install \
+  adtech/dashboard-generator@latest \
+  --runtime codex
+./bin/skills-hub install \
+  adtech/dashboard-qa-checker@latest \
+  --runtime codex
+./bin/skills-hub install \
+  adtech/executive-narrative-writer@latest \
+  --runtime codex
+```
+
+Install tools/MCP connectors:
+
+```bash
+./bin/skills-hub install \
+  --module tools \
+  --entry analytics/ga4-mcp-connector@latest \
+  --runtime codex
+./bin/skills-hub install \
+  --module tools \
+  --entry warehouse/bigquery-mcp-query-runner@latest \
+  --runtime codex
+```
+
+### 3. Configure Role and Memory
+
+Use project-level instructions:
+- role and goals
+- constraints (read-only, approval gates)
+- response style
+- memory references (brand docs, KPI dictionary, runbooks)
+
+For Codex, use `AGENTS.md` in repo root.
+For Claude projects, use your project guidance file/workspace instructions.
+
+### 4. Connect Tools via MCP
+
+Map your installed tool connectors to real MCP servers and credentials:
+- GA4
+- warehouse (BigQuery/Redshift)
+- ads platforms
+- Slack/Teams for alerts
+
+Keep tool permissions scoped. Start read-only, then expand.
+
+### 5. Run and validate
+
+Run your workflow request and verify:
+- deterministic section ordering
+- QA block behavior on critical failures
+- explicit evidence values in failures
+- no fabricated metrics
+
+### Runtime examples
+
+#### A) Claude Code / Claude Agent SDK
+
+Docs:
+- [Claude API Docs](https://platform.claude.com/docs/en/home)
+
+Install to Claude runtime paths:
+
+```bash
+./bin/skills-hub install \
+  --module agents \
+  --entry marketing/weekly-performance-supervisor@latest \
+  --runtime claude
+./bin/skills-hub install \
+  adtech/dashboard-generator@latest \
+  --runtime claude
+./bin/skills-hub install \
+  --module tools \
+  --entry analytics/ga4-mcp-connector@latest \
+  --runtime claude
+```
+
+Then map MCP servers in your Claude environment and add project constraints
+for approval gates before live actions.
+
+#### B) OpenAI Codex
+
+Docs:
+- [OpenAI Codex Docs](https://developers.openai.com/codex/)
+
+Install to Codex runtime paths:
+
+```bash
+./bin/skills-hub install \
+  --module agents \
+  --entry adtech/bi-insights-orchestrator@latest \
+  --runtime codex
+./bin/skills-hub install \
+  adtech/analyst-copilot-bigquery-redshift@latest \
+  --runtime codex
+./bin/skills-hub install \
+  --module tools \
+  --entry warehouse/bigquery-mcp-query-runner@latest \
+  --runtime codex
+```
+
+Add an `AGENTS.md` with role, goals, boundaries, and preferred tools.
+
+#### C) OpenClaw or other generic agent runtimes
+
+Source:
+- [OpenClaw](https://github.com/openclaw/openclaw)
+
+Install with explicit targets:
+
+```bash
+./bin/skills-hub install \
+  --module agents \
+  --entry marketing/weekly-performance-supervisor@latest \
+  --runtime generic \
+  --target ./openclaw-workspace/agents
+./bin/skills-hub install \
+  adtech/dashboard-generator@latest \
+  --runtime generic \
+  --target ./openclaw-workspace/skills
+./bin/skills-hub install \
+  --module tools \
+  --entry analytics/ga4-mcp-connector@latest \
+  --runtime generic \
+  --target ./openclaw-workspace/tools-mcp
+```
+
+Mount those folders into your runtime workspace and reference them in your
+agent onboarding/config flow.
+
 ## CLI Scaffold (Go)
 
 This repo now includes a starter CLI at `cmd/skills-hub`
@@ -208,13 +371,31 @@ Example usage:
   --entry analytics/ga4-mcp-connector@latest \
   --runtime generic \
   --target ./my-agent/tools-mcp
+./bin/skills-hub run-agent \
+  --agent marketing/weekly-performance-supervisor \
+  --bindings agents/marketing/weekly-performance-supervisor/config/\
+tool-bindings.example.json \
+  --memory agents/marketing/weekly-performance-supervisor/config/\
+memory-profile.example.json \
+  --governance agents/marketing/weekly-performance-supervisor/config/\
+governance.example.json \
+  --approve-live \
+  --audit-log ./tmp/weekly-performance-supervisor-run.json
 ```
 
 Runtime target defaults:
 
-- `--runtime codex` -> `$CODEX_HOME/skills` (or `~/.codex/skills`)
-- `--runtime claude` -> `$CLAUDE_HOME/skills` (or `$CLAUDE_CODE_HOME/skills`,
-  or `~/.claude/skills`)
+- `--runtime codex`:
+  - skills -> `$CODEX_HOME/skills` (or `~/.codex/skills`)
+  - agents -> `$CODEX_HOME/agents` (or `~/.codex/agents`)
+  - tools -> `$CODEX_HOME/tools-mcp` (or `~/.codex/tools-mcp`)
+- `--runtime claude`:
+  - skills -> `$CLAUDE_HOME/skills` (or `$CLAUDE_CODE_HOME/skills`,
+    or `~/.claude/skills`)
+  - agents -> `$CLAUDE_HOME/agents` (or `$CLAUDE_CODE_HOME/agents`,
+    or `~/.claude/agents`)
+  - tools -> `$CLAUDE_HOME/tools-mcp` (or `$CLAUDE_CODE_HOME/tools-mcp`,
+    or `~/.claude/tools-mcp`)
 - `--runtime generic` -> requires explicit `--target`
 
 ## Contributing

--- a/agents/adtech/bi-insights-orchestrator/README.md
+++ b/agents/adtech/bi-insights-orchestrator/README.md
@@ -1,3 +1,93 @@
 # BI Insights Orchestrator
 
-Agent template for orchestrating cross-source BI insight generation in marketing analytics.
+Agent template for orchestrating cross-source BI insight generation in
+marketing analytics.
+
+## What this agent does
+
+- Pulls data from multiple sources for fixed date windows.
+- Normalizes KPI definitions across sources.
+- Surfaces anomalies and insight candidates.
+- Routes approved outputs into dashboard-ready reporting flows.
+
+## Before you start
+
+1. Install this agent package.
+2. Install required skills.
+3. Install required tools/MCP connectors.
+4. Confirm your data sources are reachable.
+5. Copy and adapt config examples in `config/`:
+   - `tool-bindings.example.json`
+   - `memory-profile.example.json`
+   - `governance.example.json`
+
+Install commands (Codex example):
+
+```bash
+./bin/skills-hub install \
+  --module agents \
+  --entry adtech/bi-insights-orchestrator@latest \
+  --runtime codex
+
+./bin/skills-hub install \
+  adtech/analyst-copilot-bigquery-redshift@latest \
+  --runtime codex
+./bin/skills-hub install \
+  adtech/dashboard-generator@latest \
+  --runtime codex
+./bin/skills-hub install \
+  adtech/dashboard-qa-checker@latest \
+  --runtime codex
+
+./bin/skills-hub install \
+  --module tools \
+  --entry warehouse/bigquery-mcp-query-runner@latest \
+  --runtime codex
+./bin/skills-hub install \
+  --module tools \
+  --entry analytics/ga4-mcp-connector@latest \
+  --runtime codex
+```
+
+## First run (copy/paste prompt)
+
+```text
+Use the BI Insights Orchestrator for:
+- Current window: 2026-02-23 to 2026-03-01
+- Previous window: 2026-02-16 to 2026-02-22
+- Sources: GA4, BigQuery, Meta Ads
+
+Required output:
+1) Normalized KPI table (CTR, CPC, CPA, ROAS, CVR)
+2) Top anomalies with evidence
+3) Publish recommendation (approved or blocked)
+4) Risks and data limitations
+```
+
+## What good output looks like
+
+- Includes explicit metric formulas.
+- Separates observed facts from hypotheses.
+- Shows evidence values for anomalies.
+- Includes a clear publish recommendation.
+
+## Beginner safety checklist
+
+- Start read-only for all data tools.
+- Ask the agent to show limitations if any source fails.
+- Require QA approval before any publish recommendation.
+
+## Production preflight command
+
+```bash
+./bin/skills-hub run-agent \
+  --agent adtech/bi-insights-orchestrator \
+  --bindings agents/adtech/bi-insights-orchestrator/config/\
+tool-bindings.example.json \
+  --memory agents/adtech/bi-insights-orchestrator/config/\
+memory-profile.example.json \
+  --governance agents/adtech/bi-insights-orchestrator/config/\
+governance.example.json \
+  --approve-live \
+  --audit-log ./tmp/bi-insights-orchestrator-run.json
+```

--- a/agents/adtech/bi-insights-orchestrator/config/governance.example.json
+++ b/agents/adtech/bi-insights-orchestrator/config/governance.example.json
@@ -1,0 +1,5 @@
+{
+  "require_approval_for_live": true,
+  "allow_write_tools": false,
+  "max_tool_calls": 120
+}

--- a/agents/adtech/bi-insights-orchestrator/config/memory-profile.example.json
+++ b/agents/adtech/bi-insights-orchestrator/config/memory-profile.example.json
@@ -1,0 +1,7 @@
+{
+  "context_files": [
+    "shared/metrics/core-metrics.md"
+  ],
+  "state_store": "local-json",
+  "retention_days": 30
+}

--- a/agents/adtech/bi-insights-orchestrator/config/tool-bindings.example.json
+++ b/agents/adtech/bi-insights-orchestrator/config/tool-bindings.example.json
@@ -1,0 +1,12 @@
+{
+  "tools": {
+    "bigquery_sql": {
+      "endpoint": "mcp://bigquery",
+      "mode": "read_only"
+    },
+    "ga4_query": {
+      "endpoint": "mcp://ga4",
+      "mode": "read_only"
+    }
+  }
+}

--- a/agents/marketing/campaign-qa-supervisor/README.md
+++ b/agents/marketing/campaign-qa-supervisor/README.md
@@ -1,3 +1,77 @@
 # Campaign QA Supervisor
 
 Agent template for campaign QA gating with clear remediation outputs.
+
+## What this agent does
+
+- Runs pre-launch and in-flight QA checks for campaigns.
+- Flags missing tracking fields and policy issues.
+- Returns pass/warn/fail with remediation actions.
+- Blocks launch recommendations on critical failures.
+
+## Before you start
+
+1. Install this agent package.
+2. Install its required skill dependency.
+3. Connect campaign config and alerting tools.
+4. Copy and adapt config examples in `config/`:
+   - `tool-bindings.example.json`
+   - `memory-profile.example.json`
+   - `governance.example.json`
+
+Install commands (Codex example):
+
+```bash
+./bin/skills-hub install \
+  --module agents \
+  --entry marketing/campaign-qa-supervisor@latest \
+  --runtime codex
+
+./bin/skills-hub install \
+  adtech/policy-brand-compliance-checker@latest \
+  --runtime codex
+```
+
+## First run (copy/paste prompt)
+
+```text
+Use Campaign QA Supervisor to validate this campaign before launch:
+- Campaign ID: spring-launch-2026
+- Channel: Paid Social
+- Required tracking fields: utm_source, utm_medium, utm_campaign
+
+Return:
+1) Overall status (pass/warn/fail)
+2) Critical failures
+3) Warnings
+4) Required remediation actions
+5) A short alert message if status is fail
+```
+
+## What good output looks like
+
+- Every failure includes evidence and reason.
+- Critical blockers are clearly separated from warnings.
+- Action list is specific and fix-ready.
+- Status is explicit: pass, warn, or fail.
+
+## Beginner safety checklist
+
+- Do not launch on `fail`.
+- Require human approval for any override.
+- Keep policy checks active even if deadlines are tight.
+
+## Production preflight command
+
+```bash
+./bin/skills-hub run-agent \
+  --agent marketing/campaign-qa-supervisor \
+  --bindings agents/marketing/campaign-qa-supervisor/config/\
+tool-bindings.example.json \
+  --memory agents/marketing/campaign-qa-supervisor/config/\
+memory-profile.example.json \
+  --governance agents/marketing/campaign-qa-supervisor/config/\
+governance.example.json \
+  --approve-live \
+  --audit-log ./tmp/campaign-qa-supervisor-run.json
+```

--- a/agents/marketing/campaign-qa-supervisor/config/governance.example.json
+++ b/agents/marketing/campaign-qa-supervisor/config/governance.example.json
@@ -1,0 +1,5 @@
+{
+  "require_approval_for_live": true,
+  "allow_write_tools": false,
+  "max_tool_calls": 80
+}

--- a/agents/marketing/campaign-qa-supervisor/config/memory-profile.example.json
+++ b/agents/marketing/campaign-qa-supervisor/config/memory-profile.example.json
@@ -1,0 +1,7 @@
+{
+  "context_files": [
+    "shared/policies/severity-taxonomy.md"
+  ],
+  "state_store": "local-json",
+  "retention_days": 14
+}

--- a/agents/marketing/campaign-qa-supervisor/config/tool-bindings.example.json
+++ b/agents/marketing/campaign-qa-supervisor/config/tool-bindings.example.json
@@ -1,0 +1,12 @@
+{
+  "tools": {
+    "campaign_config_reader": {
+      "endpoint": "mcp://campaign-config",
+      "mode": "read_only"
+    },
+    "slack_post": {
+      "endpoint": "mcp://slack",
+      "mode": "read_only"
+    }
+  }
+}

--- a/agents/marketing/weekly-performance-supervisor/README.md
+++ b/agents/marketing/weekly-performance-supervisor/README.md
@@ -1,3 +1,94 @@
 # Weekly Performance Supervisor
 
-Agent template for deterministic weekly performance reporting with QA-gated publish control.
+Agent template for deterministic weekly performance reporting with
+QA-gated publish control.
+
+## What this agent does
+
+- Orchestrates weekly reporting in a fixed sequence.
+- Builds dashboard sections from normalized data.
+- Runs QA checks before publish.
+- Generates executive narrative only when QA passes.
+
+## Before you start
+
+1. Install this agent package.
+2. Install required skills.
+3. Install required tools/MCP connectors.
+4. Confirm date windows and required channels.
+5. Copy and adapt config examples in `config/`:
+   - `tool-bindings.example.json`
+   - `memory-profile.example.json`
+   - `governance.example.json`
+
+Install commands (Codex example):
+
+```bash
+./bin/skills-hub install \
+  --module agents \
+  --entry marketing/weekly-performance-supervisor@latest \
+  --runtime codex
+
+./bin/skills-hub install \
+  adtech/dashboard-generator@latest \
+  --runtime codex
+./bin/skills-hub install \
+  adtech/dashboard-qa-checker@latest \
+  --runtime codex
+./bin/skills-hub install \
+  adtech/executive-narrative-writer@latest \
+  --runtime codex
+
+./bin/skills-hub install \
+  --module tools \
+  --entry analytics/ga4-mcp-connector@latest \
+  --runtime codex
+./bin/skills-hub install \
+  --module tools \
+  --entry warehouse/bigquery-mcp-query-runner@latest \
+  --runtime codex
+```
+
+## First run (copy/paste prompt)
+
+```text
+Use Weekly Performance Supervisor for:
+- Current period: 2026-02-23 to 2026-03-01
+- Previous period: 2026-02-16 to 2026-02-22
+- Required channels: Paid Search, Paid Social
+- Audience: CMO
+
+Required output in this order:
+1) Publish decision
+2) Dashboard package
+3) QA package
+4) Executive narrative (only if approved)
+```
+
+## What good output looks like
+
+- Section order is deterministic.
+- QA result is explicit and evidence-backed.
+- Publish is blocked on critical QA failure.
+- Narrative appears only when publish decision is approved.
+
+## Beginner safety checklist
+
+- Keep reconciliation and freshness checks enabled.
+- Never force publish when critical QA fails.
+- Ask for missing-source limitations in the final output.
+
+## Production preflight command
+
+```bash
+./bin/skills-hub run-agent \
+  --agent marketing/weekly-performance-supervisor \
+  --bindings agents/marketing/weekly-performance-supervisor/config/\
+tool-bindings.example.json \
+  --memory agents/marketing/weekly-performance-supervisor/config/\
+memory-profile.example.json \
+  --governance agents/marketing/weekly-performance-supervisor/config/\
+governance.example.json \
+  --approve-live \
+  --audit-log ./tmp/weekly-performance-supervisor-run.json
+```

--- a/agents/marketing/weekly-performance-supervisor/config/governance.example.json
+++ b/agents/marketing/weekly-performance-supervisor/config/governance.example.json
@@ -1,0 +1,5 @@
+{
+  "require_approval_for_live": true,
+  "allow_write_tools": false,
+  "max_tool_calls": 100
+}

--- a/agents/marketing/weekly-performance-supervisor/config/memory-profile.example.json
+++ b/agents/marketing/weekly-performance-supervisor/config/memory-profile.example.json
@@ -1,0 +1,8 @@
+{
+  "context_files": [
+    "shared/metrics/core-metrics.md",
+    "shared/policies/severity-taxonomy.md"
+  ],
+  "state_store": "local-json",
+  "retention_days": 30
+}

--- a/agents/marketing/weekly-performance-supervisor/config/tool-bindings.example.json
+++ b/agents/marketing/weekly-performance-supervisor/config/tool-bindings.example.json
@@ -1,0 +1,12 @@
+{
+  "tools": {
+    "ga4_query": {
+      "endpoint": "mcp://ga4",
+      "mode": "read_only"
+    },
+    "warehouse_query": {
+      "endpoint": "mcp://warehouse",
+      "mode": "read_only"
+    }
+  }
+}

--- a/apps/web/app/agents/[...id]/page.tsx
+++ b/apps/web/app/agents/[...id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { getEntryById, loadAgentsRegistry } from "@/lib/registry";
+import InstallCommands from "@/components/InstallCommands";
+import { buildModuleInstallSnippet, getEntryById, loadAgentsRegistry } from "@/lib/registry";
 
 export async function generateStaticParams() {
   const registry = await loadAgentsRegistry();
@@ -55,6 +56,11 @@ export default async function AgentDetailPage({ params }: { params: { id: string
             {latestVersion ? <a href={latestVersion.artifact_url}>{latestVersion.artifact_url}</a> : "n/a"}
           </p>
         </article>
+        <InstallCommands
+          codex={buildModuleInstallSnippet("agents", entry, "codex")}
+          claude={buildModuleInstallSnippet("agents", entry, "claude")}
+          generic={buildModuleInstallSnippet("agents", entry, "generic")}
+        />
       </section>
     </main>
   );

--- a/apps/web/app/tools-mcp/[...id]/page.tsx
+++ b/apps/web/app/tools-mcp/[...id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { getEntryById, loadToolsRegistry } from "@/lib/registry";
+import InstallCommands from "@/components/InstallCommands";
+import { buildModuleInstallSnippet, getEntryById, loadToolsRegistry } from "@/lib/registry";
 
 export async function generateStaticParams() {
   const registry = await loadToolsRegistry();
@@ -55,6 +56,11 @@ export default async function ToolDetailPage({ params }: { params: { id: string[
             {latestVersion ? <a href={latestVersion.artifact_url}>{latestVersion.artifact_url}</a> : "n/a"}
           </p>
         </article>
+        <InstallCommands
+          codex={buildModuleInstallSnippet("tools", entry, "codex")}
+          claude={buildModuleInstallSnippet("tools", entry, "claude")}
+          generic={buildModuleInstallSnippet("tools", entry, "generic")}
+        />
       </section>
     </main>
   );

--- a/apps/web/lib/registry.ts
+++ b/apps/web/lib/registry.ts
@@ -90,6 +90,25 @@ export function buildInstallSnippet(skill: RegistryEntry, runtime: "codex" | "cl
   return `${base} --runtime ${runtime}`;
 }
 
+export function buildModuleInstallSnippet(
+  module: ModuleKey,
+  entry: RegistryEntry,
+  runtime: "codex" | "claude" | "generic"
+) {
+  const moduleFlag = module === "tools" ? "tools" : module;
+  const base = `./bin/skills-hub install --module ${moduleFlag} --entry ${entry.id}@${entry.latest}`;
+  if (runtime === "generic") {
+    const targetDir =
+      module === "agents"
+        ? "./my-agent/agents"
+        : module === "tools"
+          ? "./my-agent/tools-mcp"
+          : "./my-agent/skills";
+    return `${base} --runtime generic --target ${targetDir}`;
+  }
+  return `${base} --runtime ${runtime}`;
+}
+
 export function uniqueValues(values: string[]) {
   return [...new Set(values)].sort((a, b) => a.localeCompare(b));
 }

--- a/cmd/skills-hub/main.go
+++ b/cmd/skills-hub/main.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ai-knowledge-hub/ai-skills-guide/internal/agents"
 	"github.com/ai-knowledge-hub/ai-skills-guide/internal/installer"
 	"github.com/ai-knowledge-hub/ai-skills-guide/internal/registry"
 	"github.com/ai-knowledge-hub/ai-skills-guide/internal/skills"
@@ -35,6 +36,8 @@ func main() {
 		err = runValidate(args)
 	case "install":
 		err = runInstall(args)
+	case "run-agent":
+		err = runAgent(args)
 	case "help", "-h", "--help":
 		printUsage()
 		return
@@ -305,6 +308,7 @@ func printUsage() {
 		"  info      Show details for one entry",
 		"  validate  Validate local skill structure and prompt coverage",
 		"  install   Install a local module entry resolved from registry metadata",
+		"  run-agent Run production preflight checks for an installed agent package",
 		"",
 		"Examples:",
 		"  skills-hub list",
@@ -315,8 +319,66 @@ func printUsage() {
 		"  skills-hub install marketing/meta-google-weekly-performance-review@latest --runtime codex",
 		"  skills-hub install --module agents --entry marketing/weekly-performance-supervisor@latest --runtime codex",
 		"  skills-hub install --skill marketing/meta-google-weekly-performance-review@0.1.0 --runtime generic --target ./my-agent/skills",
+		"  skills-hub run-agent --agent marketing/weekly-performance-supervisor --bindings agents/marketing/weekly-performance-supervisor/config/tool-bindings.example.json --approve-live",
 	}
 	fmt.Println(strings.Join(lines, "\n"))
+}
+
+func runAgent(args []string) error {
+	fs := flag.NewFlagSet("run-agent", flag.ContinueOnError)
+	agentID := fs.String("agent", "", "agent id in <domain>/<slug> format")
+	agentsRoot := fs.String("agents-root", "agents", "agents root directory")
+	skillsRoot := fs.String("skills-root", "skills", "skills root directory")
+	toolsRoot := fs.String("tools-root", "tools-mcp", "tools root directory")
+	bindingsPath := fs.String("bindings", "", "path to JSON tool bindings")
+	memoryPath := fs.String("memory", "", "path to JSON memory profile")
+	governancePath := fs.String("governance", "", "path to JSON governance profile")
+	auditPath := fs.String("audit-log", "", "path to output JSON audit report")
+	approveLive := fs.Bool("approve-live", false, "approve live actions for this run")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*agentID) == "" {
+		return errors.New("--agent is required")
+	}
+
+	report, err := agents.RunPreflight(agents.RunOptions{
+		AgentsRoot:     *agentsRoot,
+		SkillsRoot:     *skillsRoot,
+		ToolsRoot:      *toolsRoot,
+		AgentID:        strings.TrimSpace(*agentID),
+		BindingsPath:   strings.TrimSpace(*bindingsPath),
+		MemoryPath:     strings.TrimSpace(*memoryPath),
+		GovernancePath: strings.TrimSpace(*governancePath),
+		ApproveLive:    *approveLive,
+		AuditPath:      strings.TrimSpace(*auditPath),
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("agent: %s\n", report.AgentID)
+	fmt.Printf("status: %s\n", report.Status)
+	if len(report.WorkflowSteps) > 0 {
+		fmt.Printf("workflow_steps: %d\n", len(report.WorkflowSteps))
+	}
+	if len(report.Warnings) > 0 {
+		fmt.Println("warnings:")
+		for _, w := range report.Warnings {
+			fmt.Printf("  - %s\n", w)
+		}
+	}
+	if len(report.BlockingReasons) > 0 {
+		fmt.Println("blocking_reasons:")
+		for _, b := range report.BlockingReasons {
+			fmt.Printf("  - %s\n", b)
+		}
+	}
+
+	if report.Status != "ready" {
+		return fmt.Errorf("agent preflight not ready: %s", report.Status)
+	}
+	return nil
 }
 
 func normalizeModule(raw string) (string, error) {

--- a/docs/implementation-plan-modular-registries.md
+++ b/docs/implementation-plan-modular-registries.md
@@ -38,9 +38,9 @@ Implement one repository with three route modules and three registry indexes:
 - [x] Update homepage/navigation to expose all three modules.
 
 ### Phase 5: Validation and CI
-- [ ] Generalize `scripts/validate-skills.sh` to support all modules.
+- [x] Generalize `scripts/validate-skills.sh` to support all modules.
 - [x] Extend `scripts/validate-manifests.sh` for agent/tool manifests.
-- [ ] Add unit tests for parsers/builders.
+- [x] Add unit tests for parsers/builders.
 - [x] Update web smoke tests for new routes.
 
 ### Phase 6: Seed Content

--- a/internal/agents/manifest.go
+++ b/internal/agents/manifest.go
@@ -1,0 +1,126 @@
+package agents
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func ParseAgentManifest(path string) (Manifest, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("open manifest %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var out Manifest
+	scanner := bufio.NewScanner(f)
+	currentList := ""
+	section := ""
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "  ") && strings.HasSuffix(trimmed, ":") {
+			key := strings.TrimSuffix(trimmed, ":")
+			if section == "dependencies" {
+				currentList = key
+				continue
+			}
+			section = key
+			currentList = ""
+			continue
+		}
+
+		if strings.HasPrefix(line, "    - ") {
+			item := strings.TrimSpace(strings.TrimPrefix(line, "    - "))
+			item = unquote(item)
+			if section == "dependencies" {
+				switch currentList {
+				case "skills":
+					out.DependencySkills = append(out.DependencySkills, item)
+				case "tools":
+					out.DependencyTools = append(out.DependencyTools, item)
+				}
+			}
+			continue
+		}
+
+		if strings.HasPrefix(line, "  - ") {
+			item := strings.TrimSpace(strings.TrimPrefix(line, "  - "))
+			item = unquote(item)
+			switch currentList {
+			case "tags":
+				out.Tags = append(out.Tags, item)
+			case "runtimes":
+				out.Runtimes = append(out.Runtimes, item)
+			}
+			continue
+		}
+
+		if strings.HasPrefix(line, "  ") && strings.Contains(trimmed, ":") {
+			parts := strings.SplitN(trimmed, ":", 2)
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+			_ = value
+			if section == "dependencies" && value == "" {
+				currentList = key
+			}
+			continue
+		}
+
+		parts := strings.SplitN(trimmed, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := unquote(strings.TrimSpace(parts[1]))
+		section = ""
+		currentList = ""
+
+		switch key {
+		case "id":
+			out.ID = value
+		case "name":
+			out.Name = value
+		case "description":
+			out.Description = value
+		case "version":
+			out.Version = value
+		case "released_at":
+			out.ReleasedAt = value
+		case "category":
+			out.Category = value
+		case "tags":
+			currentList = "tags"
+		case "runtimes":
+			currentList = "runtimes"
+		case "dependencies":
+			section = "dependencies"
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return Manifest{}, fmt.Errorf("scan manifest %s: %w", path, err)
+	}
+
+	if out.ID == "" || out.Name == "" || out.Version == "" {
+		return Manifest{}, fmt.Errorf("manifest %s missing required id/name/version", path)
+	}
+	return out, nil
+}
+
+func unquote(v string) string {
+	value := strings.TrimSpace(v)
+	if len(value) >= 2 {
+		if (value[0] == '"' && value[len(value)-1] == '"') ||
+			(value[0] == '\'' && value[len(value)-1] == '\'') {
+			return value[1 : len(value)-1]
+		}
+	}
+	return value
+}

--- a/internal/agents/manifest_test.go
+++ b/internal/agents/manifest_test.go
@@ -1,0 +1,44 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseAgentManifest(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	content := `id: marketing/demo-supervisor
+name: Demo Supervisor
+description: Demo agent.
+version: 0.1.0
+released_at: "2026-03-03T00:00:00Z"
+category: marketing-agents/performance
+tags:
+  - demo
+runtimes:
+  - codex
+dependencies:
+  skills:
+    - adtech/dashboard-generator
+  tools:
+    - ga4_query
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	m, err := ParseAgentManifest(path)
+	if err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	if m.ID != "marketing/demo-supervisor" {
+		t.Fatalf("unexpected id: %s", m.ID)
+	}
+	if len(m.DependencySkills) != 1 || m.DependencySkills[0] != "adtech/dashboard-generator" {
+		t.Fatalf("unexpected skills deps: %#v", m.DependencySkills)
+	}
+	if len(m.DependencyTools) != 1 || m.DependencyTools[0] != "ga4_query" {
+		t.Fatalf("unexpected tools deps: %#v", m.DependencyTools)
+	}
+}

--- a/internal/agents/run.go
+++ b/internal/agents/run.go
@@ -1,0 +1,195 @@
+package agents
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type RunOptions struct {
+	AgentsRoot     string
+	SkillsRoot     string
+	ToolsRoot      string
+	AgentID        string
+	BindingsPath   string
+	MemoryPath     string
+	GovernancePath string
+	ApproveLive    bool
+	AuditPath      string
+}
+
+func RunPreflight(opts RunOptions) (RunReport, error) {
+	agentDir := filepath.Join(opts.AgentsRoot, filepath.FromSlash(opts.AgentID))
+	manifestPath := filepath.Join(agentDir, "agent.yaml")
+	specPath := filepath.Join(agentDir, "AGENT.md")
+
+	m, err := ParseAgentManifest(manifestPath)
+	if err != nil {
+		return RunReport{}, err
+	}
+	report := RunReport{
+		AgentID:          m.ID,
+		Status:           "ready",
+		Checks:           []string{},
+		Warnings:         []string{},
+		BlockingReasons:  []string{},
+		DependencySkills: append([]string{}, m.DependencySkills...),
+		DependencyTools:  append([]string{}, m.DependencyTools...),
+		ResolvedTools:    map[string]ToolBinding{},
+	}
+
+	if _, err := os.Stat(specPath); err != nil {
+		report.Status = "blocked"
+		report.BlockingReasons = append(report.BlockingReasons, "Missing AGENT.md")
+	}
+
+	report.WorkflowSteps = extractWorkflowSteps(specPath)
+	if len(report.WorkflowSteps) == 0 {
+		report.Warnings = append(report.Warnings, "No workflow steps parsed from AGENT.md")
+	}
+
+	for _, dep := range m.DependencySkills {
+		p := filepath.Join(opts.SkillsRoot, filepath.FromSlash(dep))
+		if _, err := os.Stat(p); err != nil {
+			report.Status = "blocked"
+			report.BlockingReasons = append(report.BlockingReasons, fmt.Sprintf("Missing skill dependency: %s", dep))
+		}
+	}
+
+	bindings := ToolBindingsFile{Tools: map[string]ToolBinding{}}
+	if strings.TrimSpace(opts.BindingsPath) != "" {
+		if err := loadJSON(opts.BindingsPath, &bindings); err != nil {
+			return RunReport{}, fmt.Errorf("load bindings: %w", err)
+		}
+	} else {
+		report.Warnings = append(report.Warnings, "No tool bindings file supplied")
+	}
+
+	for _, depTool := range m.DependencyTools {
+		binding, ok := bindings.Tools[depTool]
+		if !ok {
+			report.Status = "blocked"
+			report.BlockingReasons = append(report.BlockingReasons, fmt.Sprintf("Missing tool binding: %s", depTool))
+			continue
+		}
+		report.ResolvedTools[depTool] = binding
+		if binding.Mode == "" {
+			report.Warnings = append(report.Warnings, fmt.Sprintf("Tool %s missing mode; expected read_only/read_write", depTool))
+		}
+		if strings.TrimSpace(binding.Endpoint) == "" {
+			report.Status = "blocked"
+			report.BlockingReasons = append(report.BlockingReasons, fmt.Sprintf("Tool %s missing endpoint", depTool))
+		}
+	}
+
+	var memory MemoryProfile
+	if strings.TrimSpace(opts.MemoryPath) != "" {
+		if err := loadJSON(opts.MemoryPath, &memory); err != nil {
+			return RunReport{}, fmt.Errorf("load memory profile: %w", err)
+		}
+		for _, f := range memory.ContextFiles {
+			if _, err := os.Stat(f); err != nil {
+				report.Warnings = append(report.Warnings, fmt.Sprintf("Missing memory context file: %s", f))
+			}
+		}
+	} else {
+		report.Warnings = append(report.Warnings, "No memory profile supplied")
+	}
+
+	governance := GovernanceProfile{
+		RequireApprovalForLive: true,
+		AllowWriteTools:        false,
+		MaxToolCalls:           100,
+	}
+	if strings.TrimSpace(opts.GovernancePath) != "" {
+		if err := loadJSON(opts.GovernancePath, &governance); err != nil {
+			return RunReport{}, fmt.Errorf("load governance profile: %w", err)
+		}
+	} else {
+		report.Warnings = append(report.Warnings, "No governance profile supplied; using safe defaults")
+	}
+
+	if governance.RequireApprovalForLive && !opts.ApproveLive {
+		report.Status = "blocked"
+		report.BlockingReasons = append(report.BlockingReasons, "Live approval is required (--approve-live not set)")
+	}
+	if !governance.AllowWriteTools {
+		for name, binding := range report.ResolvedTools {
+			if strings.EqualFold(binding.Mode, "read_write") {
+				report.Status = "blocked"
+				report.BlockingReasons = append(report.BlockingReasons, fmt.Sprintf("Write-capable tool blocked by governance: %s", name))
+			}
+		}
+	}
+
+	if len(report.BlockingReasons) == 0 {
+		report.Checks = append(report.Checks, "All preflight checks passed")
+	}
+	if strings.TrimSpace(opts.AuditPath) != "" {
+		if err := writeJSON(opts.AuditPath, report); err != nil {
+			return RunReport{}, fmt.Errorf("write audit report: %w", err)
+		}
+	}
+	return report, nil
+}
+
+func extractWorkflowSteps(agentSpecPath string) []string {
+	f, err := os.Open(agentSpecPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	steps := []string{}
+	scanner := bufio.NewScanner(f)
+	inWorkflow := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "## ") {
+			inWorkflow = strings.EqualFold(strings.TrimSpace(strings.TrimPrefix(trimmed, "## ")), "Workflow")
+			continue
+		}
+		if !inWorkflow {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "1.") ||
+			strings.HasPrefix(trimmed, "2.") ||
+			strings.HasPrefix(trimmed, "3.") ||
+			strings.HasPrefix(trimmed, "4.") ||
+			strings.HasPrefix(trimmed, "5.") ||
+			strings.HasPrefix(trimmed, "6.") ||
+			strings.HasPrefix(trimmed, "7.") ||
+			strings.HasPrefix(trimmed, "8.") ||
+			strings.HasPrefix(trimmed, "9.") {
+			steps = append(steps, strings.TrimSpace(trimmed[2:]))
+		}
+	}
+	return steps
+}
+
+func loadJSON(path string, out any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	return nil
+}
+
+func writeJSON(path string, v any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}

--- a/internal/agents/run_test.go
+++ b/internal/agents/run_test.go
@@ -1,0 +1,63 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunPreflightReady(t *testing.T) {
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agents", "marketing", "demo")
+	skillDir := filepath.Join(root, "skills", "adtech", "dashboard-generator")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent: %v", err)
+	}
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "AGENT.md"), []byte("## Workflow\n1. Step A\n2. Step B\n"), 0o644); err != nil {
+		t.Fatalf("write AGENT.md: %v", err)
+	}
+	manifest := `id: marketing/demo
+name: Demo
+description: Demo.
+version: 0.1.0
+released_at: "2026-03-03T00:00:00Z"
+category: marketing-agents/performance
+tags:
+  - demo
+runtimes:
+  - codex
+dependencies:
+  skills:
+    - adtech/dashboard-generator
+  tools:
+    - ga4_query
+`
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	bindingsPath := filepath.Join(root, "bindings.json")
+	if err := os.WriteFile(bindingsPath, []byte(`{"tools":{"ga4_query":{"endpoint":"mcp://ga4","mode":"read_only"}}}`), 0o644); err != nil {
+		t.Fatalf("write bindings: %v", err)
+	}
+	report, err := RunPreflight(RunOptions{
+		AgentsRoot:     filepath.Join(root, "agents"),
+		SkillsRoot:     filepath.Join(root, "skills"),
+		ToolsRoot:      filepath.Join(root, "tools-mcp"),
+		AgentID:        "marketing/demo",
+		BindingsPath:   bindingsPath,
+		ApproveLive:    true,
+		GovernancePath: "",
+	})
+	if err != nil {
+		t.Fatalf("run preflight: %v", err)
+	}
+	if report.Status != "ready" {
+		t.Fatalf("expected ready, got %s (%v)", report.Status, report.BlockingReasons)
+	}
+	if len(report.WorkflowSteps) != 2 {
+		t.Fatalf("expected workflow steps, got %#v", report.WorkflowSteps)
+	}
+}

--- a/internal/agents/types.go
+++ b/internal/agents/types.go
@@ -1,0 +1,47 @@
+package agents
+
+type Manifest struct {
+	ID               string
+	Name             string
+	Description      string
+	Version          string
+	ReleasedAt       string
+	Category         string
+	Tags             []string
+	Runtimes         []string
+	DependencySkills []string
+	DependencyTools  []string
+}
+
+type ToolBinding struct {
+	Endpoint string `json:"endpoint"`
+	Mode     string `json:"mode"` // read_only | read_write
+}
+
+type ToolBindingsFile struct {
+	Tools map[string]ToolBinding `json:"tools"`
+}
+
+type MemoryProfile struct {
+	ContextFiles  []string `json:"context_files"`
+	StateStore    string   `json:"state_store"`
+	RetentionDays int      `json:"retention_days"`
+}
+
+type GovernanceProfile struct {
+	RequireApprovalForLive bool `json:"require_approval_for_live"`
+	AllowWriteTools        bool `json:"allow_write_tools"`
+	MaxToolCalls           int  `json:"max_tool_calls"`
+}
+
+type RunReport struct {
+	AgentID          string                 `json:"agent_id"`
+	Status           string                 `json:"status"` // ready | blocked | failed
+	Checks           []string               `json:"checks"`
+	Warnings         []string               `json:"warnings"`
+	BlockingReasons  []string               `json:"blocking_reasons"`
+	DependencySkills []string               `json:"dependency_skills"`
+	DependencyTools  []string               `json:"dependency_tools"`
+	ResolvedTools    map[string]ToolBinding `json:"resolved_tools"`
+	WorkflowSteps    []string               `json:"workflow_steps"`
+}

--- a/internal/registry/builder_test.go
+++ b/internal/registry/builder_test.go
@@ -1,0 +1,106 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildAgentsIndex(t *testing.T) {
+	root := t.TempDir()
+	entryDir := filepath.Join(root, "agents", "marketing", "demo-agent")
+	if err := os.MkdirAll(entryDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mf := `id: marketing/demo-agent
+name: Demo Agent
+description: Demo agent manifest used for index generation tests.
+version: 0.1.0
+released_at: "2026-03-02T00:00:00Z"
+category: marketing-agents/performance
+tags:
+  - demo
+license: MIT
+author:
+  name: Tests
+runtimes:
+  - codex
+entrypoints:
+  spec: AGENT.md
+deprecated: false
+`
+	if err := os.WriteFile(filepath.Join(entryDir, "agent.yaml"), []byte(mf), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entryDir, "AGENT.md"), []byte("# Demo\n"), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+
+	idx, err := BuildAgentsIndex(root)
+	if err != nil {
+		t.Fatalf("build index: %v", err)
+	}
+	if len(idx.Skills) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(idx.Skills))
+	}
+	entry := idx.Skills[0]
+	if entry.ID != "marketing/demo-agent" {
+		t.Fatalf("unexpected id: %s", entry.ID)
+	}
+	if !strings.Contains(entry.Versions[0].ManifestURL, "/agents/marketing/demo-agent/agent.yaml") {
+		t.Fatalf("unexpected manifest url: %s", entry.Versions[0].ManifestURL)
+	}
+	if !strings.Contains(entry.Versions[0].ArtifactURL, "/artifacts/marketing/demo-agent/0.1.0.tar.gz") {
+		t.Fatalf("unexpected artifact url: %s", entry.Versions[0].ArtifactURL)
+	}
+}
+
+func TestBuildToolsIndex(t *testing.T) {
+	root := t.TempDir()
+	entryDir := filepath.Join(root, "tools-mcp", "analytics", "demo-tool")
+	if err := os.MkdirAll(entryDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mf := `id: analytics/demo-tool
+name: Demo Tool
+description: Demo tool manifest used for index generation tests.
+version: 0.1.0
+released_at: "2026-03-02T00:00:00Z"
+category: tools-mcp/analytics
+tags:
+  - demo
+license: MIT
+author:
+  name: Tests
+runtimes:
+  - codex
+entrypoints:
+  spec: TOOL.md
+deprecated: false
+`
+	if err := os.WriteFile(filepath.Join(entryDir, "tool.yaml"), []byte(mf), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entryDir, "TOOL.md"), []byte("# Demo\n"), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+
+	idx, err := BuildToolsIndex(root)
+	if err != nil {
+		t.Fatalf("build index: %v", err)
+	}
+	if len(idx.Skills) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(idx.Skills))
+	}
+	entry := idx.Skills[0]
+	if entry.ID != "analytics/demo-tool" {
+		t.Fatalf("unexpected id: %s", entry.ID)
+	}
+	if !strings.Contains(entry.Versions[0].ManifestURL, "/tools-mcp/analytics/demo-tool/tool.yaml") {
+		t.Fatalf("unexpected manifest url: %s", entry.Versions[0].ManifestURL)
+	}
+	if !strings.Contains(entry.Versions[0].ArtifactURL, "/artifacts/analytics/demo-tool/0.1.0.tar.gz") {
+		t.Fatalf("unexpected artifact url: %s", entry.Versions[0].ArtifactURL)
+	}
+}

--- a/registry/agents-index.json
+++ b/registry/agents-index.json
@@ -14,7 +14,7 @@
           "released_at": "2026-03-02T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/agents/adtech/bi-insights-orchestrator/agent.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/bi-insights-orchestrator/0.1.0.tar.gz",
-          "sha256": "dfe8275313e50fe7ca6044946e56a722e9201f640e19e6a254d85cbb6fb98336"
+          "sha256": "87084e1dfb9321ffae095eaf851a3b13415c8320323fb6772a655d13099eadca"
         }
       ],
       "runtimes": [
@@ -41,7 +41,7 @@
           "released_at": "2026-03-02T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/agents/marketing/campaign-qa-supervisor/agent.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/campaign-qa-supervisor/0.1.0.tar.gz",
-          "sha256": "2ce4cba13aa763f3e4443c8b2781853fc0fc15dac3f42c27cb9067a64b8dbcdc"
+          "sha256": "322d35a70c0913c992bd065d2791758616dea462d847b73598ef6639ce327e66"
         }
       ],
       "runtimes": [
@@ -68,7 +68,7 @@
           "released_at": "2026-03-02T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/agents/marketing/weekly-performance-supervisor/agent.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/weekly-performance-supervisor/0.1.0.tar.gz",
-          "sha256": "16de9fb13df6dd4864a4b51d0706a7846c1fc048b22d7ff9b1ebe082da3d33af"
+          "sha256": "40dad67f9624f7c238542a22943b8ee391e3df9f2c9a876102bfc63f4c5f8da5"
         }
       ],
       "runtimes": [

--- a/registry/index.json
+++ b/registry/index.json
@@ -14,7 +14,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/analyst-copilot-bigquery-redshift/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/analyst-copilot-bigquery-redshift/0.1.0.tar.gz",
-          "sha256": "5f71bceb61e489bb69104d690ec0eb863056b8bdd6b886587306f99d5cba58ca"
+          "sha256": "8ba663e9403a1c5e18a8b95500f4080dff3e480447cb8ae3814b19f55b652687"
         }
       ],
       "runtimes": [
@@ -42,7 +42,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/brand-rag-memory-bootstrap/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/brand-rag-memory-bootstrap/0.1.0.tar.gz",
-          "sha256": "05de3932e35bfd3b52a58332624d69502847f1a2c2f71d74eb0427fcc3f125be"
+          "sha256": "64c1551dfb816cbb4eacd7f5bae1a45dd322dcf0a9bdcd771ecc9ecbed44188d"
         }
       ],
       "runtimes": [
@@ -71,7 +71,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/dashboard-generator/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/dashboard-generator/0.1.0.tar.gz",
-          "sha256": "e08ba5c6eeeea0093bac7600b4c386b39e2ccbb361984718a70adb2f67bcc660"
+          "sha256": "e0b5283ce8bb3d2d5c5d149dc164d9095e8535c8c52840fc0c8d73311c4aa665"
         }
       ],
       "runtimes": [
@@ -99,7 +99,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/dashboard-qa-checker/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/dashboard-qa-checker/0.1.0.tar.gz",
-          "sha256": "af17084525dc6ac7c29cf2f3fbab3882841b1d9cf6415230f06082aa908a807f"
+          "sha256": "6503483b9c90ceb17a964954f9cbd35c4103915512e4f415cdb553975f6e14e5"
         }
       ],
       "runtimes": [
@@ -127,7 +127,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/executive-narrative-writer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/executive-narrative-writer/0.1.0.tar.gz",
-          "sha256": "6f9676ad4b76dc9884ac554a4033eb56dab805eeeefc729513cac35831fd2240"
+          "sha256": "9645db97cf9337f29ee41217d03e887e41abd763739340930014c41f58403bc6"
         }
       ],
       "runtimes": [
@@ -155,7 +155,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/playwright-agentic-e2e/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/playwright-agentic-e2e/0.1.0.tar.gz",
-          "sha256": "d3d52ad5a6aab365b24dfdaf99dac9e40ae8758b83c6b577ac97bc57c3d2d6fa"
+          "sha256": "fe21689cd37baa5e7a0d3adf9809f6d0d40004e525d553893d6357b19b942252"
         }
       ],
       "runtimes": [
@@ -184,7 +184,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/playwright-vscode-loop-codex/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/playwright-vscode-loop-codex/0.1.0.tar.gz",
-          "sha256": "93ef3df77fd46d685ae4f49524807bc350e7dd954c57c4306760f3a98e76dba4"
+          "sha256": "8659f15552be13c06cee94710e4bbe3b62031cdd37ad207ab1eb8825f007c617"
         }
       ],
       "runtimes": [
@@ -213,7 +213,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/policy-brand-compliance-checker/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/policy-brand-compliance-checker/0.1.0.tar.gz",
-          "sha256": "288d5795725c8348d2ff02a553d00142a88ef9027e4244d7d86354645b52d9ac"
+          "sha256": "0298e115ffc9c6a1d1fefb1dd91c946d12fe6d7b54023fc96dddce56be767b48"
         }
       ],
       "runtimes": [
@@ -241,7 +241,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/weekly-performance-review-bi/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/weekly-performance-review-bi/0.1.0.tar.gz",
-          "sha256": "4c45ca487b0ef4167c6be77d57e89037c63238b7c4b602b57001ff7f57baa6a2"
+          "sha256": "836587a6370e8284cccd4b3633aacf12c948367863bef840019314ef485f82e8"
         }
       ],
       "runtimes": [
@@ -270,7 +270,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ab-test-planner-analyzer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ab-test-planner-analyzer/0.1.0.tar.gz",
-          "sha256": "774114da87c62eac1cda68ca379c2d87241287cfdadcfafee968358d222f0e3c"
+          "sha256": "51d6bdeb5261331cdcb7b23da8c8a7c926cec32796747670b53863b044ff8623"
         }
       ],
       "runtimes": [
@@ -299,7 +299,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ai-output-eval-scorecard/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ai-output-eval-scorecard/0.1.0.tar.gz",
-          "sha256": "5a1b8950e7914ebdfeb6864f137d5b117c1fddb3a68b8093e7569e363c2ffe05"
+          "sha256": "fd567640fedf2e053392ff2bf85f708595019cb5550d162bee73d340502be507"
         }
       ],
       "runtimes": [
@@ -328,7 +328,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/creative-workshop-pmax-reels/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creative-workshop-pmax-reels/0.1.0.tar.gz",
-          "sha256": "64e981fc44af92bbb6a6aff0baefc3229771a0a59aa50cc270b1a09535c34a75"
+          "sha256": "dbdcac3bb53a412349f5e83f1d6e7a0144dbc8099863facabf509a26177bfda8"
         }
       ],
       "runtimes": [
@@ -356,7 +356,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/cross-channel-budget-pacing-agent/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/cross-channel-budget-pacing-agent/0.1.0.tar.gz",
-          "sha256": "7ac6b0350925f9c53e875abf8c57d5bbfe9e5721eba2acb2ea58d6079dee04f8"
+          "sha256": "5dea3e1335e309c891e2ea28bfb98c975c47d4812a544f5980608c2bc0f6fd34"
         }
       ],
       "runtimes": [
@@ -385,7 +385,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/dynamic-creative-rules-engine/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/dynamic-creative-rules-engine/0.1.0.tar.gz",
-          "sha256": "e15dfe6bb25335f6061f78222fef48a8bd7c97e571e19d23790fd9c9c057590e"
+          "sha256": "578d6115038f6bbdd3d230ed4f1ffad8941f3556b60747cbac9ccc15e3a3eed0"
         }
       ],
       "runtimes": [
@@ -414,7 +414,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/lifecycle-experiment-planner/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/lifecycle-experiment-planner/0.1.0.tar.gz",
-          "sha256": "a59868da91877823558670707e8f32531bef2c77049dcfaa6e9e3d426d4f91a6"
+          "sha256": "5ff0c3ab6205443cf3ca12b402581ae32d3d1d45aabceb8f047eb383dcdcfd73"
         }
       ],
       "runtimes": [
@@ -442,7 +442,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/lifecycle-journey-trigger-designer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/lifecycle-journey-trigger-designer/0.1.0.tar.gz",
-          "sha256": "276a554d450d20db68f66116718e7bd9ea73b5e5b8b380587660b981c09151c5"
+          "sha256": "04de39a058fae73fe1ec4c44a05901d6d08054446b1428808d29c1271bb21f0c"
         }
       ],
       "runtimes": [
@@ -471,7 +471,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/meta-google-weekly-performance-review/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/meta-google-weekly-performance-review/0.1.0.tar.gz",
-          "sha256": "b4c90869ffab316f78f9439a1c96c021921249de5eb974a4e595c632ef8da057"
+          "sha256": "ffb2174126c35ce575ce2dbfa90f42425fba849e9cac2dea816114ce14fa680d"
         }
       ],
       "runtimes": [
@@ -499,7 +499,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/seo-paid-search-synergy/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/seo-paid-search-synergy/0.1.0.tar.gz",
-          "sha256": "b4496217276d81c17ace07a41f1f526388cae5b51192ea7bc7bd5f28cd16b9f7"
+          "sha256": "ce3f88909c5ffbd907efd28e1f5f18cc76d9a35827435131e7e5276f70183327"
         }
       ],
       "runtimes": [

--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -14,7 +14,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/analyst-copilot-bigquery-redshift/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/analyst-copilot-bigquery-redshift/0.1.0.tar.gz",
-          "sha256": "5f71bceb61e489bb69104d690ec0eb863056b8bdd6b886587306f99d5cba58ca"
+          "sha256": "8ba663e9403a1c5e18a8b95500f4080dff3e480447cb8ae3814b19f55b652687"
         }
       ],
       "runtimes": [
@@ -42,7 +42,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/brand-rag-memory-bootstrap/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/brand-rag-memory-bootstrap/0.1.0.tar.gz",
-          "sha256": "05de3932e35bfd3b52a58332624d69502847f1a2c2f71d74eb0427fcc3f125be"
+          "sha256": "64c1551dfb816cbb4eacd7f5bae1a45dd322dcf0a9bdcd771ecc9ecbed44188d"
         }
       ],
       "runtimes": [
@@ -71,7 +71,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/dashboard-generator/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/dashboard-generator/0.1.0.tar.gz",
-          "sha256": "e08ba5c6eeeea0093bac7600b4c386b39e2ccbb361984718a70adb2f67bcc660"
+          "sha256": "e0b5283ce8bb3d2d5c5d149dc164d9095e8535c8c52840fc0c8d73311c4aa665"
         }
       ],
       "runtimes": [
@@ -99,7 +99,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/dashboard-qa-checker/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/dashboard-qa-checker/0.1.0.tar.gz",
-          "sha256": "af17084525dc6ac7c29cf2f3fbab3882841b1d9cf6415230f06082aa908a807f"
+          "sha256": "6503483b9c90ceb17a964954f9cbd35c4103915512e4f415cdb553975f6e14e5"
         }
       ],
       "runtimes": [
@@ -127,7 +127,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/executive-narrative-writer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/executive-narrative-writer/0.1.0.tar.gz",
-          "sha256": "6f9676ad4b76dc9884ac554a4033eb56dab805eeeefc729513cac35831fd2240"
+          "sha256": "9645db97cf9337f29ee41217d03e887e41abd763739340930014c41f58403bc6"
         }
       ],
       "runtimes": [
@@ -155,7 +155,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/playwright-agentic-e2e/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/playwright-agentic-e2e/0.1.0.tar.gz",
-          "sha256": "d3d52ad5a6aab365b24dfdaf99dac9e40ae8758b83c6b577ac97bc57c3d2d6fa"
+          "sha256": "fe21689cd37baa5e7a0d3adf9809f6d0d40004e525d553893d6357b19b942252"
         }
       ],
       "runtimes": [
@@ -184,7 +184,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/playwright-vscode-loop-codex/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/playwright-vscode-loop-codex/0.1.0.tar.gz",
-          "sha256": "93ef3df77fd46d685ae4f49524807bc350e7dd954c57c4306760f3a98e76dba4"
+          "sha256": "8659f15552be13c06cee94710e4bbe3b62031cdd37ad207ab1eb8825f007c617"
         }
       ],
       "runtimes": [
@@ -213,7 +213,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/policy-brand-compliance-checker/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/policy-brand-compliance-checker/0.1.0.tar.gz",
-          "sha256": "288d5795725c8348d2ff02a553d00142a88ef9027e4244d7d86354645b52d9ac"
+          "sha256": "0298e115ffc9c6a1d1fefb1dd91c946d12fe6d7b54023fc96dddce56be767b48"
         }
       ],
       "runtimes": [
@@ -241,7 +241,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/weekly-performance-review-bi/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/weekly-performance-review-bi/0.1.0.tar.gz",
-          "sha256": "4c45ca487b0ef4167c6be77d57e89037c63238b7c4b602b57001ff7f57baa6a2"
+          "sha256": "836587a6370e8284cccd4b3633aacf12c948367863bef840019314ef485f82e8"
         }
       ],
       "runtimes": [
@@ -270,7 +270,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ab-test-planner-analyzer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ab-test-planner-analyzer/0.1.0.tar.gz",
-          "sha256": "774114da87c62eac1cda68ca379c2d87241287cfdadcfafee968358d222f0e3c"
+          "sha256": "51d6bdeb5261331cdcb7b23da8c8a7c926cec32796747670b53863b044ff8623"
         }
       ],
       "runtimes": [
@@ -299,7 +299,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ai-output-eval-scorecard/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ai-output-eval-scorecard/0.1.0.tar.gz",
-          "sha256": "5a1b8950e7914ebdfeb6864f137d5b117c1fddb3a68b8093e7569e363c2ffe05"
+          "sha256": "fd567640fedf2e053392ff2bf85f708595019cb5550d162bee73d340502be507"
         }
       ],
       "runtimes": [
@@ -328,7 +328,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/creative-workshop-pmax-reels/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creative-workshop-pmax-reels/0.1.0.tar.gz",
-          "sha256": "64e981fc44af92bbb6a6aff0baefc3229771a0a59aa50cc270b1a09535c34a75"
+          "sha256": "dbdcac3bb53a412349f5e83f1d6e7a0144dbc8099863facabf509a26177bfda8"
         }
       ],
       "runtimes": [
@@ -356,7 +356,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/cross-channel-budget-pacing-agent/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/cross-channel-budget-pacing-agent/0.1.0.tar.gz",
-          "sha256": "7ac6b0350925f9c53e875abf8c57d5bbfe9e5721eba2acb2ea58d6079dee04f8"
+          "sha256": "5dea3e1335e309c891e2ea28bfb98c975c47d4812a544f5980608c2bc0f6fd34"
         }
       ],
       "runtimes": [
@@ -385,7 +385,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/dynamic-creative-rules-engine/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/dynamic-creative-rules-engine/0.1.0.tar.gz",
-          "sha256": "e15dfe6bb25335f6061f78222fef48a8bd7c97e571e19d23790fd9c9c057590e"
+          "sha256": "578d6115038f6bbdd3d230ed4f1ffad8941f3556b60747cbac9ccc15e3a3eed0"
         }
       ],
       "runtimes": [
@@ -414,7 +414,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/lifecycle-experiment-planner/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/lifecycle-experiment-planner/0.1.0.tar.gz",
-          "sha256": "a59868da91877823558670707e8f32531bef2c77049dcfaa6e9e3d426d4f91a6"
+          "sha256": "5ff0c3ab6205443cf3ca12b402581ae32d3d1d45aabceb8f047eb383dcdcfd73"
         }
       ],
       "runtimes": [
@@ -442,7 +442,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/lifecycle-journey-trigger-designer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/lifecycle-journey-trigger-designer/0.1.0.tar.gz",
-          "sha256": "276a554d450d20db68f66116718e7bd9ea73b5e5b8b380587660b981c09151c5"
+          "sha256": "04de39a058fae73fe1ec4c44a05901d6d08054446b1428808d29c1271bb21f0c"
         }
       ],
       "runtimes": [
@@ -471,7 +471,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/meta-google-weekly-performance-review/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/meta-google-weekly-performance-review/0.1.0.tar.gz",
-          "sha256": "b4c90869ffab316f78f9439a1c96c021921249de5eb974a4e595c632ef8da057"
+          "sha256": "ffb2174126c35ce575ce2dbfa90f42425fba849e9cac2dea816114ce14fa680d"
         }
       ],
       "runtimes": [
@@ -499,7 +499,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/seo-paid-search-synergy/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/seo-paid-search-synergy/0.1.0.tar.gz",
-          "sha256": "b4496217276d81c17ace07a41f1f526388cae5b51192ea7bc7bd5f28cd16b9f7"
+          "sha256": "ce3f88909c5ffbd907efd28e1f5f18cc76d9a35827435131e7e5276f70183327"
         }
       ],
       "runtimes": [

--- a/registry/tools-index.json
+++ b/registry/tools-index.json
@@ -14,7 +14,7 @@
           "released_at": "2026-03-02T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/ads/meta-ads-mcp-connector/tool.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/ads/meta-ads-mcp-connector/0.1.0.tar.gz",
-          "sha256": "8d6f3f0a74b78e168934bc2fe05fab084324cc59df0afdf8e1d338f902a0fe94"
+          "sha256": "ff1ade3ce21346ebebb2470e075528519b4173aca32225bbd7831e2122520d37"
         }
       ],
       "runtimes": [
@@ -41,7 +41,7 @@
           "released_at": "2026-03-02T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/analytics/ga4-mcp-connector/tool.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/analytics/ga4-mcp-connector/0.1.0.tar.gz",
-          "sha256": "da4f0c3cb7f8b0a9c1ae8049fb00d700e6e505d8d3394ebdb29723a22d5f33c2"
+          "sha256": "7eb4e30ea92d68a580afe63ceaf1c24cea5f60b60ecac0de53d733af293faae1"
         }
       ],
       "runtimes": [
@@ -68,7 +68,7 @@
           "released_at": "2026-03-02T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/warehouse/bigquery-mcp-query-runner/tool.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/warehouse/bigquery-mcp-query-runner/0.1.0.tar.gz",
-          "sha256": "10b572e64c8e30fdb6c53920f55375ed4e605be2edcf2325baf19691f62c88bc"
+          "sha256": "8cbdafb2f2aa032e8cf36c3ea5db03b2c76a21857c5d06a5cdc59a4a1b29d14f"
         }
       ],
       "runtimes": [

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -4,48 +4,63 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 FAIL=0
 
-while IFS= read -r -d '' skill_dir; do
-  required=("SKILL.md" "README.md" "skill.yaml" "tests/test-prompts.md")
-  for f in "${required[@]}"; do
-    if [[ ! -f "$skill_dir/$f" ]]; then
-      echo "[ERROR] Missing $f in ${skill_dir#$ROOT/}"
-      FAIL=1
-    fi
-  done
+validate_module_structure() {
+  local module_root="$1"
+  local label="$2"
+  local spec_file="$3"
+  local manifest_file="$4"
 
-  if [[ ! -d "$skill_dir/examples" ]]; then
-    echo "[ERROR] Missing examples/ in ${skill_dir#$ROOT/}"
-    FAIL=1
+  if [[ ! -d "$module_root" ]]; then
+    echo "[info] Skipping $label validation; ${module_root#$ROOT/}/ does not exist."
+    return 0
   fi
 
-  if [[ -f "$skill_dir/SKILL.md" ]]; then
-    if ! grep -q "^---" "$skill_dir/SKILL.md"; then
-      echo "[ERROR] Missing frontmatter in ${skill_dir#$ROOT/}/SKILL.md"
-      FAIL=1
-    fi
-    if ! grep -qi "## When to use" "$skill_dir/SKILL.md"; then
-      echo "[ERROR] Missing 'When to use' section in ${skill_dir#$ROOT/}/SKILL.md"
-      FAIL=1
-    fi
-    if ! grep -qi "## Guardrails" "$skill_dir/SKILL.md"; then
-      echo "[ERROR] Missing 'Guardrails' section in ${skill_dir#$ROOT/}/SKILL.md"
-      FAIL=1
-    fi
-  fi
+  while IFS= read -r -d '' entry_dir; do
+    required=("$spec_file" "README.md" "$manifest_file" "tests/test-prompts.md")
+    for f in "${required[@]}"; do
+      if [[ ! -f "$entry_dir/$f" ]]; then
+        echo "[ERROR] Missing $f in ${entry_dir#$ROOT/}"
+        FAIL=1
+      fi
+    done
 
-  prompt_file="$skill_dir/tests/test-prompts.md"
-  if [[ -f "$prompt_file" ]]; then
-    prompt_count="$(grep -Ec '^[0-9]+\.' "$prompt_file" || true)"
-    if [[ "$prompt_count" -lt 5 ]]; then
-      echo "[ERROR] Need at least 5 numbered prompts in ${prompt_file#$ROOT/} (found $prompt_count)"
+    if [[ ! -d "$entry_dir/examples" ]]; then
+      echo "[ERROR] Missing examples/ in ${entry_dir#$ROOT/}"
       FAIL=1
     fi
-  fi
 
-done < <(find "$ROOT/skills" -mindepth 2 -maxdepth 2 -type d -print0)
+    if [[ -f "$entry_dir/$spec_file" ]]; then
+      if [[ "$spec_file" == "SKILL.md" ]] && ! grep -q "^---" "$entry_dir/$spec_file"; then
+        echo "[ERROR] Missing frontmatter in ${entry_dir#$ROOT/}/$spec_file"
+        FAIL=1
+      fi
+      if [[ "$spec_file" == "SKILL.md" ]] && ! grep -qi "## When to use" "$entry_dir/$spec_file"; then
+        echo "[ERROR] Missing 'When to use' section in ${entry_dir#$ROOT/}/$spec_file"
+        FAIL=1
+      fi
+      if ! grep -qi "## Guardrails" "$entry_dir/$spec_file"; then
+        echo "[ERROR] Missing 'Guardrails' section in ${entry_dir#$ROOT/}/$spec_file"
+        FAIL=1
+      fi
+    fi
+
+    prompt_file="$entry_dir/tests/test-prompts.md"
+    if [[ -f "$prompt_file" ]]; then
+      prompt_count="$(grep -Ec '^[0-9]+\.' "$prompt_file" || true)"
+      if [[ "$prompt_count" -lt 5 ]]; then
+        echo "[ERROR] Need at least 5 numbered prompts in ${prompt_file#$ROOT/} (found $prompt_count)"
+        FAIL=1
+      fi
+    fi
+  done < <(find "$module_root" -mindepth 2 -maxdepth 2 -type d -print0)
+}
+
+validate_module_structure "$ROOT/skills" "skills" "SKILL.md" "skill.yaml"
+validate_module_structure "$ROOT/agents" "agents" "AGENT.md" "agent.yaml"
+validate_module_structure "$ROOT/tools-mcp" "tools-mcp" "TOOL.md" "tool.yaml"
 
 if [[ "$FAIL" -eq 0 ]]; then
-  echo "All skills passed structural validation."
+  echo "All module entries passed structural validation."
 else
   exit 1
 fi

--- a/skills/adtech/analyst-copilot-bigquery-redshift/README.md
+++ b/skills/adtech/analyst-copilot-bigquery-redshift/README.md
@@ -1,3 +1,48 @@
 # Analyst Co-pilot on BigQuery/Redshift
 
-Transforms analyst requests into safe, structured query workflows.
+Use this skill to turn analyst questions into safe SQL drafts and
+stakeholder-ready findings.
+
+## What this skill does
+
+- Clarifies business questions and target metrics.
+- Drafts SQL for BigQuery or Redshift.
+- Validates metric logic and join safety.
+- Produces concise findings with caveats.
+
+## Before you start
+
+1. Confirm schema context and date range.
+2. Decide SQL dialect: `bigquery` or `redshift`.
+3. Start in read-only mode.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  adtech/analyst-copilot-bigquery-redshift@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Analyst Co-pilot on BigQuery/Redshift.
+Business question: Why did conversion rate drop last week?
+Dialect: bigquery
+Date range: 2026-02-23 to 2026-03-01
+Return SQL draft, logic assumptions, and a stakeholder summary.
+```
+
+## What good output looks like
+
+- SQL is syntactically valid for selected dialect.
+- Assumptions are explicit.
+- Caveats are clearly stated.
+- No destructive operations.
+
+## Beginner safety checklist
+
+- Do not run write queries.
+- Verify table names before execution.
+- Ask for missing schema fields explicitly.

--- a/skills/adtech/brand-rag-memory-bootstrap/README.md
+++ b/skills/adtech/brand-rag-memory-bootstrap/README.md
@@ -1,3 +1,45 @@
 # Brand RAG Memory Bootstrap
 
-Bootstraps a private brand and campaign memory structure that agent skills can query before generating outputs.
+Use this skill to set up a private brand memory system that other skills
+can query before generating outputs.
+
+## What this skill does
+
+- Audits and classifies brand/policy/campaign documents.
+- Defines metadata schema and chunking strategy.
+- Produces retrieval quality and refresh plans.
+
+## Before you start
+
+1. Collect approved source documents.
+2. Define taxonomy labels (brand, channel, audience, date).
+3. Define refresh cadence and ownership.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  adtech/brand-rag-memory-bootstrap@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Brand RAG Memory Bootstrap.
+Sources: brand guidelines, policy docs, campaign history.
+Return source inventory, metadata schema, chunking plan,
+retrieval eval plan, and refresh schedule.
+```
+
+## What good output looks like
+
+- Source inventory is complete and categorized.
+- Metadata keys are consistent.
+- Retrieval plan includes evaluation checks.
+
+## Beginner safety checklist
+
+- Use only approved private documents.
+- Require citation paths for key claims.
+- Flag stale sources before use.

--- a/skills/adtech/dashboard-generator/README.md
+++ b/skills/adtech/dashboard-generator/README.md
@@ -1,15 +1,49 @@
 # Dashboard Generator
 
-Generates deterministic weekly performance dashboard sections and a publish-ready payload from normalized marketing data.
+Use this skill to build deterministic weekly dashboard sections from a
+normalized performance table.
 
-## Inputs
-- normalized table
-- current and previous date windows
-- optional anomaly thresholds
+## What this skill does
 
-## Outputs
-- executive summary
-- channel table
-- anomaly panel
-- action panel
-- stable publish payload
+- Computes canonical KPIs (CTR, CPC, CVR, CPA, ROAS).
+- Builds fixed output sections in stable order.
+- Produces a publish-ready payload for BI tools.
+
+## Before you start
+
+1. Ensure required columns exist in your normalized table.
+2. Set current and previous date windows.
+3. Confirm anomaly thresholds (optional).
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  adtech/dashboard-generator@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Dashboard Generator.
+Current window: 2026-02-23 to 2026-03-01
+Previous window: 2026-02-16 to 2026-02-22
+Output sections in this order:
+1) Executive Summary
+2) Channel Table
+3) Anomaly Panel
+4) Action Panel
+```
+
+## What good output looks like
+
+- Section ordering is deterministic.
+- KPI formulas are consistent.
+- Missing data is explicitly flagged.
+
+## Beginner safety checklist
+
+- Never invent missing channels.
+- Keep metric definitions unchanged.
+- Preserve output schema for weekly comparability.

--- a/skills/adtech/dashboard-qa-checker/README.md
+++ b/skills/adtech/dashboard-qa-checker/README.md
@@ -1,17 +1,45 @@
 # Dashboard QA Checker
 
-Runs a fixed set of pre-publish QA validations for marketing dashboard data and returns a clear publish decision.
+Use this skill to run pre-publish QA checks and decide whether dashboard
+publishing should be approved or blocked.
 
-## Checks
-- freshness
-- completeness
-- reconciliation
-- anomaly thresholds
-- schema drift
+## What this skill does
 
-## Outputs
-- QA summary
-- check-level evidence
-- blocking reasons
-- alert payload
-- publish decision
+- Checks freshness, completeness, reconciliation, anomalies, and drift.
+- Returns pass/warn/fail evidence by rule.
+- Produces blocking reasons and alert payloads.
+
+## Before you start
+
+1. Gather source totals and dashboard totals.
+2. Set thresholds and criticality rules.
+3. Confirm expected data freshness SLA.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  adtech/dashboard-qa-checker@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Dashboard QA Checker for run weekly-2026-03-01.
+Apply checks: freshness, completeness, reconciliation,
+anomaly detection, schema drift.
+Return publish decision and alert payload if blocked.
+```
+
+## What good output looks like
+
+- Each failed check includes evidence values.
+- Critical blockers are clearly separated from warnings.
+- Publish decision is explicit.
+
+## Beginner safety checklist
+
+- Do not downgrade critical failures.
+- Do not publish on critical reconciliation mismatch.
+- Require explicit override to proceed after block.

--- a/skills/adtech/executive-narrative-writer/README.md
+++ b/skills/adtech/executive-narrative-writer/README.md
@@ -1,15 +1,46 @@
 # Executive Narrative Writer
 
-Turns QA-approved dashboard outputs into short leadership-ready narratives with clear actions.
+Use this skill to convert QA-approved dashboard outputs into concise,
+leadership-ready narratives.
 
-## Inputs
-- validated dashboard sections
-- KPI deltas and anomalies
-- business goals and constraints
+## What this skill does
 
-## Outputs
-- headline
-- executive summary
-- driver breakdown
-- risks and unknowns
-- next actions with owners
+- Summarizes KPI movement and drivers.
+- Distinguishes facts from hypotheses.
+- Produces risks, unknowns, and next actions.
+
+## Before you start
+
+1. Ensure QA status is approved.
+2. Provide KPI deltas and anomaly findings.
+3. Define audience (for example CMO or finance lead).
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  adtech/executive-narrative-writer@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Executive Narrative Writer.
+Audience: CMO
+Input: QA-approved dashboard output for current week.
+Return headline, executive summary, drivers,
+risks/unknowns, and next actions.
+```
+
+## What good output looks like
+
+- Main conclusion appears in first lines.
+- Drivers are quantified where possible.
+- Assumptions are explicitly marked.
+
+## Beginner safety checklist
+
+- Do not rewrite metric definitions.
+- Avoid causal claims without evidence.
+- Keep recommendations specific and actionable.

--- a/skills/adtech/playwright-agentic-e2e/README.md
+++ b/skills/adtech/playwright-agentic-e2e/README.md
@@ -1,3 +1,45 @@
 # Playwright Agentic E2E QA
 
-Reusable smoke-test skill for Playwright-based web QA with planner, test generation, and healing loops.
+Use this skill to plan, generate, run, and heal Playwright smoke tests
+for web apps.
+
+## What this skill does
+
+- Defines smoke scope and pass criteria.
+- Generates Playwright tests with stable locators.
+- Runs tests and applies minimal healing patches.
+
+## Before you start
+
+1. Confirm app URL or local dev command.
+2. List high-risk routes/interactions.
+3. Confirm Playwright config path.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  adtech/playwright-agentic-e2e@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Playwright Agentic E2E QA.
+Target routes: /, /skills, /agents, /tools-mcp
+Generate smoke tests, run them, and summarize failures
+with minimal healing suggestions.
+```
+
+## What good output looks like
+
+- Scope is small and explicit.
+- Assertions use user-facing locators.
+- Failures include actionable root cause notes.
+
+## Beginner safety checklist
+
+- Do not claim coverage for untested flows.
+- Do not auto-delete failing tests.
+- Prefer robust locators over brittle CSS selectors.

--- a/skills/adtech/playwright-vscode-loop-codex/README.md
+++ b/skills/adtech/playwright-vscode-loop-codex/README.md
@@ -1,3 +1,46 @@
 # Playwright VS Code Loop for Codex
 
-Reusable skill for driving Playwright planner/generator/healer loops from Codex while using the VS Code loop backend.
+Use this skill when Codex orchestrates a Playwright planner/generator/
+healer loop that runs through a VS Code-compatible workflow.
+
+## What this skill does
+
+- Plans smoke scope and acceptance checks.
+- Generates and updates Playwright specs.
+- Runs healing loops and reports minimal fixes.
+
+## Before you start
+
+1. Confirm app directory and Playwright config path.
+2. Define smoke routes and core interactions.
+3. Confirm the VS Code loop backend is available.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  adtech/playwright-vscode-loop-codex@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Playwright VS Code Loop for Codex.
+App dir: apps/web
+Config: apps/web/playwright.config.ts
+Scope: smoke tests for /skills, /agents, /tools-mcp.
+Return plan, generated files, run summary, and healing notes.
+```
+
+## What good output looks like
+
+- Planner scope is explicit.
+- Generated tests are deterministic.
+- Healing patches are minimal and explainable.
+
+## Beginner safety checklist
+
+- Keep first pass smoke-only.
+- Re-run after each fix.
+- Track residual flaky areas explicitly.

--- a/skills/adtech/policy-brand-compliance-checker/README.md
+++ b/skills/adtech/policy-brand-compliance-checker/README.md
@@ -1,3 +1,45 @@
 # Policy + Brand Compliance Checker
 
-Checks creative, destination URLs, and tracking conventions before launch.
+Use this skill to validate ad copy, URLs, and tracking conventions
+before launch.
+
+## What this skill does
+
+- Checks policy and brand rule compliance.
+- Validates URLs and UTMs.
+- Produces severity-ranked findings with fixes.
+
+## Before you start
+
+1. Gather ad copy and destination URLs.
+2. Specify target platform.
+3. Confirm policy rules and brand constraints.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  adtech/policy-brand-compliance-checker@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Policy + Brand Compliance Checker.
+Platform: Meta Ads
+Validate ad copy and landing URL set.
+Return PASS/FAIL, findings table, and launch recommendation.
+```
+
+## What good output looks like
+
+- Every issue includes severity and fix.
+- Ambiguous cases are marked for review.
+- Recommendation is explicit.
+
+## Beginner safety checklist
+
+- Do not assume guaranteed ad approval.
+- Escalate unclear policy cases.
+- Do not modify live assets automatically.

--- a/skills/adtech/weekly-performance-review-bi/README.md
+++ b/skills/adtech/weekly-performance-review-bi/README.md
@@ -1,17 +1,43 @@
 # Weekly Performance Review BI
 
-Orchestrates three BI skills in one deterministic weekly reporting run.
+Use this skill to orchestrate deterministic weekly BI reporting with a
+hard QA gate before publication.
 
-## Skill chain
-1. dashboard-generator
-2. dashboard-qa-checker
-3. executive-narrative-writer (only if QA approved)
+## What this skill does
 
-## Outputs
-- publish decision
-- dashboard package
-- QA package
-- executive narrative (conditional on QA pass)
+- Runs dashboard generation.
+- Runs dashboard QA checks.
+- Runs executive narrative only when QA passes.
 
-## Starter prompt
-- See [examples/starter-prompt.md](examples/starter-prompt.md) for a copy/paste weekly run template with fixed BI contract and QA thresholds.
+## Before you start
+
+1. Prepare normalized performance data.
+2. Prepare source totals and freshness timestamps.
+3. Define QA thresholds and audience.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  adtech/weekly-performance-review-bi@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+Use the starter template:
+
+- [examples/starter-prompt.md](examples/starter-prompt.md)
+
+## What good output looks like
+
+- Publish decision is explicit.
+- Dashboard section order is deterministic.
+- QA package includes evidence values.
+- Narrative appears only when QA approved.
+
+## Beginner safety checklist
+
+- Never bypass critical QA failures.
+- Keep metric dictionary fixed across runs.
+- Require alerting on blocked publish.

--- a/skills/marketing/ab-test-planner-analyzer/README.md
+++ b/skills/marketing/ab-test-planner-analyzer/README.md
@@ -1,3 +1,47 @@
 # A/B Test Planner + Analyzer
 
-Designs experiments with clear hypotheses and analyzes results into ship/iterate/stop decisions.
+Use this skill to design strong experiments and convert results into
+clear decisions.
+
+## What this skill does
+
+- Validates hypotheses and metrics.
+- Recommends sample size and duration.
+- Analyzes results into `ship`, `iterate`, or `stop`.
+
+## Before you start
+
+1. Define experiment goal and primary metric.
+2. Provide baseline rate and MDE.
+3. Provide traffic estimate and test window.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  marketing/ab-test-planner-analyzer@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use A/B Test Planner + Analyzer.
+Goal: improve trial signup rate.
+Primary metric: signup CVR
+Baseline: 4.2%
+MDE: 10%
+Return sample size, stop rules, and decision framework.
+```
+
+## What good output looks like
+
+- Assumptions are explicit.
+- Primary and guardrail metrics are clear.
+- Decision is tied to evidence quality.
+
+## Beginner safety checklist
+
+- Use one primary metric.
+- Treat weak evidence as inconclusive.
+- Avoid causal claims beyond test design.

--- a/skills/marketing/ai-output-eval-scorecard/README.md
+++ b/skills/marketing/ai-output-eval-scorecard/README.md
@@ -1,3 +1,46 @@
 # AI Output Eval Scorecard
 
-Scores AI-generated marketing outputs for quality, compliance, and actionability using a structured rubric.
+Use this skill to score AI-generated outputs with a repeatable quality
+and compliance rubric.
+
+## What this skill does
+
+- Scores accuracy, clarity, brand fit, compliance, and actionability.
+- Flags high-severity findings with evidence.
+- Returns pass/revise/fail verdict.
+
+## Before you start
+
+1. Provide task context and prompt used.
+2. Provide generated output.
+3. Provide brand and policy rules.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  marketing/ai-output-eval-scorecard@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use AI Output Eval Scorecard.
+Task type: campaign copy
+Score this output for quality and compliance.
+Return overall score, verdict, critical findings,
+and rewrite recommendations.
+```
+
+## What good output looks like
+
+- Dimension scores are clear.
+- Critical findings include concrete evidence.
+- Verdict is actionable.
+
+## Beginner safety checklist
+
+- Do not infer missing policy rules.
+- Do not fabricate compliance certainty.
+- Keep scoring criteria consistent across runs.

--- a/skills/marketing/creative-workshop-pmax-reels/README.md
+++ b/skills/marketing/creative-workshop-pmax-reels/README.md
@@ -1,3 +1,47 @@
 # Creative Workshop for PMax + Reels
 
-Generates structured ad creative variants aligned to platform constraints.
+Use this skill to generate platform-ready creative variants for Google
+PMax and Meta Reels.
+
+## What this skill does
+
+- Produces multiple messaging angles.
+- Generates platform-specific variants.
+- Validates field lengths and restricted terms.
+
+## Before you start
+
+1. Define offer, audience, and campaign goal.
+2. Provide brand tone and constraints.
+3. Confirm platform-specific restrictions.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  marketing/creative-workshop-pmax-reels@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Creative Workshop for PMax + Reels.
+Offer: spring enrollment
+Audience: first-time buyers
+Goal: drive qualified leads
+Return messaging angles and publish-ready variants
+for both PMax and Reels.
+```
+
+## What good output looks like
+
+- Clear angle summary.
+- Platform-specific outputs are separated.
+- Compliance notes are explicit.
+
+## Beginner safety checklist
+
+- Enforce character limits per platform.
+- Avoid restricted claims.
+- Flag uncertain cases for human review.

--- a/skills/marketing/cross-channel-budget-pacing-agent/README.md
+++ b/skills/marketing/cross-channel-budget-pacing-agent/README.md
@@ -1,3 +1,46 @@
 # Cross-Channel Budget Pacing Agent
 
-Monitors spend pacing and performance across channels, detects anomalies, and proposes bounded reallocations.
+Use this skill to monitor spend pacing and propose bounded reallocations
+across channels.
+
+## What this skill does
+
+- Compares actual vs plan.
+- Detects pacing and efficiency anomalies.
+- Recommends constrained budget shifts.
+
+## Before you start
+
+1. Provide channel performance data.
+2. Provide targets and constraints.
+3. Provide calendar context.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  marketing/cross-channel-budget-pacing-agent@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Cross-Channel Budget Pacing Agent.
+Date range: last 7 days
+Return pacing status, channel summary,
+anomalies, and next 7-day reallocation plan.
+Respect max 15% shift per channel.
+```
+
+## What good output looks like
+
+- Variance vs plan is explicit.
+- Constraints are respected.
+- Actions are prioritized and bounded.
+
+## Beginner safety checklist
+
+- Never exceed budget constraints.
+- Separate facts from speculation.
+- Highlight missing channel data.

--- a/skills/marketing/dynamic-creative-rules-engine/README.md
+++ b/skills/marketing/dynamic-creative-rules-engine/README.md
@@ -1,3 +1,46 @@
 # Dynamic Creative Rules Engine
 
-Defines audience-aware creative assembly rules with brand and policy constraints for scalable personalization.
+Use this skill to define audience-aware creative assembly rules with
+brand and policy guardrails.
+
+## What this skill does
+
+- Maps segment and context signal logic.
+- Builds allowed creative component combinations.
+- Returns deployable rules and test matrix.
+
+## Before you start
+
+1. Provide audience segments and context signals.
+2. Provide creative components.
+3. Provide brand and policy constraints.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  marketing/dynamic-creative-rules-engine@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Dynamic Creative Rules Engine.
+Segments: new visitors, returning users
+Signals: channel, device, intent bucket
+Return segmentation logic, creative rules,
+blocked combinations, and test matrix.
+```
+
+## What good output looks like
+
+- Rule logic is explicit and testable.
+- Blocked combinations are documented.
+- Monitoring metrics are defined.
+
+## Beginner safety checklist
+
+- Enforce hard policy constraints first.
+- Keep human review for high-risk segments.
+- Avoid uncontrolled variant explosion.

--- a/skills/marketing/lifecycle-experiment-planner/README.md
+++ b/skills/marketing/lifecycle-experiment-planner/README.md
@@ -1,3 +1,46 @@
 # Lifecycle Experiment Planner
 
-Builds statistically coherent test plans for lifecycle marketing.
+Use this skill to design statistically coherent lifecycle experiments.
+
+## What this skill does
+
+- Validates hypothesis quality.
+- Calculates sample-size guidance.
+- Defines stop/continue criteria.
+
+## Before you start
+
+1. Provide baseline rate and MDE.
+2. Set confidence and power assumptions.
+3. Define primary and guardrail metrics.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  marketing/lifecycle-experiment-planner@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Lifecycle Experiment Planner.
+Channel: email journey
+Baseline: 3.8% conversion
+MDE: 12%
+Return hypothesis, design table, sample-size guidance,
+and stop/continue criteria.
+```
+
+## What good output looks like
+
+- Hypothesis is specific and testable.
+- Sample-size assumptions are explicit.
+- Decision criteria are unambiguous.
+
+## Beginner safety checklist
+
+- Keep one primary metric.
+- Avoid early stopping without guardrail breach.
+- Reject vague hypotheses.

--- a/skills/marketing/lifecycle-journey-trigger-designer/README.md
+++ b/skills/marketing/lifecycle-journey-trigger-designer/README.md
@@ -1,3 +1,47 @@
 # Lifecycle Journey Trigger Designer
 
-Designs lifecycle journey triggers, channel sequencing, and measurement plans from customer behavior signals.
+Use this skill to design event-based lifecycle triggers, sequencing,
+and measurement plans.
+
+## What this skill does
+
+- Defines entry/progression/exit triggers.
+- Designs channel timing and suppression logic.
+- Returns rollout and measurement plans.
+
+## Before you start
+
+1. Define journey goal and audience.
+2. Provide trigger events and channel constraints.
+3. Define success metrics.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  marketing/lifecycle-journey-trigger-designer@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Lifecycle Journey Trigger Designer.
+Goal: increase activation in first 14 days.
+Audience: new signups
+Return journey blueprint, trigger rules,
+channel sequence, suppression rules,
+and measurement plan.
+```
+
+## What good output looks like
+
+- Trigger logic is unambiguous.
+- Suppression/frequency controls are explicit.
+- Measurement plan ties to goal.
+
+## Beginner safety checklist
+
+- Prevent overlapping trigger collisions.
+- Respect legal communication constraints.
+- Flag missing event instrumentation.

--- a/skills/marketing/meta-google-weekly-performance-review/README.md
+++ b/skills/marketing/meta-google-weekly-performance-review/README.md
@@ -1,13 +1,46 @@
 # Meta/Google Weekly Performance Review
 
-Produces a standardized weekly narrative across Google Ads and Meta Ads.
+Use this skill to generate a standardized weekly narrative across Google
+Ads and Meta Ads.
 
-## Inputs
-- account IDs
-- date range
-- channels
+## What this skill does
 
-## Outputs
-- executive summary
-- KPI table with deltas
-- prioritized actions
+- Compares current and previous period performance.
+- Computes core paid media KPIs.
+- Produces prioritized actions and risk notes.
+
+## Before you start
+
+1. Provide Meta and Google account IDs.
+2. Provide analysis date range.
+3. Confirm required channels.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  marketing/meta-google-weekly-performance-review@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Meta/Google Weekly Performance Review.
+Date range: last 7 days
+Compare against prior 7 days.
+Return executive summary, KPI table,
+key insights, and recommended actions.
+```
+
+## What good output looks like
+
+- KPI deltas are clear and accurate.
+- Winners and underperformers are explicit.
+- Limitations are called out.
+
+## Beginner safety checklist
+
+- Never fabricate missing numbers.
+- Request exports if data access fails.
+- Flag low-confidence conclusions.

--- a/skills/marketing/seo-paid-search-synergy/README.md
+++ b/skills/marketing/seo-paid-search-synergy/README.md
@@ -1,3 +1,45 @@
-# SEO -> Paid Search Synergy Skill
+# SEO -> Paid Search Synergy
 
-Uses organic winners to generate paid search opportunities.
+Use this skill to convert organic winners into paid search opportunities.
+
+## What this skill does
+
+- Selects high-intent SEO winners.
+- Clusters terms into paid ad groups.
+- Returns keyword/ad copy starters and test plan.
+
+## Before you start
+
+1. Provide top queries and landing page performance.
+2. Provide paid search constraints.
+3. Separate brand and non-brand strategy.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  marketing/seo-paid-search-synergy@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use SEO -> Paid Search Synergy.
+Input top SEO winners for last 30 days.
+Return paid ad group recommendations,
+keyword starters, ad copy starters,
+and launch experiment plan.
+```
+
+## What good output looks like
+
+- Intent clusters are logical.
+- Brand and non-brand are separated.
+- Suggested tests are measurable.
+
+## Beginner safety checklist
+
+- Treat uncertain mappings as hypotheses.
+- Do not assume conversion intent without evidence.
+- Keep launch plan test-first, not full-scale.

--- a/tools-mcp/ads/meta-ads-mcp-connector/README.md
+++ b/tools-mcp/ads/meta-ads-mcp-connector/README.md
@@ -1,3 +1,56 @@
 # Meta Ads MCP Connector
 
-Tool manifest for Meta Ads performance data retrieval via MCP.
+Use this tool package to pull Meta Ads performance data via MCP for
+analysis and reporting.
+
+## Current status
+
+- This package is currently a tool specification and usage contract.
+- It does **not** yet include a production Python implementation in
+  `scripts/` for live execution.
+- It does **not** ship a managed MCP server binary in this repository.
+- You need to connect it to your own Meta Ads MCP server/runtime
+  integration.
+
+## What this tool does
+
+- Pulls campaign/ad set metrics for date windows.
+- Returns spend, impressions, clicks, and conversions.
+- Preserves source timestamps for QA checks.
+
+## Before you start
+
+1. Confirm Meta ad account ID scope.
+2. Confirm MCP server auth is valid.
+3. Keep tool access read-only.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  --module tools \
+  --entry ads/meta-ads-mcp-connector@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Meta Ads MCP Connector.
+Account ID: act_1234567890
+Date range: 2026-02-23 to 2026-03-01
+Fields: campaign_name, spend, impressions, clicks, actions
+Return normalized campaign-level performance rows.
+```
+
+## What good output looks like
+
+- Campaign rows include requested metrics.
+- Missing scope errors are clear and actionable.
+- Source timestamp is included for downstream freshness checks.
+
+## Beginner safety checklist
+
+- Reject requests without account scope.
+- Keep connector read-only.
+- Do not infer missing conversion mappings silently.

--- a/tools-mcp/analytics/ga4-mcp-connector/README.md
+++ b/tools-mcp/analytics/ga4-mcp-connector/README.md
@@ -1,3 +1,56 @@
 # GA4 MCP Connector
 
-Tool manifest for GA4 analytics querying via MCP.
+Use this tool package to query GA4 metrics through MCP in a safe,
+structured format.
+
+## Current status
+
+- This package is currently a tool specification and usage contract.
+- It does **not** yet include a production Python implementation in
+  `scripts/` for live execution.
+- It does **not** ship a managed MCP server binary in this repository.
+- You need to connect it to your own GA4 MCP server/runtime integration.
+
+## What this tool does
+
+- Pulls GA4 sessions, conversions, and revenue by dimensions.
+- Supports fixed date windows for period comparison.
+- Returns normalized output for skills and agents.
+
+## Before you start
+
+1. Confirm GA4 property ID.
+2. Confirm MCP server is configured and authenticated.
+3. Keep access read-only.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  --module tools \
+  --entry analytics/ga4-mcp-connector@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use GA4 MCP Connector.
+Property ID: 123456789
+Date range: 2026-02-23 to 2026-03-01
+Dimensions: sessionDefaultChannelGroup
+Metrics: sessions, conversions, totalRevenue
+Return normalized rows for dashboard input.
+```
+
+## What good output looks like
+
+- Output rows include channel and metric values.
+- Date window is applied correctly.
+- Errors are explicit for invalid property/auth.
+
+## Beginner safety checklist
+
+- Do not use write/update endpoints.
+- Validate metric/dimension allowlist first.
+- Log source timestamp for freshness QA.

--- a/tools-mcp/warehouse/bigquery-mcp-query-runner/README.md
+++ b/tools-mcp/warehouse/bigquery-mcp-query-runner/README.md
@@ -1,3 +1,59 @@
 # BigQuery MCP Query Runner
 
-Tool manifest for BigQuery read-only query execution via MCP.
+Use this tool package to run parameterized, read-only BigQuery queries
+through MCP.
+
+## Current status
+
+- This package is currently a tool specification and usage contract.
+- It does **not** yet include a production Python implementation in
+  `scripts/` for live execution.
+- It does **not** ship a managed MCP server binary in this repository.
+- You need to connect it to your own BigQuery MCP server/runtime
+  integration.
+
+## What this tool does
+
+- Executes parameterized SQL templates.
+- Enforces read-only query behavior.
+- Returns typed rows for analytics skills and agents.
+
+## Before you start
+
+1. Confirm dataset/table access.
+2. Prepare parameterized SQL template.
+3. Set query timeout and row limits.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  --module tools \
+  --entry warehouse/bigquery-mcp-query-runner@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use BigQuery MCP Query Runner.
+SQL template:
+SELECT channel, SUM(spend) AS spend
+FROM marketing.performance
+WHERE date BETWEEN @start AND @end
+GROUP BY 1
+Params: start=2026-02-23, end=2026-03-01
+Return typed rows and row_count.
+```
+
+## What good output looks like
+
+- Query executes with provided parameters.
+- Output schema is stable and typed.
+- Non-read-only SQL is rejected with clear diagnostics.
+
+## Beginner safety checklist
+
+- Allow only SELECT-style queries.
+- Enforce timeout and row limits.
+- Capture and return query diagnostics on failure.


### PR DESCRIPTION
## Summary

This PR closes the biggest production-readiness gaps across the modular hub by adding:

1. a real agent preflight runtime path (`run-agent`) with governance and audit controls,
2. module-wide validation/testing hardening,
3. install UX improvements for agents/tools,
4. beginner-friendly onboarding docs across agents, skills, and tools.

---

## What’s Included

### 1) Agent preflight runtime (new executable capability)

Added a new `skills-hub run-agent` command to move agent packages beyond static stubs into operational preflight checks.

New capabilities:
- agent manifest parsing and dependency resolution
- skill dependency existence checks
- tool binding validation (endpoint + mode)
- memory profile loading/validation
- governance profile enforcement
- approval gating (`--approve-live`)
- JSON audit log output

Key files:
- [[cmd/skills-hub/main.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/cmd/skills-hub/main.go)](cmd/skills-hub/main.go)
- [[internal/agents/types.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/internal/agents/types.go)](internal/agents/types.go)
- [[internal/agents/manifest.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/internal/agents/manifest.go)](internal/agents/manifest.go)
- [[internal/agents/run.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/internal/agents/run.go)](internal/agents/run.go)

New tests:
- [[internal/agents/manifest_test.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/internal/agents/manifest_test.go)](internal/agents/manifest_test.go)
- [[internal/agents/run_test.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/internal/agents/run_test.go)](internal/agents/run_test.go)

---

### 2) Production config scaffolding per agent

Added `config/` examples for each agent package to standardize runtime wiring:

- `tool-bindings.example.json`
- `memory-profile.example.json`
- `governance.example.json`

Added under:
- [[agents/marketing/weekly-performance-supervisor/config](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/agents/marketing/weekly-performance-supervisor/config)](agents/marketing/weekly-performance-supervisor/config)
- [[agents/marketing/campaign-qa-supervisor/config](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/agents/marketing/campaign-qa-supervisor/config)](agents/marketing/campaign-qa-supervisor/config)
- [[agents/adtech/bi-insights-orchestrator/config](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/agents/adtech/bi-insights-orchestrator/config)](agents/adtech/bi-insights-orchestrator/config)

---

### 3) Validation hardening across modules

Generalized structural validation from skills-only to all modules.

Updated:
- [[scripts/validate-skills.sh](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/scripts/validate-skills.sh)](scripts/validate-skills.sh)

Now validates:
- `skills/`, `agents/`, `tools-mcp/`
- required files
- examples presence
- test prompt count
- guardrails sections

Also added registry builder test coverage for new module indexes:
- [[internal/registry/builder_test.go](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/internal/registry/builder_test.go)](internal/registry/builder_test.go)

---

### 4) Agent/tool install UX improvements in web app

Added install command panels to agent/tool detail pages (same UX pattern as skills).

Updated:
- [[apps/web/app/agents/[...id]/page.tsx](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/app/agents/%5B...id%5D/page.tsx)](apps/web/app/agents/[...id]/page.tsx)
- [[apps/web/app/tools-mcp/[...id]/page.tsx](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/app/tools-mcp/%5B...id%5D/page.tsx)](apps/web/app/tools-mcp/[...id]/page.tsx)
- [[apps/web/lib/registry.ts](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/apps/web/lib/registry.ts)](apps/web/lib/registry.ts)

---

### 5) Documentation and onboarding expansion

#### Agents
Expanded all agent READMEs with beginner setup and production preflight usage:
- [[agents/marketing/weekly-performance-supervisor/README.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/agents/marketing/weekly-performance-supervisor/README.md)](agents/marketing/weekly-performance-supervisor/README.md)
- [[agents/marketing/campaign-qa-supervisor/README.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/agents/marketing/campaign-qa-supervisor/README.md)](agents/marketing/campaign-qa-supervisor/README.md)
- [[agents/adtech/bi-insights-orchestrator/README.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/agents/adtech/bi-insights-orchestrator/README.md)](agents/adtech/bi-insights-orchestrator/README.md)

#### Skills
Augmented all skill READMEs with a beginner-friendly standard:
- what it does
- prerequisites
- install command
- first-run prompt
- expected output
- safety checklist

#### Tools/MCP
Augmented all tool READMEs similarly and added explicit “current status” disclaimers:
- currently spec/contract packages
- no production Python runtime code bundled yet
- no managed MCP binaries in-repo
- requires user runtime integration

#### Top-level README
Added step-by-step “Use Agent Packages” guide with concrete examples for:
- Claude docs
- Codex docs
- OpenClaw
and added `run-agent` examples plus module-specific runtime defaults.

Updated:
- [[README.md](https://github.com/ai-knowledge-hub/ai-skills-guide/pull/README.md)](README.md)

---

## Validation / Test Evidence

- `bash scripts/validate-skills.sh` ✅
- `go test ./internal/agents ./cmd/skills-hub ./internal/installer ./internal/registry` ✅
- `skills-hub run-agent ... --approve-live` sample execution ✅
  - produced `status: ready`
  - produced JSON audit report with dependency/tool/workflow checks

---

## Practical impact

This PR moves agent packages from “catalog stubs” to an executable readiness baseline:
- enforceable preflight checks,
- explicit governance/approval controls,
- auditable runs,
- clearer onboarding for non-expert users,
- and better install UX for all modules.

---

## Follow-up (next PR suggestion)

1. Add optional live execution adapter layer after preflight (`--execute` mode).
2. Add signed artifact verification step before install.
3. Add post-deploy URL smoke checks for manifest/artifact links.