### PR TITLE
fix category filter

### DIFF
--- a/apps/web/app/agents/page.tsx
+++ b/apps/web/app/agents/page.tsx
@@ -1,6 +1,7 @@
 import { loadAgentsRegistry, uniqueValues } from "@/lib/registry";
 import CatalogClient from "@/components/CatalogClient";
 import { parseMultiValue, type SearchParamValue } from "@/lib/catalogFilters";
+import { getDomainKey } from "@/lib/categoryLabels";
 
 type SearchParams = {
   q?: SearchParamValue;
@@ -16,7 +17,7 @@ export default async function AgentsPage({ searchParams = {} }: { searchParams?:
   const categoriesSelected = parseMultiValue(searchParams.category);
   const runtimes = parseMultiValue(searchParams.runtime);
 
-  const categories = uniqueValues(registry.skills.map((s) => s.category));
+  const categories = uniqueValues(registry.skills.map((s) => getDomainKey(s.category, "/agents")));
   const availableTags = uniqueValues(registry.skills.flatMap((s) => s.tags));
 
   return (

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,7 +2,7 @@ import { loadAgentsRegistry, loadSkillsRegistry, loadToolsRegistry, uniqueValues
 import { FEATURED_SKILL_IDS } from "@/lib/home";
 import {
   formatCategoryFamily,
-  formatCategoryLabel,
+  getCategoryFamilyKey,
   formatReadinessLabel
 } from "@/lib/categoryLabels";
 
@@ -15,7 +15,7 @@ export default async function HomePage() {
   const skills = skillsRegistry.skills;
   const agents = agentsRegistry.skills;
   const tools = toolsRegistry.skills;
-  const categories = uniqueValues(skills.map((s) => s.category));
+  const categoryGroups = uniqueValues(skills.map((s) => getCategoryFamilyKey(s.category)));
   const tags = uniqueValues(skills.flatMap((s) => s.tags));
   const featuredSkills = FEATURED_SKILL_IDS
     .map((id) => skills.find((skill) => skill.id === id))
@@ -68,7 +68,7 @@ export default async function HomePage() {
         </article>
         <article className="card">
           <h2>Catalog Snapshot</h2>
-          <p><span className="meta">Skills categories:</span> {categories.length}</p>
+          <p><span className="meta">Category groups:</span> {categoryGroups.length}</p>
           <p><span className="meta">Skills tags:</span> {tags.length}</p>
           <p><span className="meta">Runtimes:</span> codex, claude, generic</p>
           <div className="actions snapshot-actions">
@@ -133,7 +133,6 @@ export default async function HomePage() {
               </div>
             </div>
             <h3>{skill.name}</h3>
-            <p className="meta catalog-card-category">{formatCategoryLabel(skill.category)}</p>
             <p>{skill.description}</p>
             <div className="tags">
               {skill.tags.slice(0, 2).map((tag) => (

--- a/apps/web/app/skills/page.tsx
+++ b/apps/web/app/skills/page.tsx
@@ -1,6 +1,7 @@
 import { loadSkillsRegistry, uniqueValues } from "@/lib/registry";
 import CatalogClient from "@/components/CatalogClient";
 import { parseMultiValue, type SearchParamValue } from "@/lib/catalogFilters";
+import { getDomainKey } from "@/lib/categoryLabels";
 
 type SearchParams = {
   q?: SearchParamValue;
@@ -16,7 +17,7 @@ export default async function SkillsPage({ searchParams = {} }: { searchParams?:
   const categoriesSelected = parseMultiValue(searchParams.category);
   const runtimes = parseMultiValue(searchParams.runtime);
 
-  const categories = uniqueValues(registry.skills.map((s) => s.category));
+  const categories = uniqueValues(registry.skills.map((s) => getDomainKey(s.category, "/skills")));
   const availableTags = uniqueValues(registry.skills.flatMap((s) => s.tags));
 
   return (

--- a/apps/web/app/tools-mcp/page.tsx
+++ b/apps/web/app/tools-mcp/page.tsx
@@ -1,6 +1,7 @@
 import { loadToolsRegistry, uniqueValues } from "@/lib/registry";
 import CatalogClient from "@/components/CatalogClient";
 import { parseMultiValue, type SearchParamValue } from "@/lib/catalogFilters";
+import { getDomainKey } from "@/lib/categoryLabels";
 
 type SearchParams = {
   q?: SearchParamValue;
@@ -16,7 +17,7 @@ export default async function ToolsMcpPage({ searchParams = {} }: { searchParams
   const categoriesSelected = parseMultiValue(searchParams.category);
   const runtimes = parseMultiValue(searchParams.runtime);
 
-  const categories = uniqueValues(registry.skills.map((s) => s.category));
+  const categories = uniqueValues(registry.skills.map((s) => getDomainKey(s.category, "/tools-mcp")));
   const availableTags = uniqueValues(registry.skills.flatMap((s) => s.tags));
 
   return (

--- a/apps/web/components/CatalogClient.tsx
+++ b/apps/web/components/CatalogClient.tsx
@@ -7,8 +7,10 @@ import type { RegistryEntry } from "@/lib/registry";
 import FilterSelect, { type FilterOption } from "@/components/FilterSelect";
 import type { CatalogInitialFilters } from "@/lib/catalogFilters";
 import {
+  formatDomainLabel,
   formatCategoryFamily,
-  formatCategoryLabel,
+  getDomainKey,
+  normalizeDomainFilterValues,
   formatReadinessLabel
 } from "@/lib/categoryLabels";
 
@@ -26,7 +28,9 @@ export default function CatalogClient({ entries, categories, tags, basePath, ini
   const searchParams = useSearchParams();
   const [q, setQ] = useState(initial.q);
   const [selectedTags, setSelectedTags] = useState(initial.tags);
-  const [selectedCategories, setSelectedCategories] = useState(initial.categories);
+  const [selectedCategories, setSelectedCategories] = useState(
+    normalizeDomainFilterValues(initial.categories, basePath)
+  );
   const [selectedRuntimes, setSelectedRuntimes] = useState(initial.runtimes);
   const deferredQ = useDeferredValue(q);
 
@@ -42,7 +46,7 @@ export default function CatalogClient({ entries, categories, tags, basePath, ini
       if (selectedTags.length > 0 && !selectedTags.some((tag) => entry.tags.includes(tag))) {
         return false;
       }
-      if (selectedCategories.length > 0 && !selectedCategories.includes(entry.category)) {
+      if (selectedCategories.length > 0 && !selectedCategories.includes(getDomainKey(entry.category, basePath))) {
         return false;
       }
       if (selectedRuntimes.length > 0 && !selectedRuntimes.some((runtime) => entry.runtimes.includes(runtime))) {
@@ -50,17 +54,16 @@ export default function CatalogClient({ entries, categories, tags, basePath, ini
       }
       return true;
     });
-  }, [deferredQ, entries, selectedCategories, selectedRuntimes, selectedTags]);
+  }, [basePath, deferredQ, entries, selectedCategories, selectedRuntimes, selectedTags]);
 
   const categoryOptions = useMemo<FilterOption[]>(
     () =>
       categories.map((category) => ({
         value: category,
-        label: formatCategoryLabel(category),
-        count: entries.filter((entry) => entry.category === category).length,
-        group: groupCategory(category)
+        label: formatDomainLabel(category, basePath),
+        count: entries.filter((entry) => getDomainKey(entry.category, basePath) === category).length
       })),
-    [categories, entries]
+    [basePath, categories, entries]
   );
 
   const tagOptions = useMemo<FilterOption[]>(
@@ -146,10 +149,10 @@ export default function CatalogClient({ entries, categories, tags, basePath, ini
         />
 
         <FilterSelect
-          label="Category"
+          label="Domain"
           values={selectedCategories}
           options={categoryOptions}
-          placeholder="All categories"
+          placeholder="All domains"
           onChange={setSelectedCategories}
         />
 
@@ -184,7 +187,7 @@ export default function CatalogClient({ entries, categories, tags, basePath, ini
               onClick={() => removeFilter(filter.kind as "category" | "tag" | "runtime", filter.value)}
             >
               <span className="meta">{filter.kind}</span>
-              <span>{filter.kind === "category" ? formatCategoryLabel(filter.value) : filter.value}</span>
+              <span>{filter.kind === "category" ? formatDomainLabel(filter.value, basePath) : filter.value}</span>
               <span aria-hidden>×</span>
             </button>
           ))}
@@ -209,7 +212,6 @@ export default function CatalogClient({ entries, categories, tags, basePath, ini
             </div>
             <p className="meta catalog-card-id">{entry.id}</p>
             <h2>{entry.name}</h2>
-            <p className="meta catalog-card-category">{formatCategoryLabel(entry.category)}</p>
             <p>{entry.description}</p>
             <div className="tags">
               {entry.tags.slice(0, 2).map((tagEntry) => (
@@ -224,17 +226,4 @@ export default function CatalogClient({ entries, categories, tags, basePath, ini
       </section>
     </>
   );
-}
-
-function groupCategory(category: string) {
-  const [family] = category.split("/");
-  if (family === "marketing-tools") return "Marketing Tools";
-  if (family === "adtech") return "Adtech";
-  if (family === "engineering") return "Engineering";
-  if (family === "security") return "Security";
-  if (family === "agentops") return "AgentOps";
-  if (family === "marketing-agents") return "Marketing Agents";
-  if (family === "adtech-agents") return "Adtech Agents";
-  if (family === "tools-mcp") return "Tools & MCP";
-  return "Other";
 }

--- a/apps/web/components/SkillsCatalogClient.tsx
+++ b/apps/web/components/SkillsCatalogClient.tsx
@@ -134,10 +134,10 @@ export default function SkillsCatalogClient({ skills, categories, tags, initial 
         />
 
         <FilterSelect
-          label="Category"
+          label="Domain"
           values={draftCategories}
           options={categoryOptions}
-          placeholder="All categories"
+          placeholder="All domains"
           onChange={setDraftCategories}
         />
 

--- a/apps/web/lib/categoryLabels.ts
+++ b/apps/web/lib/categoryLabels.ts
@@ -55,6 +55,39 @@ export function formatCategoryFamily(category: string) {
   return "Other";
 }
 
+export function getCategoryFamilyKey(category: string) {
+  return category.split("/")[0] ?? category;
+}
+
+export function normalizeCategoryFilterValues(categories: string[]) {
+  return [...new Set(categories.map((category) => getCategoryFamilyKey(category)))];
+}
+
+export function getDomainKey(category: string, basePath: "/skills" | "/agents" | "/tools-mcp") {
+  const [family, domain] = category.split("/");
+  if (basePath === "/tools-mcp") {
+    return domain ?? family ?? category;
+  }
+  return family ?? category;
+}
+
+export function formatDomainLabel(domain: string, basePath: "/skills" | "/agents" | "/tools-mcp") {
+  if (basePath === "/tools-mcp") {
+    return domain
+      .split("-")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+  }
+  return formatCategoryFamily(domain);
+}
+
+export function normalizeDomainFilterValues(
+  categories: string[],
+  basePath: "/skills" | "/agents" | "/tools-mcp"
+) {
+  return [...new Set(categories.map((category) => getDomainKey(category, basePath)))];
+}
+
 export function formatReadinessLabel(readiness: "experimental" | "reviewed" | "deprecated") {
   if (readiness === "reviewed") return "Reviewed";
   if (readiness === "deprecated") return "Deprecated";


### PR DESCRIPTION
## Summary

This PR simplifies the catalog taxonomy UX and improves account-level Git/SSH setup guidance for multi-account GitHub usage.

The main product change is a cleaner, less confusing filter model:

- `Category` is renamed to `Domain`
- skills and agents now filter by **top-level domain/family**
- tools & MCP now filter by **meaningful tool domains** (`Analytics`, `Ads`, `Warehouse`)
- catalog cards no longer surface subcategory text, reducing visual noise

This keeps the registry taxonomy intact while making the UI much easier to understand.

---

## UX changes

### Domain filter replaces category filter
- renamed filter label from `Category` to `Domain`
- renamed placeholder from `All categories` to `All domains`

### Skills and agents
Domain now maps to the top-level family only:
- `Marketing Tools`
- `Adtech`
- `Engineering`
- `Security`
- `AgentOps`
- `Marketing Agents`
- `Adtech Agents`

### Tools & MCP
Domain now maps to the second-level tool area instead of the collapsed `tools-mcp` family:
- `Analytics`
- `Ads`
- `Warehouse`

This fixes the previous issue where tools appeared to have no meaningful category segmentation in the UI.

---

## Card simplification

To align with the new browsing model:
- removed subcategory text from catalog cards
- kept pack/domain badge as the primary classification cue
- retained tags as the precision layer

This reduces clutter and makes the cards read more cleanly.

---

## Compatibility behavior

The underlying manifest taxonomy has **not** been changed.

The UI now derives display/filter domains from the existing category path:
- skills/agents -> first segment
- tools-mcp -> second segment

Old query param values based on full category paths are normalized, so existing links remain tolerant.

---

## Files changed

### Domain/filter logic
- `apps/web/lib/categoryLabels.ts`
- `apps/web/components/CatalogClient.tsx`

### Route pages
- `apps/web/app/skills/page.tsx`
- `apps/web/app/agents/page.tsx`
- `apps/web/app/tools-mcp/page.tsx`

### Legacy/secondary component consistency
- `apps/web/components/SkillsCatalogClient.tsx`

### Homepage snapshot alignment
- `apps/web/app/page.tsx`

---

## Additional fixes included

### Previous CI stabilization carried forward
- updated stale Playwright assertion for agent category label
- removed `next/link` from server-rendered app shell pages/breadcrumbs to avoid the App Router dev-mode `useContext` crash in Playwright/Next dev
- hardened catalog page `searchParams` handling


This is local machine setup work, not repo code, but it was completed alongside this PR branch to prevent accidental cross-account pushes.

---

## Verification

Local checks completed:
- `pnpm --dir apps/web build`

Build passed cleanly.

---

## Why this matters

The previous model was technically correct but confusing:
- cards emphasized family-level grouping
- filters exposed subcategories
- tools collapsed into a single `tools-mcp` family
- homepage counts reflected subcategories instead of the browsing model

This PR aligns the UI around a simpler mental model:

- `Domain` = broad browse dimension
- `Tags` = precision
- `Runtime` = compatibility

That is a cleaner foundation as the catalog continues to grow.

