### PR TITLE
plugin build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,12 @@ node_modules/
 pnpm-debug.log*
 .vercel/
 *.tsbuildinfo
+apps/web/public/agents/
+apps/web/public/artifacts/
+apps/web/public/plugins/
+apps/web/public/registry/
+apps/web/public/skills/
+apps/web/public/tools-mcp/
 
 # Logs
 *.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,24 +13,27 @@
 1. Add/update one entry under one module:
    - `skills/<domain>/<slug>`
    - `agents/<domain>/<slug>`
+   - `plugins/<domain>/<slug>`
    - `tools-mcp/<domain>/<slug>`
-2. Include spec file (`SKILL.md` or `AGENT.md` or `TOOL.md`),
+2. Include spec file (`SKILL.md` or `AGENT.md` or `plugin.json` or `TOOL.md`),
    `README.md`, `tests/test-prompts.md`, and `examples/`.
-3. Include correct manifest (`skill.yaml`, `agent.yaml`, or `tool.yaml`).
+3. Include correct manifest (`skill.yaml`, `agent.yaml`, `plugin.yaml`, or `tool.yaml`).
 4. Ensure at least 5 realistic prompts with expected behavior.
 5. Document assumptions (APIs, data sources, required tools).
 6. Include risk notes if shell commands, writes, or publishing actions are
    involved.
 7. For security or agentops entries, document approval boundaries and
    paths that remain read-only by default.
