### PR TITLE
extend the info on the plugins

### DIFF
--- a/apps/web/app/plugins/[...id]/page.tsx
+++ b/apps/web/app/plugins/[...id]/page.tsx
@@ -70,14 +70,14 @@ export default async function PluginDetailPage({ params }: { params: { id: strin
           <p><span className="meta">Lifecycle:</span> {entry.deprecated ? "Deprecated" : "Active"}</p>
         </article>
         <article className="card detail-panel">
-          <h2>Included Components</h2>
-          <p><span className="meta">Skills:</span> {entry.includes?.skills?.length ?? 0}</p>
-          <p><span className="meta">Agents:</span> {entry.includes?.agents?.length ?? 0}</p>
-          <p><span className="meta">Tools:</span> {entry.includes?.tools?.length ?? 0}</p>
-          <p><span className="meta">Hooks:</span> {entry.includes?.hooks?.length ?? 0}</p>
+          <h2>Install Summary</h2>
+          <p><span className="meta">Installed skills:</span> {entry.includes?.skills?.length ?? 0}</p>
+          <p><span className="meta">Installed agents:</span> {entry.includes?.agents?.length ?? 0}</p>
+          <p><span className="meta">Installed tools:</span> {entry.includes?.tools?.length ?? 0}</p>
+          <p><span className="meta">Packaged hooks:</span> {entry.includes?.hooks?.length ?? 0}</p>
         </article>
         <article className="card detail-panel">
-          <h2>Bundled Skills</h2>
+          <h2>Installed Skills</h2>
           {entry.includes?.skills?.length ? (
             <ul>
               {entry.includes.skills.map((skillId) => (
@@ -91,7 +91,7 @@ export default async function PluginDetailPage({ params }: { params: { id: strin
           )}
         </article>
         <article className="card detail-panel">
-          <h2>Bundled Agents</h2>
+          <h2>Installed Agents</h2>
           {entry.includes?.agents?.length ? (
             <ul>
               {entry.includes.agents.map((agentId) => (
@@ -105,7 +105,7 @@ export default async function PluginDetailPage({ params }: { params: { id: strin
           )}
         </article>
         <article className="card detail-panel">
-          <h2>Bundled Tools</h2>
+          <h2>Installed Tools</h2>
           {entry.includes?.tools?.length ? (
             <ul>
               {entry.includes.tools.map((toolId) => (
@@ -116,6 +116,20 @@ export default async function PluginDetailPage({ params }: { params: { id: strin
             </ul>
           ) : (
             <p>No bundled tools declared.</p>
+          )}
+        </article>
+        <article className="card detail-panel">
+          <h2>Packaged Hooks</h2>
+          {entry.includes?.hooks?.length ? (
+            <ul>
+              {entry.includes.hooks.map((hookId) => (
+                <li key={hookId}>
+                  <a href={`${REPO_BLOB_BASE}/${packageBasePath}/hooks/${hookId}.md`}>{hookId}</a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>No packaged hooks declared.</p>
           )}
         </article>
         <article className="card detail-panel">

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -62,7 +62,9 @@ test("plugins route and detail smoke", async ({ page }) => {
   await page.goto(samplePluginPath);
   await expect(page.getByRole("heading", { name: "Performance Reporting Plugin" })).toBeVisible();
   await expect(page.getByText("Marketing Plugins / Reporting")).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Included Components" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Install Summary" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Installed Skills" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Packaged Hooks" })).toBeVisible();
   await expect(page.getByRole("link", { name: "marketing/meta-google-weekly-performance-review" })).toBeVisible();
 });
 

--- a/plugins/marketing/ad-creative-plugin/README.md
+++ b/plugins/marketing/ad-creative-plugin/README.md
@@ -23,5 +23,27 @@ On install:
 Bundled skills and tools do not live inside the plugin directory itself. That
 avoids duplication and keeps each component in its native runtime location.
 
+## Install Command
+
+```bash
+./bin/skills-hub install --module plugins --entry marketing/ad-creative-plugin@0.1.0 --runtime codex
+```
+
+## Installed Dependencies
+
+Skills installed into `skills/...`:
+- `marketing/creative-workshop-pmax-reels`
+- `marketing/dynamic-creative-rules-engine`
+- `marketing/ab-test-planner-analyzer`
+- `marketing/ai-output-eval-scorecard`
+
+Tools installed into `tools-mcp/...`:
+- `ads/meta-ads-mcp-connector`
+
+## Packaged Hooks
+
+Hooks kept inside this plugin package:
+- `creative-review-before-publish`
+
 ## Use Case
 Install when a team wants one reusable package for developing ad concepts, evaluating them against rules and hypotheses, and handing approved variants into production workflows.

--- a/plugins/marketing/campaign-audit-plugin/README.md
+++ b/plugins/marketing/campaign-audit-plugin/README.md
@@ -24,5 +24,30 @@ Bundled skills, agents, and tools do not live inside the plugin directory
 itself. That avoids duplication and preserves the plugin as a composition
 package.
 
+## Install Command
+
+```bash
+./bin/skills-hub install --module plugins --entry marketing/campaign-audit-plugin@0.1.0 --runtime codex
+```
+
+## Installed Dependencies
+
+Skills installed into `skills/...`:
+- `adtech/policy-brand-compliance-checker`
+- `security/handle-untrusted-content`
+- `security/secrets-and-credential-hygiene`
+
+Agents installed into `agents/...`:
+- `marketing/campaign-qa-supervisor`
+
+Tools installed into `tools-mcp/...`:
+- `analytics/ga4-mcp-connector`
+- `ads/meta-ads-mcp-connector`
+
+## Packaged Hooks
+
+Hooks kept inside this plugin package:
+- `block-publish-on-critical-failure`
+
 ## Use Case
 Install when media or governance teams need a repeatable package for pre-launch audits and major campaign-change reviews.

--- a/plugins/marketing/competitive-intelligence-plugin/README.md
+++ b/plugins/marketing/competitive-intelligence-plugin/README.md
@@ -21,5 +21,23 @@ On install:
 Bundled skills do not live inside the plugin directory itself. That keeps the
 plugin lightweight and avoids duplicating the source component packages.
 
+## Install Command
+
+```bash
+./bin/skills-hub install --module plugins --entry marketing/competitive-intelligence-plugin@0.1.0 --runtime claude
+```
+
+## Installed Dependencies
+
+Skills installed into `skills/...`:
+- `adtech/brand-rag-memory-bootstrap`
+- `marketing/ai-output-eval-scorecard`
+- `security/handle-untrusted-content`
+
+## Packaged Hooks
+
+Hooks kept inside this plugin package:
+- `weekly-competitor-signal-digest`
+
 ## Use Case
 Install when a team needs a repeatable, safer workflow for collecting competitor signals, structuring observations, and sharing evidence-backed summaries without treating external content as trusted instructions.

--- a/plugins/marketing/content-repurposing-plugin/README.md
+++ b/plugins/marketing/content-repurposing-plugin/README.md
@@ -21,5 +21,23 @@ Bundled skills do not live inside the plugin directory itself. That keeps the
 plugin as a reusable composition package instead of a duplicated copy of its
 dependencies.
 
+## Install Command
+
+```bash
+./bin/skills-hub install --module plugins --entry marketing/content-repurposing-plugin@0.1.0 --runtime codex
+```
+
+## Installed Dependencies
+
+Skills installed into `skills/...`:
+- `marketing/creative-workshop-pmax-reels`
+- `marketing/ai-output-eval-scorecard`
+- `marketing/dynamic-creative-rules-engine`
+
+## Packaged Hooks
+
+Hooks kept inside this plugin package:
+- `content-review-before-publish`
+
 ## Use Case
 Install when teams want a repeatable plugin for turning one source asset into multiple publish-ready variants with review controls.

--- a/plugins/marketing/page-speed-technical-seo-plugin/README.md
+++ b/plugins/marketing/page-speed-technical-seo-plugin/README.md
@@ -23,5 +23,26 @@ On install:
 Bundled skills and tools do not live inside the plugin directory itself. That
 avoids duplication while still making the plugin install materially usable.
 
+## Install Command
+
+```bash
+./bin/skills-hub install --module plugins --entry marketing/page-speed-technical-seo-plugin@0.1.0 --runtime codex
+```
+
+## Installed Dependencies
+
+Skills installed into `skills/...`:
+- `marketing/seo-paid-search-synergy`
+- `adtech/playwright-agentic-e2e`
+- `security/environment-risk-assessment`
+
+Tools installed into `tools-mcp/...`:
+- `analytics/ga4-mcp-connector`
+
+## Packaged Hooks
+
+Hooks kept inside this plugin package:
+- `lighthouse-and-landing-page-review`
+
 ## Use Case
 Install when a team needs a repeatable workflow for reviewing slow landing pages, technical SEO regressions, and page-experience issues before escalating changes to engineering.

--- a/plugins/marketing/performance-reporting-plugin/README.md
+++ b/plugins/marketing/performance-reporting-plugin/README.md
@@ -25,5 +25,32 @@ Bundled skills, agents, and tools do not live inside the plugin directory
 itself. That avoids duplication and reflects the plugin's role as an
 installable composition package.
 
+## Install Command
+
+```bash
+./bin/skills-hub install --module plugins --entry marketing/performance-reporting-plugin@0.1.0 --runtime codex
+```
+
+## Installed Dependencies
+
+Skills installed into `skills/...`:
+- `marketing/meta-google-weekly-performance-review`
+- `adtech/dashboard-generator`
+- `adtech/dashboard-qa-checker`
+- `adtech/executive-narrative-writer`
+
+Agents installed into `agents/...`:
+- `marketing/weekly-performance-supervisor`
+
+Tools installed into `tools-mcp/...`:
+- `analytics/ga4-mcp-connector`
+- `ads/meta-ads-mcp-connector`
+- `warehouse/bigquery-mcp-query-runner`
+
+## Packaged Hooks
+
+Hooks kept inside this plugin package:
+- `post-analysis-slack-summary`
+
 ## Use Case
 Install when a team needs one shared reporting package instead of manually wiring separate skills, tools, and review steps.


### PR DESCRIPTION
## Summary

This PR completes the plugin packaging wave by making plugins behave like real installable composition packages and aligning the docs/UI with that behavior.

Plugins now:

- install their own package directory
- resolve and install bundled skills, agents, and tools into native runtime directories
- keep plugin-local hooks packaged inside the plugin directory
- generate runtime-specific plugin manifests for `codex` and `claude`
- validate bundled dependencies and packaged hooks explicitly
- describe the real install result clearly in both the plugin READMEs and the web UI

This closes the gap between “plugin as registry entry” and “plugin as something users can install and use immediately”.

---

## What’s included

### 1. Dependency-resolving plugin installs

`skills-hub install --module plugins ...` now does more than copy the plugin folder.

On install it now:

- installs the plugin package under `plugins/...`
- installs bundled `skills` under `skills/...`
- installs bundled `agents` under `agents/...`
- installs bundled `tools-mcp` under `tools-mcp/...`
- keeps packaged `hooks/` inside the installed plugin
- generates:
  - `.codex-plugin/plugin.json` for Codex
  - `.claude-plugin/plugin.json` for Claude

This makes plugin installs materially usable instead of just descriptive.

### 2. Packaged hook files

All current plugins now ship real hook files under `hooks/` instead of only declaring hook names in manifests.

### 3. Dedicated plugin validation

Added a real plugin validation layer that checks:

- required plugin files exist
- examples and test prompts exist
- test prompts contain at least 5 numbered prompts
- referenced bundled `skills` exist
- referenced bundled `agents` exist
- referenced bundled `tools` exist
- declared `hooks` resolve to packaged files under `hooks/`

This validation is now wired into:

- `skills-hub validate --module plugins`
- `scripts/validate-skills.sh`

### 4. Plugin docs and READMEs updated

Updated plugin docs and all plugin package READMEs to explain the correct packaging model:

- plugins are a composition layer
- dependencies do **not** live inside the plugin directory
- install resolves dependencies into native runtime locations
- hooks remain packaged locally inside the plugin

Each plugin README now also includes:
- a concrete install command
- explicit installed skill / agent / tool lists
- packaged hook names
- remaining setup expectations

### 5. Plugin UI now reflects install semantics

Plugin detail pages now distinguish between:

- `Installed Skills`
- `Installed Agents`
- `Installed Tools`
- `Packaged Hooks`

rather than treating everything as a generic bundle.

Bundled skills/agents/tools link to their catalog pages, and packaged hooks link to their repo files.

### 6. Existing plugin UX improvements retained

This PR also carries forward the earlier plugin work:
- `/plugins` catalog
- `/plugins/[...id]` detail pages
- package file links
- bundled component links
- install guidance above the fold
- README plugin install examples
- plugin card `View package file` shortcut

---

## Plugin behavior after this PR

### Codex / Claude installs
Plugin install now gives you:
- installed plugin package
- installed dependencies
- generated runtime manifest
- explicit output for:
  - installed dependency paths
  - packaged hooks
  - required secrets
  - required approvals
  - unreviewed-plugin warnings

### Generic installs
Plugin install now gives you:
- installed plugin under `./.../plugins`
- bundled dependencies installed into sibling directories:
  - `skills/`
  - `agents/`
  - `tools-mcp/`
- plugin-local hooks kept under the plugin directory
- no runtime-specific manifest auto-generated

---

## Files added / changed

### Installer
- `internal/installer/plugin.go`
- `internal/installer/plugin_test.go`
- `internal/installer/install.go`
- `internal/installer/runtime_test.go`

### CLI
- `cmd/skills-hub/main.go`
- `cmd/skills-hub/main_test.go`

### Plugin validation
- `internal/plugins/validate.go`
- `internal/plugins/validate_test.go`
- `scripts/validate-skills.sh`

### Plugin package content
- added `hooks/` across all current plugin packages
- updated plugin `README.md` files
- updated plugin `tests/test-prompts.md` to numbered prompts

### Docs / product copy
- `README.md`
- `docs/plugin-architecture.md`
- `docs/plugin-authoring-guide.md`
- `apps/web/app/plugins/[...id]/page.tsx`

### Registry
- regenerated plugin registry and package digests

---

## Validation

Passed locally:

- `go test ./internal/plugins ./internal/installer ./cmd/skills-hub ./internal/registry`
- `bash scripts/validate-skills.sh`
- `bash scripts/validate-manifests.sh`
- `rm -rf apps/web/.next && pnpm --dir apps/web build`

Also verified with real installs:

- plugin install for `codex`
- plugin install for `claude`
- plugin install for `generic`

Confirmed that dependencies land in the correct sibling runtime directories and hooks remain inside the plugin package.

---

## Why this matters

Before this PR:
- plugins were mostly installable package definitions
- referenced skills/agents/tools were not automatically materialized
- hooks were declared but not actually packaged
- validation did not enforce plugin dependency integrity
- docs/UI did not fully explain the real package model

After this PR:
- plugins behave like actual composition packages
- users can install a plugin and get the required runtime components in place
- plugin package structure now matches the documented architecture
- validation will surface missing bundled dependencies or hook files immediately
- plugin READMEs and detail pages now accurately describe what gets installed where

This is a substantial step toward making plugins the practical packaging layer for the hub rather than just another registry type.
