### PR TITLE
installable plugin package

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ a runtime-specific manifest inside the installed plugin directory:
 - `codex` -> `.codex-plugin/plugin.json`
 - `claude` -> `.claude-plugin/plugin.json`
 
+Plugin installs also resolve bundled dependencies automatically:
+
+- referenced `skills` install into the runtime skills directory
+- referenced `agents` install into the runtime agents directory
+- referenced `tools-mcp` install into the runtime tools directory
+- packaged `hooks/` remain inside the installed plugin directory
+
 For Codex:
 
 ```bash
@@ -256,6 +263,7 @@ Expected result:
 
 - plugin files copied into your Codex plugins directory
 - generated `.codex-plugin/plugin.json`
+- bundled skills, agents, and tools installed into sibling Codex runtime directories
 - CLI output listing bundled component IDs, required secrets, and approvals
 
 For Claude:
@@ -270,6 +278,7 @@ Expected result:
 
 - plugin files copied into your Claude plugins directory
 - generated `.claude-plugin/plugin.json`
+- bundled skills, agents, and tools installed into sibling Claude runtime directories
 - CLI output warning when the plugin is not security reviewed
 
 For generic runtimes:
@@ -284,6 +293,7 @@ For generic runtimes:
 Expected result:
 
 - plugin files copied into `./my-agent/plugins`
+- bundled skills, agents, and tools installed into sibling directories under `./my-agent/`
 - no runtime-specific manifest generated automatically
 - you wire the plugin into your runtime manually
 

--- a/apps/web/app/plugins/[...id]/page.tsx
+++ b/apps/web/app/plugins/[...id]/page.tsx
@@ -44,6 +44,7 @@ export default async function PluginDetailPage({ params }: { params: { id: strin
             claude={buildModuleInstallSnippet("plugins", entry, "claude")}
             generic={buildModuleInstallSnippet("plugins", entry, "generic")}
           />
+          <p className="meta">Plugin installs also resolve bundled skills, agents, and tools into their native runtime directories. Packaged hooks stay inside the plugin directory.</p>
           <p className="meta">Codex and Claude installs also generate a runtime-specific plugin manifest inside the installed plugin directory.</p>
           {!entry.security_reviewed ? (
             <p className="meta">This plugin is still experimental. Review bundled components, required secrets, and approval rules before enabling it in a live runtime.</p>

--- a/cmd/skills-hub/main.go
+++ b/cmd/skills-hub/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ai-knowledge-hub/ai-skills-guide/internal/agents"
 	"github.com/ai-knowledge-hub/ai-skills-guide/internal/installer"
+	pluginvalidate "github.com/ai-knowledge-hub/ai-skills-guide/internal/plugins"
 	"github.com/ai-knowledge-hub/ai-skills-guide/internal/registry"
 	"github.com/ai-knowledge-hub/ai-skills-guide/internal/skills"
 )
@@ -178,24 +179,69 @@ func runInfo(args []string) error {
 
 func runValidate(args []string) error {
 	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
-	root := fs.String("root", "skills", "skills root directory")
+	module := fs.String("module", "skills", "module to validate: skills|plugins|all")
+	root := fs.String("root", "skills", "module root directory")
+	skillsRoot := fs.String("skills-root", "skills", "skills root directory for plugin validation")
+	agentsRoot := fs.String("agents-root", "agents", "agents root directory for plugin validation")
+	toolsRoot := fs.String("tools-root", "tools-mcp", "tools root directory for plugin validation")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	issues, err := skills.Validate(*root)
+	moduleName, err := normalizeValidateModule(*module)
 	if err != nil {
 		return err
 	}
-	if len(issues) == 0 {
-		fmt.Println("All skills passed validation.")
-		return nil
+
+	totalIssues := 0
+	if moduleName == "skills" || moduleName == "all" {
+		skillRoot := *root
+		if moduleName == "all" {
+			skillRoot = "skills"
+		}
+		issues, err := skills.Validate(skillRoot)
+		if err != nil {
+			return err
+		}
+		for _, issue := range issues {
+			fmt.Printf("[ERROR] %s: %s\n", issue.SkillID, issue.Message)
+		}
+		totalIssues += len(issues)
+		if len(issues) == 0 && moduleName == "skills" {
+			fmt.Println("All skills passed validation.")
+		}
 	}
 
-	for _, issue := range issues {
-		fmt.Printf("[ERROR] %s: %s\n", issue.SkillID, issue.Message)
+	if moduleName == "plugins" || moduleName == "all" {
+		pluginsRoot := *root
+		if moduleName == "all" {
+			pluginsRoot = "plugins"
+		}
+		issues, err := pluginvalidate.Validate(pluginvalidate.ValidateOptions{
+			PluginsRoot: pluginsRoot,
+			SkillsRoot:  *skillsRoot,
+			AgentsRoot:  *agentsRoot,
+			ToolsRoot:   *toolsRoot,
+		})
+		if err != nil {
+			return err
+		}
+		for _, issue := range issues {
+			fmt.Printf("[ERROR] %s: %s\n", issue.PluginID, issue.Message)
+		}
+		totalIssues += len(issues)
+		if len(issues) == 0 && moduleName == "plugins" {
+			fmt.Println("All plugins passed validation.")
+		}
 	}
-	return fmt.Errorf("validation failed with %d issue(s)", len(issues))
+
+	if totalIssues == 0 {
+		if moduleName == "all" {
+			fmt.Println("All skills and plugins passed validation.")
+		}
+		return nil
+	}
+	return fmt.Errorf("validation failed with %d issue(s)", totalIssues)
 }
 
 func runInstall(args []string) error {
@@ -275,8 +321,28 @@ func runInstall(args []string) error {
 	}
 
 	var runtimeArtifacts []string
+	var dependencyResult installer.DependencyInstallResult
 	if moduleName == "plugins" {
 		runtimeArtifacts, err = installer.PreparePluginRuntimeArtifacts(destination, rt.Runtime)
+		if err != nil {
+			return err
+		}
+		dependencyResult, err = installer.InstallPluginDependencies(
+			skill,
+			rt.Runtime,
+			rt.TargetPath,
+			map[string]string{
+				"skills": resolveModuleRoot("", "skills"),
+				"agents": resolveModuleRoot("", "agents"),
+				"tools":  resolveModuleRoot("", "tools"),
+			},
+			map[string]string{
+				"skills": resolveRegistryPath("", "skills"),
+				"agents": resolveRegistryPath("", "agents"),
+				"tools":  resolveRegistryPath("", "tools"),
+			},
+			*force,
+		)
 		if err != nil {
 			return err
 		}
@@ -284,7 +350,7 @@ func runInstall(args []string) error {
 
 	fmt.Printf("Installed %s@%s to %s (runtime=%s)\n", skill.ID, resolvedVersion.Version, destination, rt.Runtime)
 	if moduleName == "plugins" {
-		printPluginInstallNotes(os.Stdout, os.Stderr, skill, rt.Runtime, destination, runtimeArtifacts)
+		printPluginInstallNotes(os.Stdout, os.Stderr, skill, rt.Runtime, destination, runtimeArtifacts, dependencyResult)
 	}
 	return nil
 }
@@ -321,7 +387,13 @@ func printPluginSummary(w io.Writer, entry registry.SkillEntry) {
 	}
 }
 
-func printPluginInstallNotes(stdout, stderr io.Writer, entry registry.SkillEntry, runtime, destination string, runtimeArtifacts []string) {
+func printPluginInstallNotes(
+	stdout, stderr io.Writer,
+	entry registry.SkillEntry,
+	runtime, destination string,
+	runtimeArtifacts []string,
+	deps installer.DependencyInstallResult,
+) {
 	if !entry.SecurityReviewed {
 		fmt.Fprintf(stderr, "warning: %s is not security reviewed; inspect bundled components and setup before use\n", entry.ID)
 	}
@@ -336,7 +408,36 @@ func printPluginInstallNotes(stdout, stderr io.Writer, entry registry.SkillEntry
 	} else if runtime != "" {
 		fmt.Fprintf(stdout, "install.next_step: connect this plugin directory to your runtime manually and verify required secrets before use\n")
 	}
+	printPluginDependencySummary(stdout, deps)
 	printPluginSummary(stdout, entry)
+}
+
+func printPluginDependencySummary(stdout io.Writer, deps installer.DependencyInstallResult) {
+	fmt.Fprintf(stdout, "deps.skills.installed: %d\n", len(deps.InstalledSkills))
+	if len(deps.InstalledSkills) > 0 {
+		fmt.Fprintf(stdout, "deps.skills.installed.list: %s\n", strings.Join(deps.InstalledSkills, ", "))
+	}
+	if len(deps.SkippedSkills) > 0 {
+		fmt.Fprintf(stdout, "deps.skills.skipped.list: %s\n", strings.Join(deps.SkippedSkills, ", "))
+	}
+	fmt.Fprintf(stdout, "deps.agents.installed: %d\n", len(deps.InstalledAgents))
+	if len(deps.InstalledAgents) > 0 {
+		fmt.Fprintf(stdout, "deps.agents.installed.list: %s\n", strings.Join(deps.InstalledAgents, ", "))
+	}
+	if len(deps.SkippedAgents) > 0 {
+		fmt.Fprintf(stdout, "deps.agents.skipped.list: %s\n", strings.Join(deps.SkippedAgents, ", "))
+	}
+	fmt.Fprintf(stdout, "deps.tools.installed: %d\n", len(deps.InstalledTools))
+	if len(deps.InstalledTools) > 0 {
+		fmt.Fprintf(stdout, "deps.tools.installed.list: %s\n", strings.Join(deps.InstalledTools, ", "))
+	}
+	if len(deps.SkippedTools) > 0 {
+		fmt.Fprintf(stdout, "deps.tools.skipped.list: %s\n", strings.Join(deps.SkippedTools, ", "))
+	}
+	fmt.Fprintf(stdout, "deps.hooks.packaged: %d\n", len(deps.HookPaths))
+	if len(deps.HookPaths) > 0 {
+		fmt.Fprintf(stdout, "deps.hooks.packaged.list: %s\n", strings.Join(deps.HookPaths, ", "))
+	}
 }
 
 func optionalList[T any](set *T, field string) []string {
@@ -491,6 +592,23 @@ func normalizeModule(raw string) (string, error) {
 		return "plugins", nil
 	default:
 		return "", fmt.Errorf("unsupported module: %s (supported: skills, agents, tools, plugins)", raw)
+	}
+}
+
+func normalizeValidateModule(raw string) (string, error) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "" {
+		value = "skills"
+	}
+	switch value {
+	case "skills", "skill":
+		return "skills", nil
+	case "plugins", "plugin":
+		return "plugins", nil
+	case "all":
+		return "all", nil
+	default:
+		return "", fmt.Errorf("unsupported validate module: %s (supported: skills, plugins, all)", raw)
 	}
 }
 

--- a/cmd/skills-hub/main_test.go
+++ b/cmd/skills-hub/main_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ai-knowledge-hub/ai-skills-guide/internal/installer"
 	"github.com/ai-knowledge-hub/ai-skills-guide/internal/registry"
 )
 
@@ -62,6 +63,10 @@ func TestPrintPluginInstallNotesWarnsWhenNotSecurityReviewed(t *testing.T) {
 		"codex",
 		"/tmp/plugins/marketing/performance-reporting-plugin",
 		[]string{"/tmp/plugins/marketing/performance-reporting-plugin/.codex-plugin/plugin.json"},
+		installer.DependencyInstallResult{
+			InstalledSkills: []string{"/tmp/codex/skills/marketing/meta-google-weekly-performance-review"},
+			HookPaths:       []string{"/tmp/plugins/marketing/performance-reporting-plugin/hooks/post-analysis-slack-summary.md"},
+		},
 	)
 
 	if !strings.Contains(errOut.String(), "is not security reviewed") {
@@ -78,5 +83,11 @@ func TestPrintPluginInstallNotesWarnsWhenNotSecurityReviewed(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "install.next_step: review the generated codex runtime manifest before enabling the plugin") {
 		t.Fatalf("expected next step guidance in stdout, got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "deps.skills.installed: 1") {
+		t.Fatalf("expected dependency summary in stdout, got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "deps.hooks.packaged.list: /tmp/plugins/marketing/performance-reporting-plugin/hooks/post-analysis-slack-summary.md") {
+		t.Fatalf("expected packaged hook path in stdout, got: %s", out.String())
 	}
 }

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -48,11 +48,20 @@ The registry index exposes plugin metadata plus composition fields:
 
 ## Runtime install behavior
 
-Plugin installs now preserve the package directory and, for supported runtimes,
-also generate a runtime-specific manifest inside the installed plugin folder:
+Plugin installs preserve the package directory, resolve referenced
+dependencies into their native runtime directories, and, for supported
+runtimes, also generate a runtime-specific manifest inside the installed
+plugin folder:
 
 - `codex` -> `.codex-plugin/plugin.json`
 - `claude` -> `.claude-plugin/plugin.json`
+
+Dependency behavior:
+
+- `includes.skills` -> runtime `skills/`
+- `includes.agents` -> runtime `agents/`
+- `includes.tools` -> runtime `tools-mcp/`
+- `includes.hooks` -> packaged under the plugin's own `hooks/`
 
 These generated files are derived from the package `plugin.json` and stamped
 with the target runtime. They are scaffolding artifacts, not proof that the

--- a/docs/plugin-authoring-guide.md
+++ b/docs/plugin-authoring-guide.md
@@ -18,6 +18,7 @@ Good plugin candidates:
   README.md
   plugin.yaml
   plugin.json
+  hooks/
   examples/
   tests/
     test-prompts.md
@@ -36,6 +37,9 @@ Good plugin candidates:
    that still remain after generation.
 4. Treat hooks as risk-bearing.
    Any automatic action should be explained in `README.md`.
+5. Keep hooks packaged locally.
+   Declared hooks should exist under `hooks/` in the plugin package instead of
+   being modeled as a separate catalog dependency.
 
 ## Required manifest sections
 
@@ -52,5 +56,6 @@ Good plugin candidates:
 - at least 5 prompts in `tests/test-prompts.md`
 - one example flow in `examples/`
 - included component references resolve to real registry entries
+- declared hooks resolve to packaged files under `hooks/`
 - required secrets and approvals are documented
 - generated runtime manifests are safe to inspect before enablement

--- a/internal/installer/plugin.go
+++ b/internal/installer/plugin.go
@@ -1,0 +1,180 @@
+package installer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ai-knowledge-hub/ai-skills-guide/internal/registry"
+)
+
+type DependencyInstallResult struct {
+	InstalledSkills []string
+	SkippedSkills   []string
+	InstalledAgents []string
+	SkippedAgents   []string
+	InstalledTools  []string
+	SkippedTools    []string
+	HookPaths       []string
+}
+
+func InstallPluginDependencies(
+	entry registry.SkillEntry,
+	runtimeName string,
+	pluginTargetRoot string,
+	moduleRoots map[string]string,
+	registryPaths map[string]string,
+	force bool,
+) (DependencyInstallResult, error) {
+	result := DependencyInstallResult{}
+
+	if entry.Includes == nil {
+		return result, nil
+	}
+
+	if len(entry.Includes.Skills) > 0 {
+		installed, skipped, err := installDependencySet(
+			entry.Includes.Skills,
+			runtimeName,
+			pluginTargetRoot,
+			"skills",
+			moduleRoots["skills"],
+			registryPaths["skills"],
+			force,
+		)
+		if err != nil {
+			return result, err
+		}
+		result.InstalledSkills = installed
+		result.SkippedSkills = skipped
+	}
+
+	if len(entry.Includes.Agents) > 0 {
+		installed, skipped, err := installDependencySet(
+			entry.Includes.Agents,
+			runtimeName,
+			pluginTargetRoot,
+			"agents",
+			moduleRoots["agents"],
+			registryPaths["agents"],
+			force,
+		)
+		if err != nil {
+			return result, err
+		}
+		result.InstalledAgents = installed
+		result.SkippedAgents = skipped
+	}
+
+	if len(entry.Includes.Tools) > 0 {
+		installed, skipped, err := installDependencySet(
+			entry.Includes.Tools,
+			runtimeName,
+			pluginTargetRoot,
+			"tools",
+			moduleRoots["tools"],
+			registryPaths["tools"],
+			force,
+		)
+		if err != nil {
+			return result, err
+		}
+		result.InstalledTools = installed
+		result.SkippedTools = skipped
+	}
+
+	for _, hookName := range entry.Includes.Hooks {
+		hookPath, err := resolveHookPath(filepath.Join(pluginTargetRoot, filepath.FromSlash(entry.ID), "hooks"), hookName)
+		if err != nil {
+			return result, fmt.Errorf("resolve hook %s for %s: %w", hookName, entry.ID, err)
+		}
+		result.HookPaths = append(result.HookPaths, hookPath)
+	}
+
+	return result, nil
+}
+
+func installDependencySet(
+	ids []string,
+	runtimeName string,
+	pluginTargetRoot string,
+	moduleName string,
+	moduleRoot string,
+	registryPath string,
+	force bool,
+) ([]string, []string, error) {
+	if strings.TrimSpace(moduleRoot) == "" {
+		return nil, nil, fmt.Errorf("missing module root for %s", moduleName)
+	}
+	if strings.TrimSpace(registryPath) == "" {
+		return nil, nil, fmt.Errorf("missing registry path for %s", moduleName)
+	}
+
+	idx, err := registry.LoadIndex(registryPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load %s registry: %w", moduleName, err)
+	}
+	target, err := ResolvePluginDependencyTarget(runtimeName, moduleName, pluginTargetRoot)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	installed := make([]string, 0, len(ids))
+	skipped := make([]string, 0)
+	for _, id := range ids {
+		if _, ok := registry.FindSkill(idx, id); !ok {
+			return nil, nil, fmt.Errorf("%s dependency not found in registry: %s", moduleName, id)
+		}
+
+		sourceDir := filepath.Join(moduleRoot, filepath.FromSlash(id))
+		if stat, statErr := os.Stat(sourceDir); statErr != nil || !stat.IsDir() {
+			return nil, nil, fmt.Errorf("local source not found for %s dependency at %s", id, sourceDir)
+		}
+
+		destinationDir := filepath.Join(target.TargetPath, filepath.FromSlash(id))
+		if _, statErr := os.Stat(destinationDir); statErr == nil && !force {
+			skipped = append(skipped, destinationDir)
+			continue
+		}
+
+		destination, installErr := InstallSkill(sourceDir, target.TargetPath, id, force)
+		if installErr != nil {
+			return nil, nil, fmt.Errorf("install %s dependency %s: %w", moduleName, id, installErr)
+		}
+		installed = append(installed, destination)
+	}
+
+	return installed, skipped, nil
+}
+
+func ResolvePluginDependencyTarget(runtimeName, moduleName, pluginTargetRoot string) (RuntimeTarget, error) {
+	runtime := strings.ToLower(strings.TrimSpace(runtimeName))
+	pluginRootAbs, err := filepath.Abs(pluginTargetRoot)
+	if err != nil {
+		return RuntimeTarget{}, fmt.Errorf("resolve plugin target path: %w", err)
+	}
+	baseRoot := filepath.Dir(pluginRootAbs)
+	moduleDir, err := normalizeModuleDir(moduleName)
+	if err != nil {
+		return RuntimeTarget{}, err
+	}
+	return RuntimeTarget{
+		Runtime:    runtime,
+		TargetPath: filepath.Join(baseRoot, moduleDir),
+	}, nil
+}
+
+func resolveHookPath(hooksDir, hookName string) (string, error) {
+	candidates := []string{
+		filepath.Join(hooksDir, hookName+".md"),
+		filepath.Join(hooksDir, hookName+".json"),
+		filepath.Join(hooksDir, hookName+".yaml"),
+	}
+	for _, candidate := range candidates {
+		if stat, err := os.Stat(candidate); err == nil && !stat.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("missing hook file in %s", hooksDir)
+}

--- a/internal/installer/plugin_test.go
+++ b/internal/installer/plugin_test.go
@@ -1,0 +1,137 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ai-knowledge-hub/ai-skills-guide/internal/registry"
+)
+
+func TestInstallPluginDependenciesInstallsReferencedModulesAndHooks(t *testing.T) {
+	root := t.TempDir()
+
+	skillsRoot := filepath.Join(root, "skills")
+	agentsRoot := filepath.Join(root, "agents")
+	toolsRoot := filepath.Join(root, "tools-mcp")
+	pluginTarget := filepath.Join(root, "runtime", "plugins")
+
+	mustMkdirAll(t, filepath.Join(skillsRoot, "marketing", "demo-skill"))
+	mustMkdirAll(t, filepath.Join(agentsRoot, "marketing", "demo-agent"))
+	mustMkdirAll(t, filepath.Join(toolsRoot, "analytics", "demo-tool"))
+	mustMkdirAll(t, filepath.Join(pluginTarget, "marketing", "demo-plugin", "hooks"))
+
+	mustWriteFile(t, filepath.Join(skillsRoot, "marketing", "demo-skill", "SKILL.md"), "# Demo skill\n")
+	mustWriteFile(t, filepath.Join(agentsRoot, "marketing", "demo-agent", "AGENT.md"), "# Demo agent\n")
+	mustWriteFile(t, filepath.Join(toolsRoot, "analytics", "demo-tool", "TOOL.md"), "# Demo tool\n")
+	mustWriteFile(t, filepath.Join(pluginTarget, "marketing", "demo-plugin", "hooks", "notify.md"), "# Hook\n")
+
+	skillsIndexPath := filepath.Join(root, "registry", "skills-index.json")
+	agentsIndexPath := filepath.Join(root, "registry", "agents-index.json")
+	toolsIndexPath := filepath.Join(root, "registry", "tools-index.json")
+	mustWriteIndex(t, skillsIndexPath, registry.Index{Skills: []registry.SkillEntry{{ID: "marketing/demo-skill"}}})
+	mustWriteIndex(t, agentsIndexPath, registry.Index{Skills: []registry.SkillEntry{{ID: "marketing/demo-agent"}}})
+	mustWriteIndex(t, toolsIndexPath, registry.Index{Skills: []registry.SkillEntry{{ID: "analytics/demo-tool"}}})
+
+	entry := registry.SkillEntry{
+		ID: "marketing/demo-plugin",
+		Includes: &registry.IncludeSet{
+			Skills: []string{"marketing/demo-skill"},
+			Agents: []string{"marketing/demo-agent"},
+			Tools:  []string{"analytics/demo-tool"},
+			Hooks:  []string{"notify"},
+		},
+	}
+
+	result, err := InstallPluginDependencies(
+		entry,
+		"generic",
+		pluginTarget,
+		map[string]string{
+			"skills": skillsRoot,
+			"agents": agentsRoot,
+			"tools":  toolsRoot,
+		},
+		map[string]string{
+			"skills": skillsIndexPath,
+			"agents": agentsIndexPath,
+			"tools":  toolsIndexPath,
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.InstalledSkills) != 1 || len(result.InstalledAgents) != 1 || len(result.InstalledTools) != 1 {
+		t.Fatalf("expected dependencies to be installed, got %#v", result)
+	}
+	if len(result.HookPaths) != 1 {
+		t.Fatalf("expected one hook path, got %#v", result.HookPaths)
+	}
+	if _, err := os.Stat(filepath.Join(root, "runtime", "skills", "marketing", "demo-skill", "SKILL.md")); err != nil {
+		t.Fatalf("expected installed skill, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "runtime", "agents", "marketing", "demo-agent", "AGENT.md")); err != nil {
+		t.Fatalf("expected installed agent, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "runtime", "tools-mcp", "analytics", "demo-tool", "TOOL.md")); err != nil {
+		t.Fatalf("expected installed tool, got %v", err)
+	}
+}
+
+func TestInstallPluginDependenciesSkipsExistingWithoutForce(t *testing.T) {
+	root := t.TempDir()
+	skillsRoot := filepath.Join(root, "skills")
+	pluginTarget := filepath.Join(root, "runtime", "plugins")
+	mustMkdirAll(t, filepath.Join(skillsRoot, "marketing", "demo-skill"))
+	mustWriteFile(t, filepath.Join(skillsRoot, "marketing", "demo-skill", "SKILL.md"), "# Demo skill\n")
+	skillsIndexPath := filepath.Join(root, "registry", "skills-index.json")
+	mustWriteIndex(t, skillsIndexPath, registry.Index{Skills: []registry.SkillEntry{{ID: "marketing/demo-skill"}}})
+	existingTarget := filepath.Join(root, "runtime", "skills", "marketing", "demo-skill")
+	mustMkdirAll(t, existingTarget)
+
+	entry := registry.SkillEntry{
+		ID: "marketing/demo-plugin",
+		Includes: &registry.IncludeSet{
+			Skills: []string{"marketing/demo-skill"},
+		},
+	}
+	result, err := InstallPluginDependencies(
+		entry,
+		"generic",
+		pluginTarget,
+		map[string]string{"skills": skillsRoot, "agents": filepath.Join(root, "agents"), "tools": filepath.Join(root, "tools-mcp")},
+		map[string]string{"skills": skillsIndexPath, "agents": filepath.Join(root, "registry", "agents-index.json"), "tools": filepath.Join(root, "registry", "tools-index.json")},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.SkippedSkills) != 1 {
+		t.Fatalf("expected one skipped skill, got %#v", result)
+	}
+}
+
+func mustWriteIndex(t *testing.T, path string, idx registry.Index) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir index dir: %v", err)
+	}
+	if err := registry.WriteIndex(path, idx); err != nil {
+		t.Fatalf("write index: %v", err)
+	}
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/installer/runtime_test.go
+++ b/internal/installer/runtime_test.go
@@ -153,3 +153,14 @@ func TestPreparePluginRuntimeArtifactsForGenericSkips(t *testing.T) {
 		t.Fatalf("expected no artifacts for generic runtime, got %d", len(artifacts))
 	}
 }
+
+func TestResolvePluginDependencyTargetGeneric(t *testing.T) {
+	target, err := ResolvePluginDependencyTarget("generic", "skills", "/tmp/my-agent/plugins")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join("/tmp/my-agent", "skills")
+	if target.TargetPath != expected {
+		t.Fatalf("expected %s, got %s", expected, target.TargetPath)
+	}
+}

--- a/internal/plugins/validate.go
+++ b/internal/plugins/validate.go
@@ -1,0 +1,188 @@
+package plugins
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/ai-knowledge-hub/ai-skills-guide/internal/registry"
+)
+
+var numberedPromptPattern = regexp.MustCompile(`^[0-9]+\.`)
+
+type ValidationIssue struct {
+	PluginID string
+	Message  string
+}
+
+type ValidateOptions struct {
+	PluginsRoot string
+	SkillsRoot  string
+	AgentsRoot  string
+	ToolsRoot   string
+}
+
+func Validate(opts ValidateOptions) ([]ValidationIssue, error) {
+	pluginDirs, err := discoverPluginDirs(opts.PluginsRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	issues := make([]ValidationIssue, 0)
+	for _, pluginDir := range pluginDirs {
+		pluginID := filepath.ToSlash(strings.TrimPrefix(pluginDir, opts.PluginsRoot+string(filepath.Separator)))
+		if pluginID == pluginDir {
+			pluginID = filepath.ToSlash(strings.TrimPrefix(pluginDir, opts.PluginsRoot))
+		}
+
+		requiredFiles := []string{
+			"README.md",
+			"plugin.yaml",
+			"plugin.json",
+			filepath.Join("tests", "test-prompts.md"),
+		}
+		for _, rel := range requiredFiles {
+			path := filepath.Join(pluginDir, rel)
+			if _, err := os.Stat(path); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					issues = append(issues, ValidationIssue{PluginID: pluginID, Message: fmt.Sprintf("missing %s", rel)})
+					continue
+				}
+				return nil, fmt.Errorf("stat %s: %w", path, err)
+			}
+		}
+
+		examplesPath := filepath.Join(pluginDir, "examples")
+		if stat, err := os.Stat(examplesPath); err != nil || !stat.IsDir() {
+			issues = append(issues, ValidationIssue{PluginID: pluginID, Message: "missing examples/ directory"})
+		}
+
+		manifestPath := filepath.Join(pluginDir, "plugin.yaml")
+		manifest, err := registry.ParseManifest(manifestPath)
+		if err != nil {
+			return nil, err
+		}
+
+		promptCount, err := countNumberedPrompts(filepath.Join(pluginDir, "tests", "test-prompts.md"))
+		if err != nil {
+			return nil, err
+		}
+		if promptCount < 5 {
+			issues = append(issues, ValidationIssue{PluginID: manifest.ID, Message: fmt.Sprintf("need at least 5 numbered prompts (found %d)", promptCount)})
+		}
+
+		for _, id := range manifest.Includes.Skills {
+			if !entryDirExists(opts.SkillsRoot, id) {
+				issues = append(issues, ValidationIssue{PluginID: manifest.ID, Message: fmt.Sprintf("missing bundled skill: %s", id)})
+			}
+		}
+		for _, id := range manifest.Includes.Agents {
+			if !entryDirExists(opts.AgentsRoot, id) {
+				issues = append(issues, ValidationIssue{PluginID: manifest.ID, Message: fmt.Sprintf("missing bundled agent: %s", id)})
+			}
+		}
+		for _, id := range manifest.Includes.Tools {
+			if !entryDirExists(opts.ToolsRoot, id) {
+				issues = append(issues, ValidationIssue{PluginID: manifest.ID, Message: fmt.Sprintf("missing bundled tool: %s", id)})
+			}
+		}
+
+		if len(manifest.Includes.Hooks) > 0 {
+			hooksDir := filepath.Join(pluginDir, "hooks")
+			if stat, err := os.Stat(hooksDir); err != nil || !stat.IsDir() {
+				issues = append(issues, ValidationIssue{PluginID: manifest.ID, Message: "missing hooks/ directory"})
+			} else {
+				for _, hookName := range manifest.Includes.Hooks {
+					if !hookExists(hooksDir, hookName) {
+						issues = append(issues, ValidationIssue{PluginID: manifest.ID, Message: fmt.Sprintf("missing packaged hook file for: %s", hookName)})
+					}
+				}
+			}
+		}
+	}
+
+	return issues, nil
+}
+
+func discoverPluginDirs(root string) ([]string, error) {
+	if _, err := os.Stat(root); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat %s: %w", root, err)
+	}
+
+	dirs := make([]string, 0)
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		if strings.Count(filepath.ToSlash(rel), "/") == 1 {
+			dirs = append(dirs, path)
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk plugins root %s: %w", root, err)
+	}
+	return dirs, nil
+}
+
+func countNumberedPrompts(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	count := 0
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if numberedPromptPattern.MatchString(line) {
+			count++
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("scan %s: %w", path, err)
+	}
+	return count, nil
+}
+
+func entryDirExists(root, id string) bool {
+	if strings.TrimSpace(root) == "" {
+		return false
+	}
+	path := filepath.Join(root, filepath.FromSlash(id))
+	stat, err := os.Stat(path)
+	return err == nil && stat.IsDir()
+}
+
+func hookExists(hooksDir, hookName string) bool {
+	candidates := []string{
+		filepath.Join(hooksDir, hookName+".md"),
+		filepath.Join(hooksDir, hookName+".json"),
+		filepath.Join(hooksDir, hookName+".yaml"),
+	}
+	for _, candidate := range candidates {
+		if stat, err := os.Stat(candidate); err == nil && !stat.IsDir() {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/validate_test.go
+++ b/internal/plugins/validate_test.go
@@ -1,0 +1,153 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidatePluginSuccess(t *testing.T) {
+	root := t.TempDir()
+	pluginsRoot := filepath.Join(root, "plugins")
+	skillsRoot := filepath.Join(root, "skills")
+	agentsRoot := filepath.Join(root, "agents")
+	toolsRoot := filepath.Join(root, "tools-mcp")
+
+	mustMkdirAll(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "examples"))
+	mustMkdirAll(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "tests"))
+	mustMkdirAll(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "hooks"))
+	mustMkdirAll(t, filepath.Join(skillsRoot, "marketing", "demo-skill"))
+	mustMkdirAll(t, filepath.Join(agentsRoot, "marketing", "demo-agent"))
+	mustMkdirAll(t, filepath.Join(toolsRoot, "analytics", "demo-tool"))
+
+	mustWriteFile(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "README.md"), "# Demo\n")
+	mustWriteFile(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "plugin.json"), "{\"name\":\"demo\"}\n")
+	mustWriteFile(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "examples", "overview.md"), "# Example\n")
+	mustWriteFile(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "tests", "test-prompts.md"), "1. One\n2. Two\n3. Three\n4. Four\n5. Five\n")
+	mustWriteFile(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "hooks", "notify.md"), "# Hook\n")
+	mustWriteFile(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "plugin.yaml"), `id: marketing/demo-plugin
+name: Demo Plugin
+description: Demo plugin manifest used for plugin validation tests.
+version: 0.1.0
+released_at: "2026-03-29T00:00:00Z"
+category: marketing-plugins/reporting
+tags:
+  - demo
+license: MIT
+author:
+  name: Tests
+runtimes:
+  - codex
+entrypoints:
+  spec: plugin.json
+includes:
+  skills:
+    - marketing/demo-skill
+  agents:
+    - marketing/demo-agent
+  tools:
+    - analytics/demo-tool
+  hooks:
+    - notify
+deprecated: false
+`)
+
+	issues, err := Validate(ValidateOptions{
+		PluginsRoot: pluginsRoot,
+		SkillsRoot:  skillsRoot,
+		AgentsRoot:  agentsRoot,
+		ToolsRoot:   toolsRoot,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("expected no issues, got %#v", issues)
+	}
+}
+
+func TestValidatePluginReportsMissingDependenciesAndHooks(t *testing.T) {
+	root := t.TempDir()
+	pluginsRoot := filepath.Join(root, "plugins")
+	mustMkdirAll(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "examples"))
+	mustMkdirAll(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "tests"))
+	mustWriteFile(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "README.md"), "# Demo\n")
+	mustWriteFile(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "plugin.json"), "{\"name\":\"demo\"}\n")
+	mustWriteFile(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "examples", "overview.md"), "# Example\n")
+	mustWriteFile(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "tests", "test-prompts.md"), "1. One\n2. Two\n3. Three\n4. Four\n5. Five\n")
+	mustWriteFile(t, filepath.Join(pluginsRoot, "marketing", "demo-plugin", "plugin.yaml"), `id: marketing/demo-plugin
+name: Demo Plugin
+description: Demo plugin manifest used for plugin validation tests.
+version: 0.1.0
+released_at: "2026-03-29T00:00:00Z"
+category: marketing-plugins/reporting
+tags:
+  - demo
+license: MIT
+author:
+  name: Tests
+runtimes:
+  - codex
+entrypoints:
+  spec: plugin.json
+includes:
+  skills:
+    - marketing/missing-skill
+  agents:
+    - marketing/missing-agent
+  tools:
+    - analytics/missing-tool
+  hooks:
+    - missing-hook
+deprecated: false
+`)
+
+	issues, err := Validate(ValidateOptions{
+		PluginsRoot: pluginsRoot,
+		SkillsRoot:  filepath.Join(root, "skills"),
+		AgentsRoot:  filepath.Join(root, "agents"),
+		ToolsRoot:   filepath.Join(root, "tools-mcp"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rendered := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		rendered = append(rendered, issue.Message)
+	}
+	expected := []string{
+		"missing bundled skill: marketing/missing-skill",
+		"missing bundled agent: marketing/missing-agent",
+		"missing bundled tool: analytics/missing-tool",
+		"missing hooks/ directory",
+	}
+	for _, needle := range expected {
+		if !contains(rendered, needle) {
+			t.Fatalf("expected issue %q, got %#v", needle, rendered)
+		}
+	}
+}
+
+func contains(items []string, needle string) bool {
+	for _, item := range items {
+		if strings.Contains(item, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/plugins/marketing/ad-creative-plugin/README.md
+++ b/plugins/marketing/ad-creative-plugin/README.md
@@ -9,5 +9,19 @@ Portable bundle for paid-media creative ideation, QA, and experiment planning.
 - Meta Ads connector reference for campaign-context setup
 - Example pre-publish creative review hook
 
+## Install Behavior
+
+This plugin is a packaging layer.
+
+On install:
+
+- the plugin package itself is installed under `plugins/...`
+- bundled skills are installed into the runtime `skills/...` directory
+- bundled tools are installed into the runtime `tools-mcp/...` directory
+- packaged hooks remain inside this plugin's `hooks/` directory
+
+Bundled skills and tools do not live inside the plugin directory itself. That
+avoids duplication and keeps each component in its native runtime location.
+
 ## Use Case
 Install when a team wants one reusable package for developing ad concepts, evaluating them against rules and hypotheses, and handing approved variants into production workflows.

--- a/plugins/marketing/ad-creative-plugin/hooks/creative-review-before-publish.md
+++ b/plugins/marketing/ad-creative-plugin/hooks/creative-review-before-publish.md
@@ -1,0 +1,8 @@
+# Creative Review Before Publish
+
+Trigger before creative variants are handed into production.
+
+## Intent
+- require human sign-off
+- confirm experiment framing and rule compliance
+- prevent autonomous publish behavior

--- a/plugins/marketing/ad-creative-plugin/tests/test-prompts.md
+++ b/plugins/marketing/ad-creative-plugin/tests/test-prompts.md
@@ -1,7 +1,7 @@
 # Test Prompts
 
-- Create a new paid-social concept pack with testable angles for our spring campaign.
-- Generate PMax and reels variants, then score them against our creative rules.
-- Produce three ad-copy directions and recommend an A/B test plan.
-- Review draft creative outputs for rule violations before sending them to production.
-- Build an experiment-ready creative brief that still requires human sign-off before publish.
+1. Create a new paid-social concept pack with testable angles for our spring campaign.
+2. Generate PMax and reels variants, then score them against our creative rules.
+3. Produce three ad-copy directions and recommend an A/B test plan.
+4. Review draft creative outputs for rule violations before sending them to production.
+5. Build an experiment-ready creative brief that still requires human sign-off before publish.

--- a/plugins/marketing/campaign-audit-plugin/README.md
+++ b/plugins/marketing/campaign-audit-plugin/README.md
@@ -8,5 +8,21 @@ Portable bundle for campaign QA and governance checks.
 - Analytics and ad connector references
 - Example block-publish hook
 
+## Install Behavior
+
+This plugin is a packaging layer.
+
+On install:
+
+- the plugin package itself is installed under `plugins/...`
+- bundled skills are installed into the runtime `skills/...` directory
+- bundled agents are installed into the runtime `agents/...` directory
+- bundled tools are installed into the runtime `tools-mcp/...` directory
+- packaged hooks remain inside this plugin's `hooks/` directory
+
+Bundled skills, agents, and tools do not live inside the plugin directory
+itself. That avoids duplication and preserves the plugin as a composition
+package.
+
 ## Use Case
 Install when media or governance teams need a repeatable package for pre-launch audits and major campaign-change reviews.

--- a/plugins/marketing/campaign-audit-plugin/hooks/block-publish-on-critical-failure.md
+++ b/plugins/marketing/campaign-audit-plugin/hooks/block-publish-on-critical-failure.md
@@ -1,0 +1,8 @@
+# Block Publish On Critical Failure
+
+Trigger when campaign QA or policy checks surface critical launch blockers.
+
+## Intent
+- stop downstream publish steps
+- route findings to a human reviewer
+- preserve the audit trail

--- a/plugins/marketing/campaign-audit-plugin/tests/test-prompts.md
+++ b/plugins/marketing/campaign-audit-plugin/tests/test-prompts.md
@@ -1,7 +1,7 @@
 # Test Prompts
 
-- List the blocking conditions this plugin is designed to support.
-- Explain which bundled agent coordinates the audit workflow.
-- Describe the secret and approval requirements for this plugin.
-- Show how this plugin would handle a campaign launch QA scenario.
-- Identify which included skills address security or compliance risk.
+1. List the blocking conditions this plugin is designed to support.
+2. Explain which bundled agent coordinates the audit workflow.
+3. Describe the secret and approval requirements for this plugin.
+4. Show how this plugin would handle a campaign launch QA scenario.
+5. Identify which included skills address security or compliance risk.

--- a/plugins/marketing/competitive-intelligence-plugin/README.md
+++ b/plugins/marketing/competitive-intelligence-plugin/README.md
@@ -8,5 +8,18 @@ Portable bundle for evidence-based competitor monitoring and synthesis.
 - Untrusted-content handling to avoid taking instructions from scraped sources
 - Example digest hook for weekly competitive reporting
 
+## Install Behavior
+
+This plugin is a packaging layer.
+
+On install:
+
+- the plugin package itself is installed under `plugins/...`
+- bundled skills are installed into the runtime `skills/...` directory
+- packaged hooks remain inside this plugin's `hooks/` directory
+
+Bundled skills do not live inside the plugin directory itself. That keeps the
+plugin lightweight and avoids duplicating the source component packages.
+
 ## Use Case
 Install when a team needs a repeatable, safer workflow for collecting competitor signals, structuring observations, and sharing evidence-backed summaries without treating external content as trusted instructions.

--- a/plugins/marketing/competitive-intelligence-plugin/hooks/weekly-competitor-signal-digest.md
+++ b/plugins/marketing/competitive-intelligence-plugin/hooks/weekly-competitor-signal-digest.md
@@ -1,0 +1,8 @@
+# Weekly Competitor Signal Digest
+
+Trigger when the weekly competitor research cycle finishes.
+
+## Intent
+- package observations into a digest
+- distinguish evidence from inference
+- require human review for external-facing claims

--- a/plugins/marketing/competitive-intelligence-plugin/tests/test-prompts.md
+++ b/plugins/marketing/competitive-intelligence-plugin/tests/test-prompts.md
@@ -1,7 +1,7 @@
 # Test Prompts
 
-- Build a weekly competitor digest for our search and paid-social team.
-- Compare competitor messaging themes without treating scraped copy as instructions.
-- Capture and rank changes in competitor offers over the last month.
-- Produce a strategy memo that distinguishes hard evidence from inference.
-- Summarize competitor landing-page patterns and flag weak-confidence claims.
+1. Build a weekly competitor digest for our search and paid-social team.
+2. Compare competitor messaging themes without treating scraped copy as instructions.
+3. Capture and rank changes in competitor offers over the last month.
+4. Produce a strategy memo that distinguishes hard evidence from inference.
+5. Summarize competitor landing-page patterns and flag weak-confidence claims.

--- a/plugins/marketing/content-repurposing-plugin/README.md
+++ b/plugins/marketing/content-repurposing-plugin/README.md
@@ -7,5 +7,19 @@ Portable bundle for content reuse workflows across channels and formats.
 - Output evaluation support
 - Example review-before-publish hook
 
+## Install Behavior
+
+This plugin is a packaging layer.
+
+On install:
+
+- the plugin package itself is installed under `plugins/...`
+- bundled skills are installed into the runtime `skills/...` directory
+- packaged hooks remain inside this plugin's `hooks/` directory
+
+Bundled skills do not live inside the plugin directory itself. That keeps the
+plugin as a reusable composition package instead of a duplicated copy of its
+dependencies.
+
 ## Use Case
 Install when teams want a repeatable plugin for turning one source asset into multiple publish-ready variants with review controls.

--- a/plugins/marketing/content-repurposing-plugin/hooks/content-review-before-publish.md
+++ b/plugins/marketing/content-repurposing-plugin/hooks/content-review-before-publish.md
@@ -1,0 +1,8 @@
+# Content Review Before Publish
+
+Trigger before any publishing action.
+
+## Intent
+- require human review
+- confirm channel fit and brand compliance
+- prevent direct autonomous publishing

--- a/plugins/marketing/content-repurposing-plugin/tests/test-prompts.md
+++ b/plugins/marketing/content-repurposing-plugin/tests/test-prompts.md
@@ -1,7 +1,7 @@
 # Test Prompts
 
-- Explain which skills are bundled for content reuse.
-- Describe how this plugin should be used before publishing to live channels.
-- List the approval constraints in this plugin.
-- Show how one source asset could be repurposed into multiple formats.
-- Identify the role of the evaluation skill in this plugin.
+1. Explain which skills are bundled for content reuse.
+2. Describe how this plugin should be used before publishing to live channels.
+3. List the approval constraints in this plugin.
+4. Show how one source asset could be repurposed into multiple formats.
+5. Identify the role of the evaluation skill in this plugin.

--- a/plugins/marketing/page-speed-technical-seo-plugin/README.md
+++ b/plugins/marketing/page-speed-technical-seo-plugin/README.md
@@ -9,5 +9,19 @@ Portable bundle for technical SEO and landing-page diagnostics.
 - GA4 connector reference for landing-page and engagement validation
 - Example hook for Lighthouse-style review handoff
 
+## Install Behavior
+
+This plugin is a packaging layer.
+
+On install:
+
+- the plugin package itself is installed under `plugins/...`
+- bundled skills are installed into the runtime `skills/...` directory
+- bundled tools are installed into the runtime `tools-mcp/...` directory
+- packaged hooks remain inside this plugin's `hooks/` directory
+
+Bundled skills and tools do not live inside the plugin directory itself. That
+avoids duplication while still making the plugin install materially usable.
+
 ## Use Case
 Install when a team needs a repeatable workflow for reviewing slow landing pages, technical SEO regressions, and page-experience issues before escalating changes to engineering.

--- a/plugins/marketing/page-speed-technical-seo-plugin/hooks/lighthouse-and-landing-page-review.md
+++ b/plugins/marketing/page-speed-technical-seo-plugin/hooks/lighthouse-and-landing-page-review.md
@@ -1,0 +1,8 @@
+# Lighthouse And Landing Page Review
+
+Trigger after a technical SEO or page-speed scan completes.
+
+## Intent
+- collect the highest-impact findings
+- escalate engineering-facing issues
+- avoid direct site changes from the plugin runtime

--- a/plugins/marketing/page-speed-technical-seo-plugin/tests/test-prompts.md
+++ b/plugins/marketing/page-speed-technical-seo-plugin/tests/test-prompts.md
@@ -1,7 +1,7 @@
 # Test Prompts
 
-- Audit our top three paid-search landing pages for technical SEO and page-speed regressions.
-- Review a new product page for crawlability, performance, and conversion friction before launch.
-- Compare slow-page complaints against GA4 engagement trends and summarize likely causes.
-- Generate a technical SEO handoff for engineering with only evidence-backed recommendations.
-- Run a safe browser-based review workflow without making any live site changes.
+1. Audit our top three paid-search landing pages for technical SEO and page-speed regressions.
+2. Review a new product page for crawlability, performance, and conversion friction before launch.
+3. Compare slow-page complaints against GA4 engagement trends and summarize likely causes.
+4. Generate a technical SEO handoff for engineering with only evidence-backed recommendations.
+5. Run a safe browser-based review workflow without making any live site changes.

--- a/plugins/marketing/performance-reporting-plugin/README.md
+++ b/plugins/marketing/performance-reporting-plugin/README.md
@@ -9,5 +9,21 @@ Portable bundle for weekly reporting workflows.
 - Connector references for analytics, ads, and warehouse data
 - Example post-analysis Slack hook
 
+## Install Behavior
+
+This plugin is a packaging layer.
+
+On install:
+
+- the plugin package itself is installed under `plugins/...`
+- bundled skills are installed into the runtime `skills/...` directory
+- bundled agents are installed into the runtime `agents/...` directory
+- bundled tools are installed into the runtime `tools-mcp/...` directory
+- packaged hooks remain inside this plugin's `hooks/` directory
+
+Bundled skills, agents, and tools do not live inside the plugin directory
+itself. That avoids duplication and reflects the plugin's role as an
+installable composition package.
+
 ## Use Case
 Install when a team needs one shared reporting package instead of manually wiring separate skills, tools, and review steps.

--- a/plugins/marketing/performance-reporting-plugin/hooks/post-analysis-slack-summary.md
+++ b/plugins/marketing/performance-reporting-plugin/hooks/post-analysis-slack-summary.md
@@ -1,0 +1,8 @@
+# Post Analysis Slack Summary
+
+Trigger after the reporting workflow completes.
+
+## Intent
+- summarize the top insights
+- include evidence-backed caveats
+- send only after human review where required

--- a/plugins/marketing/performance-reporting-plugin/tests/test-prompts.md
+++ b/plugins/marketing/performance-reporting-plugin/tests/test-prompts.md
@@ -1,7 +1,7 @@
 # Test Prompts
 
-- Install the performance reporting plugin for a Claude runtime and list the required secrets.
-- Explain which skills and agents are bundled in this plugin.
-- Show how this plugin would support a weekly paid media review.
-- Identify which included components are responsible for QA gating.
-- Describe the human approval boundaries for this plugin.
+1. Install the performance reporting plugin for a Claude runtime and list the required secrets.
+2. Explain which skills and agents are bundled in this plugin.
+3. Show how this plugin would support a weekly paid media review.
+4. Identify which included components are responsible for QA gating.
+5. Describe the human approval boundaries for this plugin.

--- a/registry/plugins-index.json
+++ b/registry/plugins-index.json
@@ -14,7 +14,7 @@
           "released_at": "2026-03-29T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/ad-creative-plugin/plugin.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ad-creative-plugin/0.1.0.tar.gz",
-          "sha256": "f15ea5b54661627dc08eee056debe9ab8a4da6302a29db5dfe0cff7ec390950c"
+          "sha256": "f2498bf8a018b038d78175a096d4b9bfbf7c2591817e2cce0842ac3f5f83d11b"
         }
       ],
       "runtimes": [
@@ -66,7 +66,7 @@
           "released_at": "2026-03-28T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/campaign-audit-plugin/plugin.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/campaign-audit-plugin/0.1.0.tar.gz",
-          "sha256": "e8488d1d50f88005217e5e8bad4aded3ff6da3b30301750419f6e0a02bd936c4"
+          "sha256": "3e3c99ccd02a9ec054a0b2f565ef049a54ba40e0cf2b6545a1c20f093344147f"
         }
       ],
       "runtimes": [
@@ -121,7 +121,7 @@
           "released_at": "2026-03-29T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/competitive-intelligence-plugin/plugin.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/competitive-intelligence-plugin/0.1.0.tar.gz",
-          "sha256": "be8ff413f5cef3c931065a282140fd2483cb51245b5629655753b98221ffec37"
+          "sha256": "31e12e863d8c988e3cf36bc98895fbe248e08058d47cb018ba4ba105745ff893"
         }
       ],
       "runtimes": [
@@ -166,7 +166,7 @@
           "released_at": "2026-03-28T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/content-repurposing-plugin/plugin.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/content-repurposing-plugin/0.1.0.tar.gz",
-          "sha256": "a2b861cf98463e6f489bb5825d13335918ef38cea75dc31281a9f93d60bac6ec"
+          "sha256": "ed0ed17b6bb3abe25cbf01c1003553fb041d989fb21360aa05cb79bba6f8799c"
         }
       ],
       "runtimes": [
@@ -211,7 +211,7 @@
           "released_at": "2026-03-29T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/page-speed-technical-seo-plugin/plugin.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/page-speed-technical-seo-plugin/0.1.0.tar.gz",
-          "sha256": "32db07958d5bd344b006a6a22c5de5fcc853db49e3c3dbefec39c939e3d32f96"
+          "sha256": "248cf0b00e3119ffadb97203b95f36334f459aebe0278bb1690b352c55fa7df3"
         }
       ],
       "runtimes": [
@@ -262,7 +262,7 @@
           "released_at": "2026-03-28T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/performance-reporting-plugin/plugin.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/performance-reporting-plugin/0.1.0.tar.gz",
-          "sha256": "0977d9f0a96f114d1ed82e827ef64727ca8daed000191cea9b7aba6142581c5a"
+          "sha256": "bdd1b6df0636227b1378ec301a09b2cab3ede7689e5b1743d706b44b4e6a539f"
         }
       ],
       "runtimes": [

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -38,7 +38,7 @@ validate_module_structure() {
         echo "[ERROR] Missing 'When to use' section in ${entry_dir#$ROOT/}/$spec_file"
         FAIL=1
       fi
-      if ! grep -qi "## Guardrails" "$entry_dir/$spec_file"; then
+      if [[ "$spec_file" != "plugin.json" ]] && ! grep -qi "## Guardrails" "$entry_dir/$spec_file"; then
         echo "[ERROR] Missing 'Guardrails' section in ${entry_dir#$ROOT/}/$spec_file"
         FAIL=1
       fi
@@ -58,6 +58,11 @@ validate_module_structure() {
 validate_module_structure "$ROOT/skills" "skills" "SKILL.md" "skill.yaml"
 validate_module_structure "$ROOT/agents" "agents" "AGENT.md" "agent.yaml"
 validate_module_structure "$ROOT/tools-mcp" "tools-mcp" "TOOL.md" "tool.yaml"
+validate_module_structure "$ROOT/plugins" "plugins" "plugin.json" "plugin.yaml"
+
+if ! GOCACHE=/tmp/go-build GOTMPDIR=/tmp go run ./cmd/skills-hub validate --module plugins --root "$ROOT/plugins" --skills-root "$ROOT/skills" --agents-root "$ROOT/agents" --tools-root "$ROOT/tools-mcp"; then
+  FAIL=1
+fi
 
 if [[ "$FAIL" -eq 0 ]]; then
   echo "All module entries passed structural validation."


### PR DESCRIPTION
## Summary

This PR completes the next major plugin wave by turning plugins from simple package definitions into real installable composition packages.

Plugins now:

- install their own package directory
- resolve and install bundled skills, agents, and tools into native runtime directories
- keep plugin-local hooks packaged inside the plugin directory
- generate runtime-specific plugin manifests for `codex` and `claude`
- validate bundled dependencies and packaged hooks explicitly

This closes the gap between “plugin as registry entry” and “plugin as something users can install and use immediately”.

---

## What’s included

### 1. Dependency-resolving plugin installs

`skills-hub install --module plugins ...` now does more than copy the plugin folder.

On install it now:

- installs the plugin package under `plugins/...`
- installs bundled `skills` under `skills/...`
- installs bundled `agents` under `agents/...`
- installs bundled `tools-mcp` under `tools-mcp/...`
- keeps packaged `hooks/` inside the installed plugin
- generates:
  - `.codex-plugin/plugin.json` for Codex
  - `.claude-plugin/plugin.json` for Claude

This makes plugin installs materially usable instead of just descriptive.

### 2. Packaged hook files

All current plugins now ship real hook files under `hooks/` instead of only declaring hook names in manifests.

### 3. Dedicated plugin validation

Added a real plugin validation layer that checks:

- required plugin files exist
- examples and test prompts exist
- test prompts contain at least 5 numbered prompts
- referenced bundled `skills` exist
- referenced bundled `agents` exist
- referenced bundled `tools` exist
- declared `hooks` resolve to packaged files under `hooks/`

This validation is now wired into:

- `skills-hub validate --module plugins`
- `scripts/validate-skills.sh`

### 4. Plugin docs and READMEs updated

Updated plugin docs and all plugin package READMEs to explain the correct packaging model:

- plugins are a composition layer
- dependencies do **not** live inside the plugin directory
- install resolves dependencies into native runtime locations
- hooks remain packaged locally inside the plugin

This makes the mental model much clearer for users.

### 5. Existing plugin UX improvements retained

This PR also carries forward the earlier plugin work:
- `/plugins` catalog
- `/plugins/[...id]` detail pages
- package file links
- bundled component links
- install guidance above the fold
- README plugin install examples
- plugin card `View package file` shortcut

---

## Plugin behavior after this PR

### Codex / Claude installs
Plugin install now gives you:
- installed plugin package
- installed dependencies
- generated runtime manifest
- explicit output for:
  - installed dependency paths
  - packaged hooks
  - required secrets
  - required approvals
  - unreviewed-plugin warnings

### Generic installs
Plugin install now gives you:
- installed plugin under `./.../plugins`
- bundled dependencies installed into sibling directories:
  - `skills/`
  - `agents/`
  - `tools-mcp/`
- plugin-local hooks kept under the plugin directory
- no runtime-specific manifest auto-generated

---

## Files added / changed

### Installer
- `internal/installer/plugin.go`
- `internal/installer/plugin_test.go`
- `internal/installer/install.go`
- `internal/installer/runtime_test.go`

### CLI
- `cmd/skills-hub/main.go`
- `cmd/skills-hub/main_test.go`

### Plugin validation
- `internal/plugins/validate.go`
- `internal/plugins/validate_test.go`
- `scripts/validate-skills.sh`

### Plugin package content
- added `hooks/` across all current plugin packages
- updated plugin `README.md` files
- updated plugin `tests/test-prompts.md` to numbered prompts

### Docs / product copy
- `README.md`
- `docs/plugin-architecture.md`
- `docs/plugin-authoring-guide.md`
- `apps/web/app/plugins/[...id]/page.tsx`

### Registry
- regenerated plugin registry and package digests

---

## Validation

Passed locally:

- `go test ./internal/plugins ./internal/installer ./cmd/skills-hub ./internal/registry`
- `bash scripts/validate-skills.sh`
- `bash scripts/validate-manifests.sh`
- `rm -rf apps/web/.next && pnpm --dir apps/web build`

Also verified with real installs:

- plugin install for `codex`
- plugin install for `claude`
- plugin install for `generic`

Confirmed that dependencies land in the correct sibling runtime directories and hooks remain inside the plugin package.

---

## Why this matters

Before this PR:
- plugins were mostly installable package definitions
- referenced skills/agents/tools were not automatically materialized
- hooks were declared but not actually packaged
- validation did not enforce plugin dependency integrity

After this PR:
- plugins behave like actual composition packages
- users can install a plugin and get the required runtime components in place
- plugin package structure now matches the documented architecture
- validation will surface missing bundled dependencies or hook files immediately

This is a substantial step toward making plugins the practical packaging layer for the hub rather than just another registry type.