+8. For plugins, disclose bundled skills/agents/tools/hooks and any required
+   secrets or approval gates.
 
 ## Module folder standard
 
 ```text
 <entry-slug>/
   README.md
-  SKILL.md | AGENT.md | TOOL.md
-  skill.yaml | agent.yaml | tool.yaml
+  SKILL.md | AGENT.md | plugin.json | TOOL.md
+  skill.yaml | agent.yaml | plugin.yaml | tool.yaml
   scripts/        # deterministic logic
   references/     # optional deep docs
   config/         # optional rules

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ scripts, test prompts, and contribution standards.
 AI Knowledge Hub is an open, runtime-agnostic platform for applied agent
 workflows. The catalog started with marketing and adtech use cases and now
 expands into engineering maintenance, cybersecurity, and agent operations.
-We publish reusable building blocks across three modules:
+We publish reusable building blocks across four modules:
 
 - skills (task-level expertise)
 - agents (orchestrated templates)
+- plugins (installable composition layer)
 - tools & MCP connectors (integration layer)
 
 - Guide article site:
@@ -75,6 +76,12 @@ We publish reusable building blocks across three modules:
 2. `ads/meta-ads-mcp-connector`
 3. `warehouse/bigquery-mcp-query-runner`
 
+### Plugins (3)
+
+1. `marketing/performance-reporting-plugin`
+2. `marketing/campaign-audit-plugin`
+3. `marketing/content-repurposing-plugin`
+
 ## Recent Additions
 
 - `ai-output-eval-scorecard`
@@ -93,6 +100,9 @@ We publish reusable building blocks across three modules:
 - `analytics/ga4-mcp-connector`
 - `ads/meta-ads-mcp-connector`
 - `warehouse/bigquery-mcp-query-runner`
+- `marketing/performance-reporting-plugin`
+- `marketing/campaign-audit-plugin`
+- `marketing/content-repurposing-plugin`
 - `engineering/implementation-strategy`
 - `engineering/code-change-verification`
 - `engineering/test-gap-analyzer`
@@ -111,12 +121,14 @@ We publish reusable building blocks across three modules:
 - Has a module spec file:
   - skills: `SKILL.md`
   - agents: `AGENT.md`
+  - plugins: `plugin.json`
   - tools-mcp: `TOOL.md`
 - Has `tests/test-prompts.md` (>= 5 realistic prompts)
 - Has `examples/` with sample input/output shape
 - Has a valid manifest:
   - skills: `skill.yaml`
   - agents: `agent.yaml`
+  - plugins: `plugin.yaml`
   - tools-mcp: `tool.yaml`
 - Documents runtime assumptions and dependencies
 - Uses scripts/config for deterministic logic where relevant
@@ -130,6 +142,8 @@ skills/
 agents/
   marketing/
   adtech/
+plugins/
+  marketing/
 tools-mcp/
   analytics/
   ads/
@@ -171,11 +185,13 @@ Useful sections include skills for:
   and runtime risk assessment.
 - `skills/agentops/*`: harness reflection, skill proposal, and regression
   evaluation for self-evolving agent scaffolds.
+- `plugins/marketing/*`: installable bundles that package existing
+  skills, agents, tools, hooks, and setup guidance.
 
 ## Quickstart
 
-1. Pick a module entry under `skills/`, `agents/`, or `tools-mcp/`.
-2. Read `README.md` and the module spec file (`SKILL.md`/`AGENT.md`/`TOOL.md`).
+1. Pick a module entry under `skills/`, `agents/`, `plugins/`, or `tools-mcp/`.
+2. Read `README.md` and the module spec file (`SKILL.md`/`AGENT.md`/`plugin.json`/`TOOL.md`).
 3. Run prompts in `tests/test-prompts.md`.
 4. Verify structure with `bash scripts/validate-skills.sh`.
 5. Validate manifests with `bash scripts/validate-manifests.sh`.
@@ -218,6 +234,63 @@ For generic runtimes:
   --runtime generic \
   --target ./my-agent/skills
 ```
+
+## Install Plugins
+
+Plugins bundle existing skills, agents, tools, hooks, and setup guidance into
+one installable package. For `codex` and `claude`, the installer also generates
+a runtime-specific manifest inside the installed plugin directory:
+
+- `codex` -> `.codex-plugin/plugin.json`
+- `claude` -> `.claude-plugin/plugin.json`
+
+For Codex:
+
+```bash
+./bin/skills-hub install --module plugins \
+  --entry marketing/performance-reporting-plugin@latest \
+  --runtime codex
+```
+
+Expected result:
+- plugin files copied into your Codex plugins directory
+- generated `.codex-plugin/plugin.json`
+- CLI output listing bundled component IDs, required secrets, and approvals
+
+For Claude:
+
+```bash
+./bin/skills-hub install --module plugins \
+  --entry marketing/competitive-intelligence-plugin@latest \
+  --runtime claude
+```
+
+Expected result:
+- plugin files copied into your Claude plugins directory
+- generated `.claude-plugin/plugin.json`
+- CLI output warning when the plugin is not security reviewed
+
+For generic runtimes:
+
+```bash
+./bin/skills-hub install --module plugins \
+  --entry marketing/ad-creative-plugin@latest \
+  --runtime generic \
+  --target ./my-agent/plugins
+```
+
+Expected result:
+- plugin files copied into `./my-agent/plugins`
+- no runtime-specific manifest generated automatically
+- you wire the plugin into your runtime manually
+
+Before enabling any plugin in a live environment:
+
+- review bundled skills, agents, and tool references
+- confirm required secrets are scoped correctly
+- confirm approval rules are compatible with your runtime
+- inspect generated runtime manifests before activation
+- treat `security_reviewed: false` as review-required, not install-ready
 
 ## Use Agent Packages (Step-by-step)
 
@@ -486,6 +559,9 @@ For security expectations, see `SECURITY_BASELINE.md`.
 For new pack guidance, see `docs/skill-pack-code-maintenance.md`,
 `docs/skill-pack-cybersecurity.md`, and
 `docs/skill-pack-autoharnessing.md`.
+For plugin guidance, see `docs/plugin-architecture.md`,
+`docs/plugin-authoring-guide.md`, and
+`docs/plugin-security-and-review.md`.
 
 ## Hub Website (MVP Scaffold)
 
@@ -505,9 +581,11 @@ Core routes:
 - `/` overview
 - `/skills` searchable catalog
 - `/agents` searchable catalog
+- `/plugins` searchable catalog
 - `/tools-mcp` searchable catalog
 - `/skills/<category>/<slug>` skill details and install snippets
 - `/agents/<category>/<slug>` agent details
+- `/plugins/<category>/<slug>` plugin details
 - `/tools-mcp/<category>/<slug>` tool/MCP details
 
 Smoke E2E tests:
@@ -526,5 +604,6 @@ Static manifest/artifact URLs:
   production routes like:
   - `/skills/.../skill.yaml`
   - `/agents/.../agent.yaml`
+  - `/plugins/.../plugin.yaml`
   - `/tools-mcp/.../tool.yaml`
   - `/artifacts/<id>/<version>.tar.gz`

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ For Codex:
 ```
 
 Expected result:
+
 - plugin files copied into your Codex plugins directory
 - generated `.codex-plugin/plugin.json`
 - CLI output listing bundled component IDs, required secrets, and approvals
@@ -266,6 +267,7 @@ For Claude:
 ```
 
 Expected result:
+
 - plugin files copied into your Claude plugins directory
 - generated `.claude-plugin/plugin.json`
 - CLI output warning when the plugin is not security reviewed
@@ -280,6 +282,7 @@ For generic runtimes:
 ```
 
 Expected result:
+
 - plugin files copied into `./my-agent/plugins`
 - no runtime-specific manifest generated automatically
 - you wire the plugin into your runtime manually

--- a/apps/web/app/agents/[...id]/page.tsx
+++ b/apps/web/app/agents/[...id]/page.tsx
@@ -21,6 +21,7 @@ export default async function AgentDetailPage({ params }: { params: { id: string
       <div className="nav">
         <a href="/" className="pill">Home</a>
         <a href="/agents" className="pill">Agents</a>
+        <a href="/plugins" className="pill">Plugins</a>
         <span className="pill">{entry.id}</span>
       </div>
 

--- a/apps/web/app/agents/page.tsx
+++ b/apps/web/app/agents/page.tsx
@@ -25,6 +25,7 @@ export default async function AgentsPage({ searchParams = {} }: { searchParams?:
       <div className="nav">
         <a href="/" className="pill">Home</a>
         <a href="/skills" className="pill">Skills</a>
+        <a href="/plugins" className="pill">Plugins</a>
         <a href="/tools-mcp" className="pill">Tools &amp; MCP</a>
         <span className="pill">Agents</span>
       </div>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -151,6 +151,18 @@ p {
   gap: 0.45rem;
 }
 
+.catalog-card-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  flex: 1;
+}
+
+.catalog-card-link:hover h2,
+.catalog-card-link:focus-visible h2 {
+  text-decoration: underline;
+}
+
 .catalog-card-head {
   display: flex;
   align-items: flex-start;
@@ -243,6 +255,24 @@ p {
 .catalog-card-category {
   margin: -0.15rem 0 0.05rem;
   font-size: 0.74rem;
+}
+
+.catalog-card-actions {
+  margin-top: auto;
+  padding-top: 0.35rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.catalog-card-secondary-link {
+  font-family: var(--font-code);
+  font-size: 0.76rem;
+  color: #b6e5c9;
+}
+
+.catalog-card-secondary-link:hover,
+.catalog-card-secondary-link:focus-visible {
+  color: #dcffe9;
+  text-decoration: underline;
 }
 
 .install {

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -7,6 +7,7 @@ export default function NotFoundPage() {
         <a href="/" className="button button--secondary">Home</a>
         <a href="/skills" className="button button--secondary">Skills</a>
         <a href="/agents" className="button button--secondary">Agents</a>
+        <a href="/plugins" className="button button--secondary">Plugins</a>
         <a href="/tools-mcp" className="button button--secondary">Tools &amp; MCP</a>
       </div>
     </main>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,4 +1,4 @@
-import { loadAgentsRegistry, loadSkillsRegistry, loadToolsRegistry, uniqueValues } from "@/lib/registry";
+import { loadAgentsRegistry, loadPluginsRegistry, loadSkillsRegistry, loadToolsRegistry, uniqueValues } from "@/lib/registry";
 import { FEATURED_SKILL_IDS } from "@/lib/home";
 import {
   formatCategoryFamily,
@@ -12,9 +12,11 @@ export default async function HomePage() {
     loadAgentsRegistry(),
     loadToolsRegistry()
   ]);
+  const pluginsRegistry = await loadPluginsRegistry();
   const skills = skillsRegistry.skills;
   const agents = agentsRegistry.skills;
   const tools = toolsRegistry.skills;
+  const plugins = pluginsRegistry.skills;
   const categoryGroups = uniqueValues(skills.map((s) => getCategoryFamilyKey(s.category)));
   const tags = uniqueValues(skills.flatMap((s) => s.tags));
   const featuredSkills = FEATURED_SKILL_IDS
@@ -43,6 +45,7 @@ export default async function HomePage() {
         <span className="pill">AI Knowledge Hub</span>
         <a href="/skills" className="pill">Skills</a>
         <a href="/agents" className="pill">Agents</a>
+        <a href="/plugins" className="pill">Plugins</a>
         <a href="/tools-mcp" className="pill">Tools &amp; MCP</a>
       </div>
 
@@ -78,6 +81,9 @@ export default async function HomePage() {
             <a href="/agents" className="button button--secondary">
               Browse agents
             </a>
+            <a href="/plugins" className="button button--secondary">
+              Browse plugins
+            </a>
             <a href="/tools-mcp" className="button button--secondary">
               Browse tools
             </a>
@@ -91,6 +97,7 @@ export default async function HomePage() {
           <div className="tags">
             <span className="tag">{skills.length} skills</span>
             <span className="tag">{agents.length} agents</span>
+            <span className="tag">{plugins.length} plugins</span>
             <span className="tag">{tools.length} tools</span>
             <span className="tag">Skills registry v{skillsRegistry.registry_version}</span>
             <span className="tag">Generated {skillsRegistry.generated_at.slice(0, 10)}</span>

--- a/apps/web/app/plugins/[...id]/page.tsx
+++ b/apps/web/app/plugins/[...id]/page.tsx
@@ -1,0 +1,167 @@
+import { notFound } from "next/navigation";
+import InstallCommands from "@/components/InstallCommands";
+import { buildModuleInstallSnippet, getEntryById, loadPluginsRegistry } from "@/lib/registry";
+import { formatCategoryLabel, formatReadinessLabel } from "@/lib/categoryLabels";
+
+const REPO_BLOB_BASE = "https://github.com/ai-knowledge-hub/ai-skills-guide/blob/main";
+
+export async function generateStaticParams() {
+  const registry = await loadPluginsRegistry();
+  return registry.skills.map((entry) => ({ id: entry.id.split("/") }));
+}
+
+export default async function PluginDetailPage({ params }: { params: { id: string[] } }) {
+  const entryId = params.id.join("/");
+  const entry = await getEntryById("plugins", entryId);
+  if (!entry) {
+    notFound();
+  }
+  const latestVersion = entry.versions.find((v) => v.version === entry.latest) ?? entry.versions[0];
+  const packageBasePath = `plugins/${entry.id}`;
+
+  return (
+    <main>
+      <div className="nav">
+        <a href="/" className="pill">Home</a>
+        <a href="/plugins" className="pill">Plugins</a>
+        <span className="pill">{entry.id}</span>
+      </div>
+
+      <article className="card">
+        <p className="meta">{formatCategoryLabel(entry.category)}</p>
+        <h1>{entry.name}</h1>
+        <p>{entry.description}</p>
+        <div className="tags">
+          {entry.tags.map((tag) => (
+            <span key={tag} className="tag">{tag}</span>
+          ))}
+        </div>
+        <div className="detail-install-lead">
+          <p className="meta">Install this plugin</p>
+          <InstallCommands
+            compact
+            codex={buildModuleInstallSnippet("plugins", entry, "codex")}
+            claude={buildModuleInstallSnippet("plugins", entry, "claude")}
+            generic={buildModuleInstallSnippet("plugins", entry, "generic")}
+          />
+          <p className="meta">Codex and Claude installs also generate a runtime-specific plugin manifest inside the installed plugin directory.</p>
+          {!entry.security_reviewed ? (
+            <p className="meta">This plugin is still experimental. Review bundled components, required secrets, and approval rules before enabling it in a live runtime.</p>
+          ) : null}
+          {entry.requires?.secrets?.length || entry.requires?.approvals?.length ? (
+            <ul>
+              {entry.requires?.secrets?.length ? (
+                <li>Required secrets: {entry.requires.secrets.join(", ")}</li>
+              ) : null}
+              {entry.requires?.approvals?.length ? (
+                <li>Approval rules: {entry.requires.approvals.join(", ")}</li>
+              ) : null}
+            </ul>
+          ) : null}
+        </div>
+      </article>
+
+      <section className="detail-grid">
+        <article className="card detail-panel">
+          <h2>Status</h2>
+          <p><span className={`catalog-status-badge is-${entry.readiness}`}>{formatReadinessLabel(entry.readiness)}</span></p>
+          <p><span className="meta">Security reviewed:</span> {entry.security_reviewed ? "yes" : "no"}</p>
+          <p><span className="meta">Lifecycle:</span> {entry.deprecated ? "Deprecated" : "Active"}</p>
+        </article>
+        <article className="card detail-panel">
+          <h2>Included Components</h2>
+          <p><span className="meta">Skills:</span> {entry.includes?.skills?.length ?? 0}</p>
+          <p><span className="meta">Agents:</span> {entry.includes?.agents?.length ?? 0}</p>
+          <p><span className="meta">Tools:</span> {entry.includes?.tools?.length ?? 0}</p>
+          <p><span className="meta">Hooks:</span> {entry.includes?.hooks?.length ?? 0}</p>
+        </article>
+        <article className="card detail-panel">
+          <h2>Bundled Skills</h2>
+          {entry.includes?.skills?.length ? (
+            <ul>
+              {entry.includes.skills.map((skillId) => (
+                <li key={skillId}>
+                  <a href={`/skills/${skillId}`}>{skillId}</a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>No bundled skills declared.</p>
+          )}
+        </article>
+        <article className="card detail-panel">
+          <h2>Bundled Agents</h2>
+          {entry.includes?.agents?.length ? (
+            <ul>
+              {entry.includes.agents.map((agentId) => (
+                <li key={agentId}>
+                  <a href={`/agents/${agentId}`}>{agentId}</a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>No bundled agents declared.</p>
+          )}
+        </article>
+        <article className="card detail-panel">
+          <h2>Bundled Tools</h2>
+          {entry.includes?.tools?.length ? (
+            <ul>
+              {entry.includes.tools.map((toolId) => (
+                <li key={toolId}>
+                  <a href={`/tools-mcp/${toolId}`}>{toolId}</a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>No bundled tools declared.</p>
+          )}
+        </article>
+        <article className="card detail-panel">
+          <h2>Metadata</h2>
+          <p><span className="meta">ID:</span> {entry.id}</p>
+          <p><span className="meta">Latest:</span> {entry.latest}</p>
+          <p><span className="meta">Runtimes:</span> {entry.runtimes.join(", ")}</p>
+          {entry.replaced_by ? <p><span className="meta">Replaced by:</span> {entry.replaced_by}</p> : null}
+        </article>
+        <article className="card detail-panel">
+          <h2>Requirements</h2>
+          <p><span className="meta">Secrets:</span> {entry.requires?.secrets?.length ?? 0}</p>
+          <p><span className="meta">Approvals:</span> {entry.requires?.approvals?.length ?? 0}</p>
+          <p><span className="meta">Hooks:</span> {entry.includes?.hooks?.length ?? 0}</p>
+          {entry.requires?.secrets?.length ? (
+            <p><span className="meta">Secret names:</span> {entry.requires.secrets.join(", ")}</p>
+          ) : null}
+          {entry.requires?.approvals?.length ? (
+            <p><span className="meta">Approval rules:</span> {entry.requires.approvals.join(", ")}</p>
+          ) : null}
+          {entry.includes?.hooks?.length ? (
+            <p><span className="meta">Hook names:</span> {entry.includes.hooks.join(", ")}</p>
+          ) : null}
+        </article>
+        <article className="card detail-panel">
+          <h2>Latest Version</h2>
+          <p><span className="meta">Released:</span> {latestVersion?.released_at.slice(0, 10) ?? "n/a"}</p>
+          <p>
+            <span className="meta">Manifest:</span>{" "}
+            {latestVersion ? <a href={latestVersion.manifest_url}>{latestVersion.manifest_url}</a> : "n/a"}
+          </p>
+          <p>
+            <span className="meta">Artifact:</span>{" "}
+            {latestVersion ? <a href={latestVersion.artifact_url}>{latestVersion.artifact_url}</a> : "n/a"}
+          </p>
+        </article>
+        <article className="card detail-panel">
+          <h2>Package Files</h2>
+          <ul>
+            <li><a href={`${REPO_BLOB_BASE}/${packageBasePath}/README.md`}>README.md</a></li>
+            <li><a href={`${REPO_BLOB_BASE}/${packageBasePath}/plugin.yaml`}>plugin.yaml</a></li>
+            <li><a href={`${REPO_BLOB_BASE}/${packageBasePath}/plugin.json`}>plugin.json</a></li>
+            <li><a href={`${REPO_BLOB_BASE}/${packageBasePath}/tests/test-prompts.md`}>tests/test-prompts.md</a></li>
+            <li><a href={`${REPO_BLOB_BASE}/${packageBasePath}/examples/overview.md`}>examples/overview.md</a></li>
+          </ul>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/plugins/page.tsx
+++ b/apps/web/app/plugins/page.tsx
@@ -1,0 +1,45 @@
+import { loadPluginsRegistry, uniqueValues } from "@/lib/registry";
+import CatalogClient from "@/components/CatalogClient";
+import { parseMultiValue, type SearchParamValue } from "@/lib/catalogFilters";
+import { getDomainKey } from "@/lib/categoryLabels";
+
+type SearchParams = {
+  q?: SearchParamValue;
+  tag?: SearchParamValue;
+  category?: SearchParamValue;
+  runtime?: SearchParamValue;
+};
+
+export default async function PluginsPage({ searchParams = {} }: { searchParams?: SearchParams }) {
+  const registry = await loadPluginsRegistry();
+  const q = typeof searchParams.q === "string" ? searchParams.q : "";
+  const tags = parseMultiValue(searchParams.tag);
+  const categoriesSelected = parseMultiValue(searchParams.category);
+  const runtimes = parseMultiValue(searchParams.runtime);
+
+  const categories = uniqueValues(registry.skills.map((s) => getDomainKey(s.category, "/plugins")));
+  const availableTags = uniqueValues(registry.skills.flatMap((s) => s.tags));
+
+  return (
+    <main>
+      <div className="nav">
+        <a href="/" className="pill">Home</a>
+        <a href="/skills" className="pill">Skills</a>
+        <a href="/agents" className="pill">Agents</a>
+        <a href="/tools-mcp" className="pill">Tools &amp; MCP</a>
+        <span className="pill">Plugins</span>
+      </div>
+
+      <h1>Plugins Catalog</h1>
+      <p>Browse installable bundles that package skills, agents, tools, hooks, and setup guidance into portable team capabilities.</p>
+
+      <CatalogClient
+        entries={registry.skills}
+        categories={categories}
+        tags={availableTags}
+        basePath="/plugins"
+        initial={{ q, tags, categories: categoriesSelected, runtimes }}
+      />
+    </main>
+  );
+}

--- a/apps/web/app/skills/[...id]/page.tsx
+++ b/apps/web/app/skills/[...id]/page.tsx
@@ -21,6 +21,7 @@ export default async function SkillDetailPage({ params }: { params: { id: string
         <a href="/" className="pill">Home</a>
         <a href="/skills" className="pill">Catalog</a>
         <a href="/agents" className="pill">Agents</a>
+        <a href="/plugins" className="pill">Plugins</a>
         <a href="/tools-mcp" className="pill">Tools &amp; MCP</a>
         <span className="pill">{skill.id}</span>
       </div>

--- a/apps/web/app/skills/page.tsx
+++ b/apps/web/app/skills/page.tsx
@@ -25,6 +25,7 @@ export default async function SkillsPage({ searchParams = {} }: { searchParams?:
       <div className="nav">
         <a href="/" className="pill">Home</a>
         <a href="/agents" className="pill">Agents</a>
+        <a href="/plugins" className="pill">Plugins</a>
         <a href="/tools-mcp" className="pill">Tools &amp; MCP</a>
         <span className="pill">Catalog</span>
       </div>

--- a/apps/web/app/tools-mcp/[...id]/page.tsx
+++ b/apps/web/app/tools-mcp/[...id]/page.tsx
@@ -20,6 +20,7 @@ export default async function ToolDetailPage({ params }: { params: { id: string[
     <main>
       <div className="nav">
         <a href="/" className="pill">Home</a>
+        <a href="/plugins" className="pill">Plugins</a>
         <a href="/tools-mcp" className="pill">Tools &amp; MCP</a>
         <span className="pill">{entry.id}</span>
       </div>

--- a/apps/web/app/tools-mcp/page.tsx
+++ b/apps/web/app/tools-mcp/page.tsx
@@ -26,6 +26,7 @@ export default async function ToolsMcpPage({ searchParams = {} }: { searchParams
         <a href="/" className="pill">Home</a>
         <a href="/skills" className="pill">Skills</a>
         <a href="/agents" className="pill">Agents</a>
+        <a href="/plugins" className="pill">Plugins</a>
         <span className="pill">Tools &amp; MCP</span>
       </div>
 

--- a/apps/web/components/CatalogClient.tsx
+++ b/apps/web/components/CatalogClient.tsx
@@ -18,11 +18,12 @@ type CatalogClientProps = {
   entries: RegistryEntry[];
   categories: string[];
   tags: string[];
-  basePath: "/skills" | "/agents" | "/tools-mcp";
+  basePath: "/skills" | "/agents" | "/tools-mcp" | "/plugins";
   initial: CatalogInitialFilters;
 };
 
 export default function CatalogClient({ entries, categories, tags, basePath, initial }: CatalogClientProps) {
+  const isPluginCatalog = basePath === "/plugins";
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -198,30 +199,44 @@ export default function CatalogClient({ entries, categories, tags, basePath, ini
 
       <section className="grid">
         {filtered.map((entry) => (
-          <Link key={entry.id} href={`${basePath}/${entry.id}`} className="card catalog-card">
-            <div className="catalog-card-head">
-              <span className="catalog-pack-badge">{formatCategoryFamily(entry.category)}</span>
-              <div className="catalog-status-badges">
-                <span className={`catalog-status-badge is-${entry.readiness}`}>
-                  {formatReadinessLabel(entry.readiness)}
-                </span>
-                {entry.security_reviewed ? (
-                  <span className="catalog-status-badge is-reviewed-detail">Security</span>
+          <article key={entry.id} className="card catalog-card">
+            <Link href={`${basePath}/${entry.id}`} className="catalog-card-link">
+              <div className="catalog-card-head">
+                <span className="catalog-pack-badge">{formatCategoryFamily(entry.category)}</span>
+                <div className="catalog-status-badges">
+                  <span className={`catalog-status-badge is-${entry.readiness}`}>
+                    {formatReadinessLabel(entry.readiness)}
+                  </span>
+                  {entry.security_reviewed ? (
+                    <span className="catalog-status-badge is-reviewed-detail">Security</span>
+                  ) : null}
+                </div>
+              </div>
+              <p className="meta catalog-card-id">{entry.id}</p>
+              <h2>{entry.name}</h2>
+              <p>{entry.description}</p>
+              <div className="tags">
+                {entry.tags.slice(0, 2).map((tagEntry) => (
+                  <span key={tagEntry} className="tag">{tagEntry}</span>
+                ))}
+                {entry.tags.length > 2 ? (
+                  <span className="tag tag--muted">+{entry.tags.length - 2}</span>
                 ) : null}
               </div>
-            </div>
-            <p className="meta catalog-card-id">{entry.id}</p>
-            <h2>{entry.name}</h2>
-            <p>{entry.description}</p>
-            <div className="tags">
-              {entry.tags.slice(0, 2).map((tagEntry) => (
-                <span key={tagEntry} className="tag">{tagEntry}</span>
-              ))}
-              {entry.tags.length > 2 ? (
-                <span className="tag tag--muted">+{entry.tags.length - 2}</span>
-              ) : null}
-            </div>
-          </Link>
+            </Link>
+            {isPluginCatalog ? (
+              <div className="catalog-card-actions">
+                <a
+                  href={`https://github.com/ai-knowledge-hub/ai-skills-guide/blob/main/plugins/${entry.id}/plugin.yaml`}
+                  className="catalog-card-secondary-link"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  View package file
+                </a>
+              </div>
+            ) : null}
+          </article>
         ))}
       </section>
     </>

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -57,8 +57,6 @@ test("plugins route and detail smoke", async ({ page }) => {
     "href",
     "https://github.com/ai-knowledge-hub/ai-skills-guide/blob/main/plugins/marketing/performance-reporting-plugin/plugin.yaml"
   );
-  await page.getByRole("button", { name: "Domain" }).click();
-  await page.getByRole("menuitemcheckbox", { name: /Marketing Plugins/ }).click();
   await expect(page.getByText("Performance Reporting Plugin")).toBeVisible();
 
   await page.goto(samplePluginPath);

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -2,12 +2,14 @@ import { expect, test } from "@playwright/test";
 
 const sampleSkillPath = "/skills/marketing/meta-google-weekly-performance-review";
 const sampleAgentPath = "/agents/marketing/weekly-performance-supervisor";
+const samplePluginPath = "/plugins/marketing/performance-reporting-plugin";
 const sampleToolPath = "/tools-mcp/analytics/ga4-mcp-connector";
 
 test("home route smoke", async ({ page }) => {
   await page.goto("/");
   await expect(page.getByRole("link", { name: "Skills", exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: "Agents", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Plugins", exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: "Tools & MCP" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Explore skills" })).toBeVisible();
 });
@@ -42,6 +44,27 @@ test("agents route and detail smoke", async ({ page }) => {
   await page.goto(sampleAgentPath);
   await expect(page.getByRole("heading", { name: "Weekly Performance Supervisor" })).toBeVisible();
   await expect(page.getByText("Marketing Agents / Performance")).toBeVisible();
+});
+
+test("plugins route and detail smoke", async ({ page }) => {
+  await page.goto("/plugins");
+  await expect(page.getByRole("heading", { name: "Plugins Catalog" })).toBeVisible();
+  await expect(page.getByText(/\d+ result\(s\)/)).toBeVisible();
+  const packageFileLink = page.getByRole("link", { name: "View package file" }).first();
+  await expect(packageFileLink).toBeVisible();
+  await expect(packageFileLink).toHaveAttribute(
+    "href",
+    "https://github.com/ai-knowledge-hub/ai-skills-guide/blob/main/plugins/marketing/performance-reporting-plugin/plugin.yaml"
+  );
+  await page.getByRole("button", { name: "Domain" }).click();
+  await page.getByRole("menuitemcheckbox", { name: /Marketing Plugins/ }).click();
+  await expect(page.getByText("Performance Reporting Plugin")).toBeVisible();
+
+  await page.goto(samplePluginPath);
+  await expect(page.getByRole("heading", { name: "Performance Reporting Plugin" })).toBeVisible();
+  await expect(page.getByText("Marketing Plugins / Reporting")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Included Components" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "marketing/meta-google-weekly-performance-review" })).toBeVisible();
 });
 
 test("tools route and detail smoke", async ({ page }) => {

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -50,7 +50,8 @@ test("plugins route and detail smoke", async ({ page }) => {
   await page.goto("/plugins");
   await expect(page.getByRole("heading", { name: "Plugins Catalog" })).toBeVisible();
   await expect(page.getByText(/\d+ result\(s\)/)).toBeVisible();
-  const packageFileLink = page.getByRole("link", { name: "View package file" }).first();
+  const performancePluginCard = page.locator(".catalog-card").filter({ hasText: "Performance Reporting Plugin" }).first();
+  const packageFileLink = performancePluginCard.getByRole("link", { name: "View package file" });
   await expect(packageFileLink).toBeVisible();
   await expect(packageFileLink).toHaveAttribute(
     "href",

--- a/apps/web/lib/categoryLabels.ts
+++ b/apps/web/lib/categoryLabels.ts
@@ -18,6 +18,12 @@ const CATEGORY_LABELS: Record<string, string> = {
   "agentops/harness-evolution": "AgentOps / Harness Evolution",
   "agentops/harness-governance": "AgentOps / Harness Governance",
   "agentops/harness-evaluation": "AgentOps / Harness Evaluation",
+  "marketing-plugins/reporting": "Marketing Plugins / Reporting",
+  "marketing-plugins/audit": "Marketing Plugins / Audit",
+  "marketing-plugins/seo": "Marketing Plugins / SEO",
+  "marketing-plugins/content": "Marketing Plugins / Content",
+  "marketing-plugins/intelligence": "Marketing Plugins / Intelligence",
+  "marketing-plugins/creative": "Marketing Plugins / Creative",
   "marketing-agents/performance": "Marketing Agents / Performance",
   "marketing-agents/governance": "Marketing Agents / Governance",
   "adtech-agents/analytics": "Adtech Agents / Analytics",
@@ -49,6 +55,7 @@ export function formatCategoryFamily(category: string) {
   if (family === "engineering") return "Engineering";
   if (family === "security") return "Security";
   if (family === "agentops") return "AgentOps";
+  if (family === "marketing-plugins") return "Marketing Plugins";
   if (family === "marketing-agents") return "Marketing Agents";
   if (family === "adtech-agents") return "Adtech Agents";
   if (family === "tools-mcp") return "Tools & MCP";
@@ -63,16 +70,16 @@ export function normalizeCategoryFilterValues(categories: string[]) {
   return [...new Set(categories.map((category) => getCategoryFamilyKey(category)))];
 }
 
-export function getDomainKey(category: string, basePath: "/skills" | "/agents" | "/tools-mcp") {
+export function getDomainKey(category: string, basePath: "/skills" | "/agents" | "/tools-mcp" | "/plugins") {
   const [family, domain] = category.split("/");
-  if (basePath === "/tools-mcp") {
+  if (basePath === "/tools-mcp" || basePath === "/plugins") {
     return domain ?? family ?? category;
   }
   return family ?? category;
 }
 
-export function formatDomainLabel(domain: string, basePath: "/skills" | "/agents" | "/tools-mcp") {
-  if (basePath === "/tools-mcp") {
+export function formatDomainLabel(domain: string, basePath: "/skills" | "/agents" | "/tools-mcp" | "/plugins") {
+  if (basePath === "/tools-mcp" || basePath === "/plugins") {
     return domain
       .split("-")
       .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
@@ -83,7 +90,7 @@ export function formatDomainLabel(domain: string, basePath: "/skills" | "/agents
 
 export function normalizeDomainFilterValues(
   categories: string[],
-  basePath: "/skills" | "/agents" | "/tools-mcp"
+  basePath: "/skills" | "/agents" | "/tools-mcp" | "/plugins"
 ) {
   return [...new Set(categories.map((category) => getDomainKey(category, basePath)))];
 }

--- a/apps/web/lib/registry.ts
+++ b/apps/web/lib/registry.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-export type ModuleKey = "skills" | "agents" | "tools";
+export type ModuleKey = "skills" | "agents" | "tools" | "plugins";
 
 export type VersionEntry = {
   version: string;
@@ -24,6 +24,16 @@ export type RegistryEntry = {
   security_reviewed: boolean;
   deprecated: boolean;
   replaced_by?: string;
+  includes?: {
+    skills?: string[];
+    agents?: string[];
+    tools?: string[];
+    hooks?: string[];
+  };
+  requires?: {
+    secrets?: string[];
+    approvals?: string[];
+  };
 };
 
 export type RegistryIndex = {
@@ -41,6 +51,9 @@ function moduleIndexPath(module: ModuleKey) {
   }
   if (module === "agents") {
     return path.join(base, "agents-index.json");
+  }
+  if (module === "plugins") {
+    return path.join(base, "plugins-index.json");
   }
   return path.join(base, "tools-index.json");
 }
@@ -75,6 +88,10 @@ export async function loadToolsRegistry() {
   return loadRegistry("tools");
 }
 
+export async function loadPluginsRegistry() {
+  return loadRegistry("plugins");
+}
+
 export async function getEntryById(module: ModuleKey, id: string): Promise<RegistryEntry | undefined> {
   const registry = await loadRegistry(module);
   return registry.skills.find((s) => s.id === id);
@@ -103,6 +120,8 @@ export function buildModuleInstallSnippet(
     const targetDir =
       module === "agents"
         ? "./my-agent/agents"
+        : module === "plugins"
+          ? "./my-agent/plugins"
         : module === "tools"
           ? "./my-agent/tools-mcp"
           : "./my-agent/skills";

--- a/apps/web/scripts/prepare-public-assets.mjs
+++ b/apps/web/scripts/prepare-public-assets.mjs
@@ -8,14 +8,15 @@ const publicRoot = path.resolve(process.cwd(), "public");
 const modules = [
   { dir: "skills", manifest: "skill.yaml" },
   { dir: "agents", manifest: "agent.yaml" },
-  { dir: "tools-mcp", manifest: "tool.yaml" }
+  { dir: "tools-mcp", manifest: "tool.yaml" },
+  { dir: "plugins", manifest: "plugin.yaml" }
 ];
 
 async function main() {
   await fs.mkdir(publicRoot, { recursive: true });
 
   // Rebuild generated static directories so manifest/artifact URLs stay in sync.
-  for (const generatedDir of ["skills", "agents", "tools-mcp", "artifacts", "registry"]) {
+  for (const generatedDir of ["skills", "agents", "tools-mcp", "plugins", "artifacts", "registry"]) {
     await fs.rm(path.join(publicRoot, generatedDir), { recursive: true, force: true });
   }
 
@@ -66,7 +67,7 @@ async function publishRegistryIndexes() {
   const outRegistryRoot = path.join(publicRoot, "registry");
   await fs.mkdir(outRegistryRoot, { recursive: true });
 
-  for (const fileName of ["index.json", "skills-index.json", "agents-index.json", "tools-index.json"]) {
+  for (const fileName of ["index.json", "skills-index.json", "agents-index.json", "tools-index.json", "plugins-index.json"]) {
     const inPath = path.join(registryRoot, fileName);
     try {
       await fs.access(inPath);

--- a/cmd/registry-builder/main.go
+++ b/cmd/registry-builder/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	fs := flag.NewFlagSet("registry-builder", flag.ExitOnError)
 	root := fs.String("root", ".", "repository root")
-	module := fs.String("module", "all", "module to build: skills|agents|tools|all")
+	module := fs.String("module", "all", "module to build: skills|agents|tools|plugins|all")
 	out := fs.String("out", "", "output path relative to root (single-module mode only)")
 	outDir := fs.String("out-dir", "registry", "output directory relative to root")
 	_ = fs.Parse(os.Args[1:])
@@ -29,10 +29,12 @@ func main() {
 		writeSingle(absRoot, *outDir, defaultOut(*out, "agents-index.json"), registry.BuildAgentsIndex)
 	case "tools":
 		writeSingle(absRoot, *outDir, defaultOut(*out, "tools-index.json"), registry.BuildToolsIndex)
+	case "plugins":
+		writeSingle(absRoot, *outDir, defaultOut(*out, "plugins-index.json"), registry.BuildPluginsIndex)
 	case "all":
 		writeAll(absRoot, *outDir)
 	default:
-		fatal(fmt.Errorf("invalid --module %q (use skills|agents|tools|all)", *module))
+		fatal(fmt.Errorf("invalid --module %q (use skills|agents|tools|plugins|all)", *module))
 	}
 }
 
@@ -63,6 +65,7 @@ func writeAll(absRoot, outDir string) {
 	writeSingle(absRoot, outDir, "skills-index.json", registry.BuildSkillsIndex)
 	writeSingle(absRoot, outDir, "agents-index.json", registry.BuildAgentsIndex)
 	writeSingle(absRoot, outDir, "tools-index.json", registry.BuildToolsIndex)
+	writeSingle(absRoot, outDir, "plugins-index.json", registry.BuildPluginsIndex)
 	// Backward compatibility: keep legacy skills index path.
 	writeSingle(absRoot, outDir, "index.json", registry.BuildSkillsIndex)
 }

--- a/cmd/skills-hub/main.go
+++ b/cmd/skills-hub/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -53,7 +54,7 @@ func main() {
 
 func runList(args []string) error {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	module := fs.String("module", "skills", "module: skills|agents|tools")
+	module := fs.String("module", "skills", "module: skills|agents|tools|plugins")
 	registryPath := fs.String("registry", "", "registry index path (defaults by module)")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -79,7 +80,7 @@ func runList(args []string) error {
 
 func runSearch(args []string) error {
 	fs := flag.NewFlagSet("search", flag.ContinueOnError)
-	module := fs.String("module", "skills", "module: skills|agents|tools")
+	module := fs.String("module", "skills", "module: skills|agents|tools|plugins")
 	registryPath := fs.String("registry", "", "registry index path (defaults by module)")
 	text := fs.String("q", "", "free text search against id/name/description")
 	tag := fs.String("tag", "", "filter by tag")
@@ -112,7 +113,7 @@ func runSearch(args []string) error {
 
 func runInfo(args []string) error {
 	fs := flag.NewFlagSet("info", flag.ContinueOnError)
-	module := fs.String("module", "skills", "module: skills|agents|tools")
+	module := fs.String("module", "skills", "module: skills|agents|tools|plugins")
 	registryPath := fs.String("registry", "", "registry index path (defaults by module)")
 	entriesRoot := fs.String("root", "", "module root directory (defaults by module)")
 	skillSpec := fs.String("skill", "", "skill id, optionally with @version")
@@ -169,6 +170,9 @@ func runInfo(args []string) error {
 	if skill.ReplacedBy != "" {
 		fmt.Printf("replaced_by: %s\n", skill.ReplacedBy)
 	}
+	if moduleName == "plugins" {
+		printPluginSummary(os.Stdout, skill)
+	}
 	return nil
 }
 
@@ -203,7 +207,7 @@ func runInstall(args []string) error {
 	}
 
 	fs := flag.NewFlagSet("install", flag.ContinueOnError)
-	module := fs.String("module", "skills", "module: skills|agents|tools")
+	module := fs.String("module", "skills", "module: skills|agents|tools|plugins")
 	entriesRoot := fs.String("root", "", "module root directory (defaults by module)")
 	registryPath := fs.String("registry", "", "registry index path (defaults by module)")
 	runtimeName := fs.String("runtime", "generic", "runtime adapter: codex|claude|generic")
@@ -270,7 +274,95 @@ func runInstall(args []string) error {
 		return err
 	}
 
+	var runtimeArtifacts []string
+	if moduleName == "plugins" {
+		runtimeArtifacts, err = installer.PreparePluginRuntimeArtifacts(destination, rt.Runtime)
+		if err != nil {
+			return err
+		}
+	}
+
 	fmt.Printf("Installed %s@%s to %s (runtime=%s)\n", skill.ID, resolvedVersion.Version, destination, rt.Runtime)
+	if moduleName == "plugins" {
+		printPluginInstallNotes(os.Stdout, os.Stderr, skill, rt.Runtime, destination, runtimeArtifacts)
+	}
+	return nil
+}
+
+func printPluginSummary(w io.Writer, entry registry.SkillEntry) {
+	skills := optionalList(entry.Includes, "skills")
+	agents := optionalList(entry.Includes, "agents")
+	tools := optionalList(entry.Includes, "tools")
+	hooks := optionalList(entry.Includes, "hooks")
+	secrets := optionalList(entry.Requires, "secrets")
+	approvals := optionalList(entry.Requires, "approvals")
+
+	fmt.Fprintf(w, "includes.skills: %d\n", len(skills))
+	if len(skills) > 0 {
+		fmt.Fprintf(w, "includes.skills.list: %s\n", strings.Join(skills, ", "))
+	}
+	fmt.Fprintf(w, "includes.agents: %d\n", len(agents))
+	if len(agents) > 0 {
+		fmt.Fprintf(w, "includes.agents.list: %s\n", strings.Join(agents, ", "))
+	}
+	fmt.Fprintf(w, "includes.tools: %d\n", len(tools))
+	if len(tools) > 0 {
+		fmt.Fprintf(w, "includes.tools.list: %s\n", strings.Join(tools, ", "))
+	}
+	fmt.Fprintf(w, "includes.hooks: %d\n", len(hooks))
+	if len(hooks) > 0 {
+		fmt.Fprintf(w, "includes.hooks.list: %s\n", strings.Join(hooks, ", "))
+	}
+	if len(secrets) > 0 {
+		fmt.Fprintf(w, "requires.secrets: %s\n", strings.Join(secrets, ", "))
+	}
+	if len(approvals) > 0 {
+		fmt.Fprintf(w, "requires.approvals: %s\n", strings.Join(approvals, ", "))
+	}
+}
+
+func printPluginInstallNotes(stdout, stderr io.Writer, entry registry.SkillEntry, runtime, destination string, runtimeArtifacts []string) {
+	if !entry.SecurityReviewed {
+		fmt.Fprintf(stderr, "warning: %s is not security reviewed; inspect bundled components and setup before use\n", entry.ID)
+	}
+	if destination != "" {
+		fmt.Fprintf(stdout, "install.root: %s\n", destination)
+	}
+	if len(runtimeArtifacts) > 0 {
+		fmt.Fprintf(stdout, "install.runtime_artifacts: %s\n", strings.Join(runtimeArtifacts, ", "))
+	}
+	if runtime == "codex" || runtime == "claude" {
+		fmt.Fprintf(stdout, "install.next_step: review the generated %s runtime manifest before enabling the plugin\n", runtime)
+	} else if runtime != "" {
+		fmt.Fprintf(stdout, "install.next_step: connect this plugin directory to your runtime manually and verify required secrets before use\n")
+	}
+	printPluginSummary(stdout, entry)
+}
+
+func optionalList[T any](set *T, field string) []string {
+	if set == nil {
+		return nil
+	}
+	switch v := any(set).(type) {
+	case *registry.IncludeSet:
+		switch field {
+		case "skills":
+			return v.Skills
+		case "agents":
+			return v.Agents
+		case "tools":
+			return v.Tools
+		case "hooks":
+			return v.Hooks
+		}
+	case *registry.RequirementSet:
+		switch field {
+		case "secrets":
+			return v.Secrets
+		case "approvals":
+			return v.Approvals
+		}
+	}
 	return nil
 }
 
@@ -297,7 +389,7 @@ func parseSkillSpec(spec string) (string, string, error) {
 
 func printUsage() {
 	lines := []string{
-		"skills-hub: manage local marketing/adtech skill, agent, and tool packages",
+		"skills-hub: manage local skill, agent, tool, and plugin packages",
 		"",
 		"Usage:",
 		"  skills-hub <command> [flags]",
@@ -315,9 +407,11 @@ func printUsage() {
 		"  skills-hub search --tag paid-media --runtime codex",
 		"  skills-hub info --skill marketing/meta-google-weekly-performance-review@latest",
 		"  skills-hub info --module agents --entry marketing/weekly-performance-supervisor@latest",
+		"  skills-hub info --module plugins --entry marketing/performance-reporting-plugin@latest",
 		"  skills-hub validate",
 		"  skills-hub install marketing/meta-google-weekly-performance-review@latest --runtime codex",
 		"  skills-hub install --module agents --entry marketing/weekly-performance-supervisor@latest --runtime codex",
+		"  skills-hub install --module plugins --entry marketing/performance-reporting-plugin@latest --runtime codex",
 		"  skills-hub install --skill marketing/meta-google-weekly-performance-review@0.1.0 --runtime generic --target ./my-agent/skills",
 		"  skills-hub run-agent --agent marketing/weekly-performance-supervisor --bindings agents/marketing/weekly-performance-supervisor/config/tool-bindings.example.json --approve-live",
 	}
@@ -393,8 +487,10 @@ func normalizeModule(raw string) (string, error) {
 		return "agents", nil
 	case "tools", "tool", "tools-mcp":
 		return "tools", nil
+	case "plugins", "plugin":
+		return "plugins", nil
 	default:
-		return "", fmt.Errorf("unsupported module: %s (supported: skills, agents, tools)", raw)
+		return "", fmt.Errorf("unsupported module: %s (supported: skills, agents, tools, plugins)", raw)
 	}
 }
 
@@ -409,6 +505,8 @@ func resolveRegistryPath(explicit, module string) string {
 		return "registry/agents-index.json"
 	case "tools":
 		return "registry/tools-index.json"
+	case "plugins":
+		return "registry/plugins-index.json"
 	default:
 		return "registry/index.json"
 	}
@@ -425,6 +523,8 @@ func resolveModuleRoot(explicit, module string) string {
 		return "agents"
 	case "tools":
 		return "tools-mcp"
+	case "plugins":
+		return "plugins"
 	default:
 		return "skills"
 	}

--- a/cmd/skills-hub/main_test.go
+++ b/cmd/skills-hub/main_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ai-knowledge-hub/ai-skills-guide/internal/registry"
+)
+
+func TestPrintPluginSummary(t *testing.T) {
+	entry := registry.SkillEntry{
+		ID: "marketing/performance-reporting-plugin",
+		Includes: &registry.IncludeSet{
+			Skills: []string{"marketing/meta-google-weekly-performance-review", "adtech/dashboard-generator"},
+			Agents: []string{"marketing/weekly-performance-supervisor"},
+			Tools:  []string{"analytics/ga4-mcp-connector"},
+			Hooks:  []string{"post-analysis-slack-summary"},
+		},
+		Requires: &registry.RequirementSet{
+			Secrets:   []string{"GA4_PROPERTY_ID", "SLACK_WEBHOOK_URL"},
+			Approvals: []string{"human-review-for-write-actions"},
+		},
+	}
+
+	var out bytes.Buffer
+	printPluginSummary(&out, entry)
+	rendered := out.String()
+
+	expected := []string{
+		"includes.skills: 2",
+		"includes.skills.list: marketing/meta-google-weekly-performance-review, adtech/dashboard-generator",
+		"includes.agents: 1",
+		"includes.agents.list: marketing/weekly-performance-supervisor",
+		"includes.tools: 1",
+		"includes.tools.list: analytics/ga4-mcp-connector",
+		"includes.hooks: 1",
+		"includes.hooks.list: post-analysis-slack-summary",
+		"requires.secrets: GA4_PROPERTY_ID, SLACK_WEBHOOK_URL",
+		"requires.approvals: human-review-for-write-actions",
+	}
+	for _, needle := range expected {
+		if !strings.Contains(rendered, needle) {
+			t.Fatalf("expected output to contain %q, got:\n%s", needle, rendered)
+		}
+	}
+}
+
+func TestPrintPluginInstallNotesWarnsWhenNotSecurityReviewed(t *testing.T) {
+	entry := registry.SkillEntry{
+		ID:               "marketing/performance-reporting-plugin",
+		SecurityReviewed: false,
+		Includes:         &registry.IncludeSet{},
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	printPluginInstallNotes(
+		&out,
+		&errOut,
+		entry,
+		"codex",
+		"/tmp/plugins/marketing/performance-reporting-plugin",
+		[]string{"/tmp/plugins/marketing/performance-reporting-plugin/.codex-plugin/plugin.json"},
+	)
+
+	if !strings.Contains(errOut.String(), "is not security reviewed") {
+		t.Fatalf("expected security review warning, got: %s", errOut.String())
+	}
+	if !strings.Contains(out.String(), "includes.skills: 0") {
+		t.Fatalf("expected plugin summary in stdout, got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "install.root: /tmp/plugins/marketing/performance-reporting-plugin") {
+		t.Fatalf("expected install root in stdout, got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "install.runtime_artifacts: /tmp/plugins/marketing/performance-reporting-plugin/.codex-plugin/plugin.json") {
+		t.Fatalf("expected runtime artifact path in stdout, got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "install.next_step: review the generated codex runtime manifest before enabling the plugin") {
+		t.Fatalf("expected next step guidance in stdout, got: %s", out.String())
+	}
+}

--- a/docs/architecture-modules.md
+++ b/docs/architecture-modules.md
@@ -1,4 +1,4 @@
-# Module Architecture: Skills, Agents, Tools & MCP
+# Module Architecture: Skills, Agents, Plugins, Tools & MCP
 
 ## Purpose
 Define the target architecture for a single codebase with separate product
@@ -8,6 +8,8 @@ modules and registries.
 - Skills: reusable task-level expertise packages across marketing, adtech,
   engineering, security, and agent operations.
 - Agents: orchestrated templates that compose role, memory, skills, and tools.
+- Plugins: installable bundles that package skills, agents, tools, hooks, and
+  setup guidance into portable team capabilities.
 - Tools & MCP: integration connectors, adapters, and MCP server definitions.
 
 ## Repository Structure
@@ -18,32 +20,39 @@ agents/
   <domain>/<slug>/
 tools-mcp/
   <domain>/<slug>/
+plugins/
+  <domain>/<slug>/
 
 registry/
   skills-index.json
   agents-index.json
+  plugins-index.json
   tools-index.json
 ```
 
 ## Route Structure
 - `/skills`
 - `/agents`
+- `/plugins`
 - `/tools-mcp`
 
 Detail routes:
 - `/skills/<domain>/<slug>`
 - `/agents/<domain>/<slug>`
+- `/plugins/<domain>/<slug>`
 - `/tools-mcp/<domain>/<slug>`
 
 ## Manifest Contracts
 - Skills: `skill.yaml` validated by `shared/schemas/skill.schema.json`
 - Agents: `agent.yaml` validated by `shared/schemas/agent.schema.json`
+- Plugins: `plugin.yaml` validated by `shared/schemas/plugin.schema.json`
 - Tools: `tool.yaml` validated by `shared/schemas/tool.schema.json`
 
 ## Registry Generation
 Build separate indexes from each top-level folder:
 - `skills/` -> `registry/skills-index.json`
 - `agents/` -> `registry/agents-index.json`
+- `plugins/` -> `registry/plugins-index.json`
 - `tools-mcp/` -> `registry/tools-index.json`
 
 Each index entry must contain:
@@ -53,6 +62,7 @@ Each index entry must contain:
 ## Domain Routing Strategy
 - `skills.ai-knowledge-hub.org` serves `/skills`
 - `agents.ai-knowledge-hub.org` serves `/agents`
+- plugins remain on `/plugins` initially, with optional future domain split
 - tools & MCP remains on `/tools-mcp` initially, with optional future domain split
 
 ## Backward Compatibility

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -1,0 +1,66 @@
+# Plugin Architecture
+
+## Purpose
+
+Plugins are the packaging layer of the hub. They bundle reusable skills,
+agent templates, tool references, hook definitions, and setup guidance into
+one installable unit.
+
+## Position in the stack
+
+- `skills/`: task-level expertise
+- `agents/`: orchestrated behavior templates
+- `tools-mcp/`: integration connectors and MCP definitions
+- `plugins/`: portable bundles that compose the layers above
+
+## Plugin package shape
+
+```text
+plugins/
+  <domain>/<slug>/
+    README.md
+    plugin.yaml
+    plugin.json
+    examples/
+    tests/
+      test-prompts.md
+```
+
+## Registry model
+
+The registry index exposes plugin metadata plus composition fields:
+
+- `includes.skills`
+- `includes.agents`
+- `includes.tools`
+- `includes.hooks`
+- `requires.secrets`
+- `requires.approvals`
+
+## Current first-wave plugin categories
+
+- `marketing-plugins/reporting`
+- `marketing-plugins/audit`
+- `marketing-plugins/seo`
+- `marketing-plugins/content`
+- `marketing-plugins/intelligence`
+- `marketing-plugins/creative`
+
+## Runtime install behavior
+
+Plugin installs now preserve the package directory and, for supported runtimes,
+also generate a runtime-specific manifest inside the installed plugin folder:
+
+- `codex` -> `.codex-plugin/plugin.json`
+- `claude` -> `.claude-plugin/plugin.json`
+
+These generated files are derived from the package `plugin.json` and stamped
+with the target runtime. They are scaffolding artifacts, not proof that the
+plugin is production approved.
+
+## Current boundaries
+
+This implementation is still registry-first. The installer prepares runtime-
+specific plugin manifests for `codex` and `claude`, but teams are still
+responsible for reviewing bundled components, wiring secrets, and enforcing
+approval rules before enabling plugins in live environments.

--- a/docs/plugin-authoring-guide.md
+++ b/docs/plugin-authoring-guide.md
@@ -1,0 +1,56 @@
+# Plugin Authoring Guide
+
+## When to create a plugin
+
+Create a plugin when a workflow needs to be shared as one installable team
+capability instead of as separate skills, agents, and tools.
+
+Good plugin candidates:
+- weekly reporting bundles
+- campaign QA bundles
+- SEO diagnostic bundles
+- content repurposing bundles
+
+## Minimum required files
+
+```text
+<plugin>/
+  README.md
+  plugin.yaml
+  plugin.json
+  examples/
+  tests/
+    test-prompts.md
+```
+
+## Authoring rules
+
+1. Keep plugins compositional.
+   Prefer referencing existing `skills/`, `agents/`, and `tools-mcp/` entries.
+2. Make setup explicit.
+   Declare required secrets and approval gates in `plugin.yaml`.
+3. Keep runtime packaging honest.
+   The installer will generate `.codex-plugin/plugin.json` or
+   `.claude-plugin/plugin.json` on install for those runtimes. Keep the source
+   `plugin.json` minimal and runtime-agnostic, and document any manual steps
+   that still remain after generation.
+4. Treat hooks as risk-bearing.
+   Any automatic action should be explained in `README.md`.
+
+## Required manifest sections
+
+- identity: `id`, `name`, `description`, `version`, `released_at`
+- placement: `category`, `tags`, `runtimes`
+- structure: `entrypoints`
+- composition: `includes`
+- governance: `requires`, `verification`
+
+## Definition of done
+
+- valid `plugin.yaml`
+- clear `README.md`
+- at least 5 prompts in `tests/test-prompts.md`
+- one example flow in `examples/`
+- included component references resolve to real registry entries
+- required secrets and approvals are documented
+- generated runtime manifests are safe to inspect before enablement

--- a/docs/plugin-security-and-review.md
+++ b/docs/plugin-security-and-review.md
@@ -1,0 +1,39 @@
+# Plugin Security and Review
+
+## Why plugins need extra scrutiny
+
+Plugins package multiple moving parts together:
+- skills
+- agents
+- tools/MCP references
+- hooks
+- runtime setup guidance
+
+That makes them higher leverage than a standalone skill and therefore a higher
+review surface.
+
+## Required review questions
+
+1. Does the plugin request only the secrets it actually needs?
+2. Are write-capable tools or hooks clearly disclosed?
+3. Are approval gates explicit for risky actions?
+4. Do included components point to trusted registry entries?
+5. Are hook names and automation behavior understandable from the README?
+
+## Current trust model
+
+Plugins in this repo should be treated as one of:
+- `experimental`
+- `reviewed`
+- `deprecated`
+
+`security_reviewed: true` should only be used when the packaged composition,
+not just the individual pieces, has been reviewed.
+
+## First-wave guardrails
+
+- prefer read-oriented or review-oriented workflows
+- disclose all required secrets
+- disclose all approval expectations
+- avoid implying that remote MCP connectors are trusted by default
+- keep runtime manifests and setup instructions auditable in plain text

--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -1,11 +1,13 @@
 package installer
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func InstallSkill(sourceDir, targetRoot, skillID string, force bool) (string, error) {
@@ -23,6 +25,40 @@ func InstallSkill(sourceDir, targetRoot, skillID string, force bool) (string, er
 		return "", err
 	}
 	return destinationDir, nil
+}
+
+func PreparePluginRuntimeArtifacts(destinationDir, runtime string) ([]string, error) {
+	normalizedRuntime := strings.ToLower(strings.TrimSpace(runtime))
+	if normalizedRuntime != "codex" && normalizedRuntime != "claude" {
+		return nil, nil
+	}
+
+	sourceManifest := filepath.Join(destinationDir, "plugin.json")
+	payload, err := os.ReadFile(sourceManifest)
+	if err != nil {
+		return nil, fmt.Errorf("read plugin manifest %s: %w", sourceManifest, err)
+	}
+
+	var manifest map[string]any
+	if err := json.Unmarshal(payload, &manifest); err != nil {
+		return nil, fmt.Errorf("parse plugin manifest %s: %w", sourceManifest, err)
+	}
+	manifest["runtime"] = normalizedRuntime
+
+	runtimeDir := filepath.Join(destinationDir, "."+normalizedRuntime+"-plugin")
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create runtime manifest dir %s: %w", runtimeDir, err)
+	}
+
+	rendered, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("render runtime manifest: %w", err)
+	}
+	runtimeManifestPath := filepath.Join(runtimeDir, "plugin.json")
+	if err := os.WriteFile(runtimeManifestPath, append(rendered, '\n'), 0o644); err != nil {
+		return nil, fmt.Errorf("write runtime manifest %s: %w", runtimeManifestPath, err)
+	}
+	return []string{runtimeManifestPath}, nil
 }
 
 func copyTree(src, dst string) error {

--- a/internal/installer/runtime.go
+++ b/internal/installer/runtime.go
@@ -84,7 +84,9 @@ func normalizeModuleDir(moduleName string) (string, error) {
 		return "agents", nil
 	case "tools", "tool", "tools-mcp":
 		return "tools-mcp", nil
+	case "plugins", "plugin":
+		return "plugins", nil
 	default:
-		return "", fmt.Errorf("unsupported module: %s (supported: skills, agents, tools)", moduleName)
+		return "", fmt.Errorf("unsupported module: %s (supported: skills, agents, tools, plugins)", moduleName)
 	}
 }

--- a/internal/installer/runtime_test.go
+++ b/internal/installer/runtime_test.go
@@ -1,7 +1,9 @@
 package installer
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -70,5 +72,84 @@ func TestResolveRuntimeTargetForModuleToolsMcp(t *testing.T) {
 	expected := filepath.Join("/tmp/claude-home", "tools-mcp")
 	if target.TargetPath != expected {
 		t.Fatalf("expected %s, got %s", expected, target.TargetPath)
+	}
+}
+
+func TestResolveRuntimeTargetForModulePlugins(t *testing.T) {
+	t.Setenv("CODEX_HOME", "/tmp/codex-home")
+	target, err := ResolveRuntimeTargetForModule("codex", "plugins", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join("/tmp/codex-home", "plugins")
+	if target.TargetPath != expected {
+		t.Fatalf("expected %s, got %s", expected, target.TargetPath)
+	}
+}
+
+func TestPreparePluginRuntimeArtifactsForCodex(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "plugin.json")
+	if err := os.WriteFile(manifestPath, []byte("{\n  \"name\": \"demo-plugin\",\n  \"version\": \"0.1.0\"\n}\n"), 0o644); err != nil {
+		t.Fatalf("write plugin manifest: %v", err)
+	}
+
+	artifacts, err := PreparePluginRuntimeArtifacts(dir, "codex")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("expected one runtime artifact, got %d", len(artifacts))
+	}
+	if !strings.HasSuffix(artifacts[0], filepath.Join(".codex-plugin", "plugin.json")) {
+		t.Fatalf("unexpected artifact path: %s", artifacts[0])
+	}
+	rendered, err := os.ReadFile(artifacts[0])
+	if err != nil {
+		t.Fatalf("read generated artifact: %v", err)
+	}
+	if !strings.Contains(string(rendered), "\"runtime\": \"codex\"") {
+		t.Fatalf("expected runtime field in generated artifact, got:\n%s", string(rendered))
+	}
+}
+
+func TestPreparePluginRuntimeArtifactsForClaude(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "plugin.json")
+	if err := os.WriteFile(manifestPath, []byte("{\n  \"name\": \"demo-plugin\",\n  \"version\": \"0.1.0\"\n}\n"), 0o644); err != nil {
+		t.Fatalf("write plugin manifest: %v", err)
+	}
+
+	artifacts, err := PreparePluginRuntimeArtifacts(dir, "claude")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("expected one runtime artifact, got %d", len(artifacts))
+	}
+	if !strings.HasSuffix(artifacts[0], filepath.Join(".claude-plugin", "plugin.json")) {
+		t.Fatalf("unexpected artifact path: %s", artifacts[0])
+	}
+	rendered, err := os.ReadFile(artifacts[0])
+	if err != nil {
+		t.Fatalf("read generated artifact: %v", err)
+	}
+	if !strings.Contains(string(rendered), "\"runtime\": \"claude\"") {
+		t.Fatalf("expected runtime field in generated artifact, got:\n%s", string(rendered))
+	}
+}
+
+func TestPreparePluginRuntimeArtifactsForGenericSkips(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), []byte("{\"name\":\"demo-plugin\"}\n"), 0o644); err != nil {
+		t.Fatalf("write plugin manifest: %v", err)
+	}
+
+	artifacts, err := PreparePluginRuntimeArtifacts(dir, "generic")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(artifacts) != 0 {
+		t.Fatalf("expected no artifacts for generic runtime, got %d", len(artifacts))
 	}
 }

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -31,6 +31,10 @@ func BuildToolsIndex(root string) (Index, error) {
 	return buildIndexFor(root, "tools-mcp", "tool.yaml")
 }
 
+func BuildPluginsIndex(root string) (Index, error) {
+	return buildIndexFor(root, "plugins", "plugin.yaml")
+}
+
 func buildIndexFor(root, moduleDir, manifestName string) (Index, error) {
 	manifests, err := findManifests(filepath.Join(root, moduleDir), manifestName)
 	if err != nil {
@@ -74,6 +78,14 @@ func buildIndexFor(root, moduleDir, manifestName string) (Index, error) {
 			Deprecated:       m.Deprecated,
 			ReplacedBy:       m.ReplacedBy,
 		}
+		if hasIncludes(m.Includes) {
+			includes := m.Includes
+			entry.Includes = &includes
+		}
+		if hasRequirements(m.Requires) {
+			requires := m.Requires
+			entry.Requires = &requires
+		}
 		skills = append(skills, entry)
 	}
 
@@ -95,6 +107,14 @@ func buildIndexFor(root, moduleDir, manifestName string) (Index, error) {
 		GeneratedAt:     generatedAt,
 		Skills:          skills,
 	}, nil
+}
+
+func hasIncludes(includes IncludeSet) bool {
+	return len(includes.Skills) > 0 || len(includes.Agents) > 0 || len(includes.Tools) > 0 || len(includes.Hooks) > 0
+}
+
+func hasRequirements(requires RequirementSet) bool {
+	return len(requires.Secrets) > 0 || len(requires.Approvals) > 0
 }
 
 func readinessFor(m Manifest) string {

--- a/internal/registry/builder_test.go
+++ b/internal/registry/builder_test.go
@@ -104,3 +104,61 @@ deprecated: false
 		t.Fatalf("unexpected artifact url: %s", entry.Versions[0].ArtifactURL)
 	}
 }
+
+func TestBuildPluginsIndex(t *testing.T) {
+	root := t.TempDir()
+	entryDir := filepath.Join(root, "plugins", "marketing", "demo-plugin")
+	if err := os.MkdirAll(filepath.Join(entryDir, "examples"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mf := `id: marketing/demo-plugin
+name: Demo Plugin
+description: Demo plugin manifest used for index generation tests.
+version: 0.1.0
+released_at: "2026-03-28T00:00:00Z"
+category: marketing-plugins/reporting
+tags:
+  - demo
+license: MIT
+author:
+  name: Tests
+runtimes:
+  - codex
+entrypoints:
+  spec: plugin.json
+includes:
+  skills:
+    - marketing/meta-google-weekly-performance-review
+requires:
+  secrets:
+    - GA4_PROPERTY_ID
+deprecated: false
+`
+	if err := os.WriteFile(filepath.Join(entryDir, "plugin.yaml"), []byte(mf), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entryDir, "plugin.json"), []byte("{\"name\":\"demo\"}\n"), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+
+	idx, err := BuildPluginsIndex(root)
+	if err != nil {
+		t.Fatalf("build index: %v", err)
+	}
+	if len(idx.Skills) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(idx.Skills))
+	}
+	entry := idx.Skills[0]
+	if entry.ID != "marketing/demo-plugin" {
+		t.Fatalf("unexpected id: %s", entry.ID)
+	}
+	if entry.Includes == nil || len(entry.Includes.Skills) != 1 {
+		t.Fatalf("expected included skills in index, got %#v", entry.Includes)
+	}
+	if entry.Requires == nil || len(entry.Requires.Secrets) != 1 {
+		t.Fatalf("expected required secrets in index, got %#v", entry.Requires)
+	}
+	if !strings.Contains(entry.Versions[0].ManifestURL, "/plugins/marketing/demo-plugin/plugin.yaml") {
+		t.Fatalf("unexpected manifest url: %s", entry.Versions[0].ManifestURL)
+	}
+}

--- a/internal/registry/manifest_parser.go
+++ b/internal/registry/manifest_parser.go
@@ -20,6 +20,7 @@ func ParseManifest(path string) (Manifest, error) {
 	currentListKey := ""
 	inNestedMap := false
 	nestedMapKey := ""
+	currentNestedListKey := ""
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -43,8 +44,39 @@ func ParseManifest(path string) (Manifest, error) {
 			continue
 		}
 
+		if strings.HasPrefix(line, "    - ") && inNestedMap && currentNestedListKey != "" {
+			item := strings.TrimSpace(strings.TrimPrefix(line, "    - "))
+			item = unquote(item)
+			switch nestedMapKey {
+			case "includes":
+				switch currentNestedListKey {
+				case "skills":
+					out.Includes.Skills = append(out.Includes.Skills, item)
+				case "agents":
+					out.Includes.Agents = append(out.Includes.Agents, item)
+				case "tools":
+					out.Includes.Tools = append(out.Includes.Tools, item)
+				case "hooks":
+					out.Includes.Hooks = append(out.Includes.Hooks, item)
+				}
+			case "requires":
+				switch currentNestedListKey {
+				case "secrets":
+					out.Requires.Secrets = append(out.Requires.Secrets, item)
+				case "approvals":
+					out.Requires.Approvals = append(out.Requires.Approvals, item)
+				}
+			}
+			continue
+		}
+
 		if strings.HasPrefix(line, "  ") {
 			if inNestedMap {
+				if strings.HasSuffix(strings.TrimSpace(line), ":") {
+					nestedParts := strings.SplitN(strings.TrimSpace(line), ":", 2)
+					currentNestedListKey = strings.TrimSpace(nestedParts[0])
+					continue
+				}
 				nestedParts := strings.SplitN(strings.TrimSpace(line), ":", 2)
 				if len(nestedParts) == 2 {
 					nestedKey := strings.TrimSpace(nestedParts[0])
@@ -52,6 +84,7 @@ func ParseManifest(path string) (Manifest, error) {
 					if nestedMapKey == "verification" && nestedKey == "security_reviewed" {
 						out.SecurityReviewed = strings.EqualFold(nestedValue, "true")
 					}
+					currentNestedListKey = ""
 				}
 			}
 			if currentScalarKey != "" && !strings.Contains(strings.TrimSpace(line), ":") {
@@ -83,6 +116,7 @@ func ParseManifest(path string) (Manifest, error) {
 		currentListKey = ""
 		inNestedMap = false
 		nestedMapKey = ""
+		currentNestedListKey = ""
 
 		switch key {
 		case "id":
@@ -106,7 +140,7 @@ func ParseManifest(path string) (Manifest, error) {
 			out.Deprecated = strings.EqualFold(value, "true")
 		case "replaced_by":
 			out.ReplacedBy = value
-		case "author", "entrypoints", "dependencies", "verification":
+		case "author", "entrypoints", "dependencies", "verification", "includes", "requires", "install":
 			inNestedMap = true
 			nestedMapKey = key
 		}

--- a/internal/registry/manifest_parser_test.go
+++ b/internal/registry/manifest_parser_test.go
@@ -56,3 +56,68 @@ deprecated: false
 		t.Fatal("expected security reviewed to be true")
 	}
 }
+
+func TestParsePluginManifestIncludesAndRequires(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.yaml")
+	content := `id: marketing/example-plugin
+name: Example Plugin
+description: Example plugin package for manifest parsing tests.
+version: 0.1.0
+released_at: "2026-03-28T00:00:00Z"
+category: marketing-plugins/reporting
+tags:
+  - reporting
+license: MIT
+author:
+  name: Example
+runtimes:
+  - codex
+  - claude
+entrypoints:
+  spec: plugin.json
+includes:
+  skills:
+    - marketing/meta-google-weekly-performance-review
+  agents:
+    - marketing/weekly-performance-supervisor
+  tools:
+    - analytics/ga4-mcp-connector
+  hooks:
+    - post-analysis-slack-summary
+requires:
+  secrets:
+    - GA4_PROPERTY_ID
+  approvals:
+    - human-review-for-write-actions
+verification:
+  security_reviewed: false
+deprecated: false
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	m, err := ParseManifest(path)
+	if err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	if len(m.Includes.Skills) != 1 || m.Includes.Skills[0] != "marketing/meta-google-weekly-performance-review" {
+		t.Fatalf("unexpected included skills: %#v", m.Includes.Skills)
+	}
+	if len(m.Includes.Agents) != 1 || m.Includes.Agents[0] != "marketing/weekly-performance-supervisor" {
+		t.Fatalf("unexpected included agents: %#v", m.Includes.Agents)
+	}
+	if len(m.Includes.Tools) != 1 || m.Includes.Tools[0] != "analytics/ga4-mcp-connector" {
+		t.Fatalf("unexpected included tools: %#v", m.Includes.Tools)
+	}
+	if len(m.Includes.Hooks) != 1 || m.Includes.Hooks[0] != "post-analysis-slack-summary" {
+		t.Fatalf("unexpected included hooks: %#v", m.Includes.Hooks)
+	}
+	if len(m.Requires.Secrets) != 1 || m.Requires.Secrets[0] != "GA4_PROPERTY_ID" {
+		t.Fatalf("unexpected required secrets: %#v", m.Requires.Secrets)
+	}
+	if len(m.Requires.Approvals) != 1 || m.Requires.Approvals[0] != "human-review-for-write-actions" {
+		t.Fatalf("unexpected required approvals: %#v", m.Requires.Approvals)
+	}
+}

--- a/internal/registry/types.go
+++ b/internal/registry/types.go
@@ -1,17 +1,31 @@
 package registry
 
 type Manifest struct {
-	ID          string
-	Name        string
-	Description string
-	Version     string
-	ReleasedAt  string
-	Category    string
-	Tags        []string
-	Runtimes    []string
+	ID               string
+	Name             string
+	Description      string
+	Version          string
+	ReleasedAt       string
+	Category         string
+	Tags             []string
+	Runtimes         []string
 	SecurityReviewed bool
-	Deprecated  bool
-	ReplacedBy  string
+	Deprecated       bool
+	ReplacedBy       string
+	Includes         IncludeSet
+	Requires         RequirementSet
+}
+
+type IncludeSet struct {
+	Skills []string `json:"skills,omitempty"`
+	Agents []string `json:"agents,omitempty"`
+	Tools  []string `json:"tools,omitempty"`
+	Hooks  []string `json:"hooks,omitempty"`
+}
+
+type RequirementSet struct {
+	Secrets   []string `json:"secrets,omitempty"`
+	Approvals []string `json:"approvals,omitempty"`
 }
 
 type Index struct {
@@ -21,18 +35,20 @@ type Index struct {
 }
 
 type SkillEntry struct {
-	ID          string         `json:"id"`
-	Name        string         `json:"name"`
-	Description string         `json:"description"`
-	Category    string         `json:"category"`
-	Latest      string         `json:"latest"`
-	Versions    []VersionEntry `json:"versions"`
-	Runtimes    []string       `json:"runtimes"`
-	Tags        []string       `json:"tags"`
-	Readiness   string         `json:"readiness"`
-	SecurityReviewed bool      `json:"security_reviewed"`
-	Deprecated  bool           `json:"deprecated"`
-	ReplacedBy  string         `json:"replaced_by,omitempty"`
+	ID               string          `json:"id"`
+	Name             string          `json:"name"`
+	Description      string          `json:"description"`
+	Category         string          `json:"category"`
+	Latest           string          `json:"latest"`
+	Versions         []VersionEntry  `json:"versions"`
+	Runtimes         []string        `json:"runtimes"`
+	Tags             []string        `json:"tags"`
+	Readiness        string          `json:"readiness"`
+	SecurityReviewed bool            `json:"security_reviewed"`
+	Deprecated       bool            `json:"deprecated"`
+	ReplacedBy       string          `json:"replaced_by,omitempty"`
+	Includes         *IncludeSet     `json:"includes,omitempty"`
+	Requires         *RequirementSet `json:"requires,omitempty"`
 }
 
 type VersionEntry struct {

--- a/plugins/marketing/ad-creative-plugin/README.md
+++ b/plugins/marketing/ad-creative-plugin/README.md
@@ -1,0 +1,13 @@
+# Ad Creative Plugin
+
+Portable bundle for paid-media creative ideation, QA, and experiment planning.
+
+## Includes
+- Creative ideation workflow for PMax, reels, and paid-social variants
+- Rules-based creative review guidance
+- A/B testing and evaluation support
+- Meta Ads connector reference for campaign-context setup
+- Example pre-publish creative review hook
+
+## Use Case
+Install when a team wants one reusable package for developing ad concepts, evaluating them against rules and hypotheses, and handing approved variants into production workflows.

--- a/plugins/marketing/ad-creative-plugin/examples/overview.md
+++ b/plugins/marketing/ad-creative-plugin/examples/overview.md
@@ -1,0 +1,6 @@
+# Example Workflow
+
+1. Generate multiple paid-social and PMax creative concepts.
+2. Apply rules-based review and experimentation framing.
+3. Score outputs for clarity, novelty, and channel fit.
+4. Hold for human review before any publishing workflow.

--- a/plugins/marketing/ad-creative-plugin/plugin.json
+++ b/plugins/marketing/ad-creative-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "ad-creative-plugin",
+  "version": "0.1.0",
+  "description": "Portable creative ideation and experiment workflow for paid-media teams."
+}

--- a/plugins/marketing/ad-creative-plugin/plugin.yaml
+++ b/plugins/marketing/ad-creative-plugin/plugin.yaml
@@ -1,0 +1,44 @@
+id: marketing/ad-creative-plugin
+name: Ad Creative Plugin
+description: Package creative ideation, rules-based review, experiment planning, and delivery guidance into one plugin for paid-media creative teams.
+version: 0.1.0
+released_at: "2026-03-29T00:00:00Z"
+category: marketing-plugins/creative
+tags:
+  - creative
+  - paid-media
+  - experiments
+  - ads
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: plugin.json
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+includes:
+  skills:
+    - marketing/creative-workshop-pmax-reels
+    - marketing/dynamic-creative-rules-engine
+    - marketing/ab-test-planner-analyzer
+    - marketing/ai-output-eval-scorecard
+  tools:
+    - ads/meta-ads-mcp-connector
+  hooks:
+    - creative-review-before-publish
+requires:
+  secrets:
+    - META_ACCESS_TOKEN
+  approvals:
+    - human-review-before-publish
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/plugins/marketing/ad-creative-plugin/tests/test-prompts.md
+++ b/plugins/marketing/ad-creative-plugin/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+- Create a new paid-social concept pack with testable angles for our spring campaign.
+- Generate PMax and reels variants, then score them against our creative rules.
+- Produce three ad-copy directions and recommend an A/B test plan.
+- Review draft creative outputs for rule violations before sending them to production.
+- Build an experiment-ready creative brief that still requires human sign-off before publish.

--- a/plugins/marketing/campaign-audit-plugin/README.md
+++ b/plugins/marketing/campaign-audit-plugin/README.md
@@ -1,0 +1,12 @@
+# Campaign Audit Plugin
+
+Portable bundle for campaign QA and governance checks.
+
+## Includes
+- Compliance and policy-focused skills
+- Campaign QA supervisor agent
+- Analytics and ad connector references
+- Example block-publish hook
+
+## Use Case
+Install when media or governance teams need a repeatable package for pre-launch audits and major campaign-change reviews.

--- a/plugins/marketing/campaign-audit-plugin/examples/overview.md
+++ b/plugins/marketing/campaign-audit-plugin/examples/overview.md
@@ -1,0 +1,6 @@
+# Example Flow
+
+1. Read campaign setup and recent change context.
+2. Run QA and compliance checks.
+3. Surface blocking issues.
+4. Require human approval before any live write action.

--- a/plugins/marketing/campaign-audit-plugin/plugin.json
+++ b/plugins/marketing/campaign-audit-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "campaign-audit-plugin",
+  "version": "0.1.0",
+  "description": "Portable audit and campaign QA bundle for marketing teams."
+}

--- a/plugins/marketing/campaign-audit-plugin/plugin.yaml
+++ b/plugins/marketing/campaign-audit-plugin/plugin.yaml
@@ -1,0 +1,46 @@
+id: marketing/campaign-audit-plugin
+name: Campaign Audit Plugin
+description: Package campaign QA, compliance checks, and audit supervision into a reusable plugin for pre-launch and in-flight campaign reviews.
+version: 0.1.0
+released_at: "2026-03-28T00:00:00Z"
+category: marketing-plugins/audit
+tags:
+  - audit
+  - qa
+  - policy
+  - governance
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: plugin.json
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+includes:
+  skills:
+    - adtech/policy-brand-compliance-checker
+    - security/handle-untrusted-content
+    - security/secrets-and-credential-hygiene
+  agents:
+    - marketing/campaign-qa-supervisor
+  tools:
+    - analytics/ga4-mcp-connector
+    - ads/meta-ads-mcp-connector
+  hooks:
+    - block-publish-on-critical-failure
+requires:
+  secrets:
+    - META_ACCESS_TOKEN
+  approvals:
+    - human-approval-for-live-changes
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/plugins/marketing/campaign-audit-plugin/tests/test-prompts.md
+++ b/plugins/marketing/campaign-audit-plugin/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+- List the blocking conditions this plugin is designed to support.
+- Explain which bundled agent coordinates the audit workflow.
+- Describe the secret and approval requirements for this plugin.
+- Show how this plugin would handle a campaign launch QA scenario.
+- Identify which included skills address security or compliance risk.

--- a/plugins/marketing/competitive-intelligence-plugin/README.md
+++ b/plugins/marketing/competitive-intelligence-plugin/README.md
@@ -1,0 +1,12 @@
+# Competitive Intelligence Plugin
+
+Portable bundle for evidence-based competitor monitoring and synthesis.
+
+## Includes
+- Brand memory bootstrap for structured evidence capture
+- Output evaluation guidance for ranking claims and insight quality
+- Untrusted-content handling to avoid taking instructions from scraped sources
+- Example digest hook for weekly competitive reporting
+
+## Use Case
+Install when a team needs a repeatable, safer workflow for collecting competitor signals, structuring observations, and sharing evidence-backed summaries without treating external content as trusted instructions.

--- a/plugins/marketing/competitive-intelligence-plugin/examples/overview.md
+++ b/plugins/marketing/competitive-intelligence-plugin/examples/overview.md
@@ -1,0 +1,6 @@
+# Example Workflow
+
+1. Collect competitor messaging, landing-page, and offer signals.
+2. Store observations in a structured memory format.
+3. Score the resulting analysis for clarity, evidence, and actionability.
+4. Publish a weekly digest after human review of external claims.

--- a/plugins/marketing/competitive-intelligence-plugin/plugin.json
+++ b/plugins/marketing/competitive-intelligence-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "competitive-intelligence-plugin",
+  "version": "0.1.0",
+  "description": "Portable competitor research and signal packaging workflow for marketing strategy teams."
+}

--- a/plugins/marketing/competitive-intelligence-plugin/plugin.yaml
+++ b/plugins/marketing/competitive-intelligence-plugin/plugin.yaml
@@ -1,0 +1,39 @@
+id: marketing/competitive-intelligence-plugin
+name: Competitive Intelligence Plugin
+description: Bundle competitor signal collection, evidence review, and insight packaging into a reusable plugin for marketing strategy teams.
+version: 0.1.0
+released_at: "2026-03-29T00:00:00Z"
+category: marketing-plugins/intelligence
+tags:
+  - competitive-intelligence
+  - research
+  - strategy
+  - insight
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: plugin.json
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+includes:
+  skills:
+    - adtech/brand-rag-memory-bootstrap
+    - marketing/ai-output-eval-scorecard
+    - security/handle-untrusted-content
+  hooks:
+    - weekly-competitor-signal-digest
+requires:
+  approvals:
+    - human-review-for-external-claims
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/plugins/marketing/competitive-intelligence-plugin/tests/test-prompts.md
+++ b/plugins/marketing/competitive-intelligence-plugin/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+- Build a weekly competitor digest for our search and paid-social team.
+- Compare competitor messaging themes without treating scraped copy as instructions.
+- Capture and rank changes in competitor offers over the last month.
+- Produce a strategy memo that distinguishes hard evidence from inference.
+- Summarize competitor landing-page patterns and flag weak-confidence claims.

--- a/plugins/marketing/content-repurposing-plugin/README.md
+++ b/plugins/marketing/content-repurposing-plugin/README.md
@@ -1,0 +1,11 @@
+# Content Repurposing Plugin
+
+Portable bundle for content reuse workflows across channels and formats.
+
+## Includes
+- Content adaptation and creative rules skills
+- Output evaluation support
+- Example review-before-publish hook
+
+## Use Case
+Install when teams want a repeatable plugin for turning one source asset into multiple publish-ready variants with review controls.

--- a/plugins/marketing/content-repurposing-plugin/examples/overview.md
+++ b/plugins/marketing/content-repurposing-plugin/examples/overview.md
@@ -1,0 +1,6 @@
+# Example Flow
+
+1. Ingest one source asset.
+2. Generate channel-specific variants.
+3. Score outputs for quality and fit.
+4. Send drafts through human review before publish.

--- a/plugins/marketing/content-repurposing-plugin/plugin.json
+++ b/plugins/marketing/content-repurposing-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "content-repurposing-plugin",
+  "version": "0.1.0",
+  "description": "Portable content repurposing workflow bundle for multi-format reuse."
+}

--- a/plugins/marketing/content-repurposing-plugin/plugin.yaml
+++ b/plugins/marketing/content-repurposing-plugin/plugin.yaml
@@ -1,0 +1,39 @@
+id: marketing/content-repurposing-plugin
+name: Content Repurposing Plugin
+description: Bundle content transformation, review guidance, and publishing-oriented workflow references into a portable plugin for multi-channel reuse.
+version: 0.1.0
+released_at: "2026-03-28T00:00:00Z"
+category: marketing-plugins/content
+tags:
+  - content
+  - repurposing
+  - publishing
+  - workflow
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: plugin.json
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+includes:
+  skills:
+    - marketing/creative-workshop-pmax-reels
+    - marketing/ai-output-eval-scorecard
+    - marketing/dynamic-creative-rules-engine
+  hooks:
+    - content-review-before-publish
+requires:
+  approvals:
+    - human-review-for-publish
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/plugins/marketing/content-repurposing-plugin/tests/test-prompts.md
+++ b/plugins/marketing/content-repurposing-plugin/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+- Explain which skills are bundled for content reuse.
+- Describe how this plugin should be used before publishing to live channels.
+- List the approval constraints in this plugin.
+- Show how one source asset could be repurposed into multiple formats.
+- Identify the role of the evaluation skill in this plugin.

--- a/plugins/marketing/page-speed-technical-seo-plugin/README.md
+++ b/plugins/marketing/page-speed-technical-seo-plugin/README.md
@@ -1,0 +1,13 @@
+# Page Speed & Technical SEO Plugin
+
+Portable bundle for technical SEO and landing-page diagnostics.
+
+## Includes
+- Search and paid-search alignment skill guidance
+- Browser-driven page review workflow
+- Runtime environment risk checks before automated diagnostics
+- GA4 connector reference for landing-page and engagement validation
+- Example hook for Lighthouse-style review handoff
+
+## Use Case
+Install when a team needs a repeatable workflow for reviewing slow landing pages, technical SEO regressions, and page-experience issues before escalating changes to engineering.

--- a/plugins/marketing/page-speed-technical-seo-plugin/examples/overview.md
+++ b/plugins/marketing/page-speed-technical-seo-plugin/examples/overview.md
@@ -1,0 +1,6 @@
+# Example Workflow
+
+1. Run a browser-driven audit on priority landing pages.
+2. Compare paid-search landing-page performance in GA4.
+3. Capture technical SEO and page-experience findings.
+4. Escalate recommended fixes to engineering with human review.

--- a/plugins/marketing/page-speed-technical-seo-plugin/plugin.json
+++ b/plugins/marketing/page-speed-technical-seo-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "page-speed-technical-seo-plugin",
+  "version": "0.1.0",
+  "description": "Portable page speed and technical SEO workflow bundle for search and landing-page teams."
+}

--- a/plugins/marketing/page-speed-technical-seo-plugin/plugin.yaml
+++ b/plugins/marketing/page-speed-technical-seo-plugin/plugin.yaml
@@ -1,0 +1,43 @@
+id: marketing/page-speed-technical-seo-plugin
+name: Page Speed & Technical SEO Plugin
+description: Package technical SEO diagnostics, page experience checks, and reporting guidance into one installable plugin for search and landing-page teams.
+version: 0.1.0
+released_at: "2026-03-29T00:00:00Z"
+category: marketing-plugins/seo
+tags:
+  - seo
+  - technical-seo
+  - performance
+  - page-speed
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: plugin.json
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+includes:
+  skills:
+    - marketing/seo-paid-search-synergy
+    - adtech/playwright-agentic-e2e
+    - security/environment-risk-assessment
+  tools:
+    - analytics/ga4-mcp-connector
+  hooks:
+    - lighthouse-and-landing-page-review
+requires:
+  secrets:
+    - GA4_PROPERTY_ID
+  approvals:
+    - human-review-before-site-change
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/plugins/marketing/page-speed-technical-seo-plugin/tests/test-prompts.md
+++ b/plugins/marketing/page-speed-technical-seo-plugin/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+- Audit our top three paid-search landing pages for technical SEO and page-speed regressions.
+- Review a new product page for crawlability, performance, and conversion friction before launch.
+- Compare slow-page complaints against GA4 engagement trends and summarize likely causes.
+- Generate a technical SEO handoff for engineering with only evidence-backed recommendations.
+- Run a safe browser-based review workflow without making any live site changes.

--- a/plugins/marketing/performance-reporting-plugin/README.md
+++ b/plugins/marketing/performance-reporting-plugin/README.md
@@ -1,0 +1,13 @@
+# Performance Reporting Plugin
+
+Portable bundle for weekly reporting workflows.
+
+## Includes
+- Weekly performance reporting skills
+- Dashboard generation and QA
+- Reporting supervisor agent
+- Connector references for analytics, ads, and warehouse data
+- Example post-analysis Slack hook
+
+## Use Case
+Install when a team needs one shared reporting package instead of manually wiring separate skills, tools, and review steps.

--- a/plugins/marketing/performance-reporting-plugin/examples/overview.md
+++ b/plugins/marketing/performance-reporting-plugin/examples/overview.md
@@ -1,0 +1,7 @@
+# Example Flow
+
+1. Pull GA4 and ad platform metrics.
+2. Generate reporting tables.
+3. Run QA checks.
+4. Draft executive narrative.
+5. Post approved summary to Slack.

--- a/plugins/marketing/performance-reporting-plugin/plugin.json
+++ b/plugins/marketing/performance-reporting-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "performance-reporting-plugin",
+  "version": "0.1.0",
+  "description": "Portable reporting workflow bundle for weekly marketing performance reviews."
+}

--- a/plugins/marketing/performance-reporting-plugin/plugin.yaml
+++ b/plugins/marketing/performance-reporting-plugin/plugin.yaml
@@ -1,0 +1,50 @@
+id: marketing/performance-reporting-plugin
+name: Performance Reporting Plugin
+description: Bundle weekly reporting skills, agent templates, connector references, and delivery hooks into one portable analytics workflow package.
+version: 0.1.0
+released_at: "2026-03-28T00:00:00Z"
+category: marketing-plugins/reporting
+tags:
+  - reporting
+  - ga4
+  - dashboard
+  - slack
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: plugin.json
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+includes:
+  skills:
+    - marketing/meta-google-weekly-performance-review
+    - adtech/dashboard-generator
+    - adtech/dashboard-qa-checker
+    - adtech/executive-narrative-writer
+  agents:
+    - marketing/weekly-performance-supervisor
+  tools:
+    - analytics/ga4-mcp-connector
+    - ads/meta-ads-mcp-connector
+    - warehouse/bigquery-mcp-query-runner
+  hooks:
+    - post-analysis-slack-summary
+requires:
+  secrets:
+    - GA4_PROPERTY_ID
+    - META_ACCESS_TOKEN
+    - SLACK_WEBHOOK_URL
+  approvals:
+    - human-review-for-write-actions
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/plugins/marketing/performance-reporting-plugin/tests/test-prompts.md
+++ b/plugins/marketing/performance-reporting-plugin/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+- Install the performance reporting plugin for a Claude runtime and list the required secrets.
+- Explain which skills and agents are bundled in this plugin.
+- Show how this plugin would support a weekly paid media review.
+- Identify which included components are responsible for QA gating.
+- Describe the human approval boundaries for this plugin.

--- a/registry/plugins-index.json
+++ b/registry/plugins-index.json
@@ -1,0 +1,313 @@
+{
+  "registry_version": "1.0",
+  "generated_at": "2026-03-29T00:00:00Z",
+  "skills": [
+    {
+      "id": "marketing/ad-creative-plugin",
+      "name": "Ad Creative Plugin",
+      "description": "Package creative ideation, rules-based review, experiment planning, and delivery guidance into one plugin for paid-media creative teams.",
+      "category": "marketing-plugins/creative",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-03-29T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/ad-creative-plugin/plugin.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ad-creative-plugin/0.1.0.tar.gz",
+          "sha256": "f15ea5b54661627dc08eee056debe9ab8a4da6302a29db5dfe0cff7ec390950c"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "creative",
+        "paid-media",
+        "experiments",
+        "ads"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "includes": {
+        "skills": [
+          "marketing/creative-workshop-pmax-reels",
+          "marketing/dynamic-creative-rules-engine",
+          "marketing/ab-test-planner-analyzer",
+          "marketing/ai-output-eval-scorecard"
+        ],
+        "tools": [
+          "ads/meta-ads-mcp-connector"
+        ],
+        "hooks": [
+          "creative-review-before-publish"
+        ]
+      },
+      "requires": {
+        "secrets": [
+          "META_ACCESS_TOKEN"
+        ],
+        "approvals": [
+          "human-review-before-publish"
+        ]
+      }
+    },
+    {
+      "id": "marketing/campaign-audit-plugin",
+      "name": "Campaign Audit Plugin",
+      "description": "Package campaign QA, compliance checks, and audit supervision into a reusable plugin for pre-launch and in-flight campaign reviews.",
+      "category": "marketing-plugins/audit",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-03-28T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/campaign-audit-plugin/plugin.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/campaign-audit-plugin/0.1.0.tar.gz",
+          "sha256": "e8488d1d50f88005217e5e8bad4aded3ff6da3b30301750419f6e0a02bd936c4"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "audit",
+        "qa",
+        "policy",
+        "governance"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "includes": {
+        "skills": [
+          "adtech/policy-brand-compliance-checker",
+          "security/handle-untrusted-content",
+          "security/secrets-and-credential-hygiene"
+        ],
+        "agents": [
+          "marketing/campaign-qa-supervisor"
+        ],
+        "tools": [
+          "analytics/ga4-mcp-connector",
+          "ads/meta-ads-mcp-connector"
+        ],
+        "hooks": [
+          "block-publish-on-critical-failure"
+        ]
+      },
+      "requires": {
+        "secrets": [
+          "META_ACCESS_TOKEN"
+        ],
+        "approvals": [
+          "human-approval-for-live-changes"
+        ]
+      }
+    },
+    {
+      "id": "marketing/competitive-intelligence-plugin",
+      "name": "Competitive Intelligence Plugin",
+      "description": "Bundle competitor signal collection, evidence review, and insight packaging into a reusable plugin for marketing strategy teams.",
+      "category": "marketing-plugins/intelligence",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-03-29T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/competitive-intelligence-plugin/plugin.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/competitive-intelligence-plugin/0.1.0.tar.gz",
+          "sha256": "be8ff413f5cef3c931065a282140fd2483cb51245b5629655753b98221ffec37"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "competitive-intelligence",
+        "research",
+        "strategy",
+        "insight"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "includes": {
+        "skills": [
+          "adtech/brand-rag-memory-bootstrap",
+          "marketing/ai-output-eval-scorecard",
+          "security/handle-untrusted-content"
+        ],
+        "hooks": [
+          "weekly-competitor-signal-digest"
+        ]
+      },
+      "requires": {
+        "approvals": [
+          "human-review-for-external-claims"
+        ]
+      }
+    },
+    {
+      "id": "marketing/content-repurposing-plugin",
+      "name": "Content Repurposing Plugin",
+      "description": "Bundle content transformation, review guidance, and publishing-oriented workflow references into a portable plugin for multi-channel reuse.",
+      "category": "marketing-plugins/content",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-03-28T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/content-repurposing-plugin/plugin.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/content-repurposing-plugin/0.1.0.tar.gz",
+          "sha256": "a2b861cf98463e6f489bb5825d13335918ef38cea75dc31281a9f93d60bac6ec"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "content",
+        "repurposing",
+        "publishing",
+        "workflow"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "includes": {
+        "skills": [
+          "marketing/creative-workshop-pmax-reels",
+          "marketing/ai-output-eval-scorecard",
+          "marketing/dynamic-creative-rules-engine"
+        ],
+        "hooks": [
+          "content-review-before-publish"
+        ]
+      },
+      "requires": {
+        "approvals": [
+          "human-review-for-publish"
+        ]
+      }
+    },
+    {
+      "id": "marketing/page-speed-technical-seo-plugin",
+      "name": "Page Speed \u0026 Technical SEO Plugin",
+      "description": "Package technical SEO diagnostics, page experience checks, and reporting guidance into one installable plugin for search and landing-page teams.",
+      "category": "marketing-plugins/seo",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-03-29T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/page-speed-technical-seo-plugin/plugin.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/page-speed-technical-seo-plugin/0.1.0.tar.gz",
+          "sha256": "32db07958d5bd344b006a6a22c5de5fcc853db49e3c3dbefec39c939e3d32f96"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "seo",
+        "technical-seo",
+        "performance",
+        "page-speed"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "includes": {
+        "skills": [
+          "marketing/seo-paid-search-synergy",
+          "adtech/playwright-agentic-e2e",
+          "security/environment-risk-assessment"
+        ],
+        "tools": [
+          "analytics/ga4-mcp-connector"
+        ],
+        "hooks": [
+          "lighthouse-and-landing-page-review"
+        ]
+      },
+      "requires": {
+        "secrets": [
+          "GA4_PROPERTY_ID"
+        ],
+        "approvals": [
+          "human-review-before-site-change"
+        ]
+      }
+    },
+    {
+      "id": "marketing/performance-reporting-plugin",
+      "name": "Performance Reporting Plugin",
+      "description": "Bundle weekly reporting skills, agent templates, connector references, and delivery hooks into one portable analytics workflow package.",
+      "category": "marketing-plugins/reporting",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-03-28T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/performance-reporting-plugin/plugin.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/performance-reporting-plugin/0.1.0.tar.gz",
+          "sha256": "0977d9f0a96f114d1ed82e827ef64727ca8daed000191cea9b7aba6142581c5a"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "reporting",
+        "ga4",
+        "dashboard",
+        "slack"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "includes": {
+        "skills": [
+          "marketing/meta-google-weekly-performance-review",
+          "adtech/dashboard-generator",
+          "adtech/dashboard-qa-checker",
+          "adtech/executive-narrative-writer"
+        ],
+        "agents": [
+          "marketing/weekly-performance-supervisor"
+        ],
+        "tools": [
+          "analytics/ga4-mcp-connector",
+          "ads/meta-ads-mcp-connector",
+          "warehouse/bigquery-mcp-query-runner"
+        ],
+        "hooks": [
+          "post-analysis-slack-summary"
+        ]
+      },
+      "requires": {
+        "secrets": [
+          "GA4_PROPERTY_ID",
+          "META_ACCESS_TOKEN",
+          "SLACK_WEBHOOK_URL"
+        ],
+        "approvals": [
+          "human-review-for-write-actions"
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/validate-manifests.sh
+++ b/scripts/validate-manifests.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SKILL_SCHEMA="$ROOT/shared/schemas/skill.schema.json"
 AGENT_SCHEMA="$ROOT/shared/schemas/agent.schema.json"
 TOOL_SCHEMA="$ROOT/shared/schemas/tool.schema.json"
+PLUGIN_SCHEMA="$ROOT/shared/schemas/plugin.schema.json"
 REGISTRY_SCHEMA="$ROOT/shared/schemas/registry-index.schema.json"
 
 CHECK_JSONSCHEMA=""
@@ -46,12 +47,14 @@ validate_module_manifests() {
 validate_module_manifests "$ROOT/skills" "skill.yaml" "$SKILL_SCHEMA" "skill"
 validate_module_manifests "$ROOT/agents" "agent.yaml" "$AGENT_SCHEMA" "agent"
 validate_module_manifests "$ROOT/tools-mcp" "tool.yaml" "$TOOL_SCHEMA" "tool"
+validate_module_manifests "$ROOT/plugins" "plugin.yaml" "$PLUGIN_SCHEMA" "plugin"
 
 for index_path in \
   "$ROOT/registry/index.json" \
   "$ROOT/registry/skills-index.json" \
   "$ROOT/registry/agents-index.json" \
-  "$ROOT/registry/tools-index.json"
+  "$ROOT/registry/tools-index.json" \
+  "$ROOT/registry/plugins-index.json"
 do
   if [[ -f "$index_path" ]]; then
     echo "[check] validating ${index_path#$ROOT/}"

--- a/shared/schemas/plugin.schema.json
+++ b/shared/schemas/plugin.schema.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://skills.ai-knowledge-hub.org/schemas/plugin.schema.json",
+  "title": "Plugin Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "description",
+    "version",
+    "released_at",
+    "category",
+    "tags",
+    "license",
+    "author",
+    "runtimes",
+    "entrypoints",
+    "includes"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 120
+    },
+    "description": {
+      "type": "string",
+      "minLength": 10,
+      "maxLength": 400
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "released_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "category": {
+      "type": "string",
+      "enum": [
+        "marketing-plugins/reporting",
+        "marketing-plugins/audit",
+        "marketing-plugins/seo",
+        "marketing-plugins/content",
+        "marketing-plugins/intelligence",
+        "marketing-plugins/creative"
+      ]
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]{1,39}$"
+      },
+      "minItems": 1,
+      "maxItems": 20,
+      "uniqueItems": true
+    },
+    "license": {
+      "type": "string",
+      "minLength": 2
+    },
+    "author": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 120
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "homepage": {
+      "type": "string",
+      "format": "uri"
+    },
+    "repository": {
+      "type": "string",
+      "format": "uri"
+    },
+    "runtimes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["codex", "claude", "generic"]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "entrypoints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["spec"],
+      "properties": {
+        "spec": {
+          "type": "string",
+          "default": "plugin.json"
+        },
+        "readme": {
+          "type": "string",
+          "default": "README.md"
+        },
+        "tests": {
+          "type": "string",
+          "default": "tests/test-prompts.md"
+        },
+        "examples_dir": {
+          "type": "string",
+          "default": "examples"
+        }
+      }
+    },
+    "includes": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "skills": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+          },
+          "uniqueItems": true
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+          },
+          "uniqueItems": true
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+          },
+          "uniqueItems": true
+        },
+        "hooks": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "requires": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "secrets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "approvals": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tests_min_prompts": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "security_reviewed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "deprecated": {
+      "type": "boolean",
+      "default": false
+    },
+    "replaced_by": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "deprecated": {
+            "const": true
+          }
+        },
+        "required": ["deprecated"]
+      },
+      "then": {
+        "required": ["replaced_by"]
+      }
+    }
+  ]
+}

--- a/shared/schemas/registry-index.schema.json
+++ b/shared/schemas/registry-index.schema.json
@@ -107,6 +107,66 @@
           "replaced_by": {
             "type": "string",
             "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+          },
+          "includes": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "skills": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+                },
+                "uniqueItems": true
+              },
+              "agents": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+                },
+                "uniqueItems": true
+              },
+              "tools": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+                },
+                "uniqueItems": true
+              },
+              "hooks": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true
+              }
+            }
+          },
+          "requires": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secrets": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true
+              },
+              "approvals": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true
+              }
+            }
           }
         },
         "allOf": [


### PR DESCRIPTION
## Summary

This PR expands and hardens the new `plugins` module across content, installer behavior, docs, and web UX.

It includes:

- 3 additional marketing plugins from the LLM plugins article
- runtime-aware plugin install behavior for `codex` and `claude`
- stronger plugin detail and catalog UX
- clearer README/docs guidance for plugin usage
- stronger plugin smoke coverage

---

## New plugins added

This PR adds the next wave of plugin packages under `plugins/marketing/`:

- `page-speed-technical-seo-plugin`
- `competitive-intelligence-plugin`
- `ad-creative-plugin`

That brings the total plugin catalog to `6`:

1. `performance-reporting-plugin`
2. `campaign-audit-plugin`
3. `content-repurposing-plugin`
4. `page-speed-technical-seo-plugin`
5. `competitive-intelligence-plugin`
6. `ad-creative-plugin`

Each plugin includes:
- `README.md`
- `plugin.yaml`
- `plugin.json`
- `examples/overview.md`
- `tests/test-prompts.md`

---

## Runtime-aware plugin install behavior

Plugin installs are no longer just a generic copy step.

### New installer behavior
For supported runtimes, install now generates a runtime-specific manifest inside the installed plugin directory:

- `codex` -> `.codex-plugin/plugin.json`
- `claude` -> `.claude-plugin/plugin.json`

These generated manifests are derived from the package `plugin.json` and stamped with the target runtime.

### CLI output improvements
`skills-hub info --module plugins ...` and `skills-hub install --module plugins ...` now print:

- bundled component counts
- bundled component IDs
- required secrets
- required approvals
- install root
- generated runtime artifact paths
- next-step setup guidance
- warning when `security_reviewed` is false

---

## Web UX improvements

### Plugin detail pages
Plugin detail pages now surface:

- install commands near the top
- required secrets and approval rules above the fold
- explicit note that `codex`/`claude` installs generate runtime manifests
- included component summary
- linked bundled skills / agents / tools
- direct package file links:
  - `README.md`
  - `plugin.yaml`
  - `plugin.json`
  - `tests/test-prompts.md`
  - `examples/overview.md`

### Plugin catalog cards
Plugin cards now include a secondary repo shortcut:

- `View package file` -> points directly to the plugin’s `plugin.yaml` in GitHub

This gives faster repo-navigation without overloading other catalog modules.

---

## README and docs updates

### README
Added a dedicated `Install Plugins` section covering:

- `codex` install example
- `claude` install example
- `generic` install example
- generated runtime manifest behavior
- pre-enable review checklist

### Plugin docs
Updated plugin docs to explain that generated runtime manifests are:

- scaffolding artifacts
- runtime-specific
- not trust or production-approval signals

Files updated:
- `README.md`
- `docs/plugin-architecture.md`
- `docs/plugin-authoring-guide.md`

---

## Tests and verification

### Added / strengthened coverage
- explicit unit coverage for generated runtime manifests for:
  - `codex`
  - `claude`
  - `generic` no-op case
- stronger Playwright plugin smoke coverage:
  - `/plugins` route renders
  - domain filter interaction works
  - plugin detail renders bundled component links
  - plugin card shortcut exists and points to expected `plugin.yaml`

### Local verification passed
- `go test ./internal/installer ./cmd/skills-hub ./internal/registry`
- `bash scripts/validate-manifests.sh`
- `rm -rf apps/web/.next && pnpm --dir apps/web build`

### Real CLI runtime checks passed
- `skills-hub install --module plugins ... --runtime codex`
- `skills-hub install --module plugins ... --runtime claude`

Both produced the expected runtime-specific plugin manifests.

---

## Why this matters

This PR moves plugins from “registry concept” to a more practical packaging layer:

- better catalog and detail-page discoverability
- clearer install expectations
- runtime-aware scaffolding for Codex and Claude
- more honest security/setup communication
- a broader first plugin set aligned with the article

The plugin layer is still intentionally lightweight and experimental, but it is now materially more useful for installation, evaluation, and extension.
