### PR TITLE
enrich tools, skills,agents info

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,43 @@ We publish reusable building blocks across four modules:
 - plugins (installable composition layer)
 - tools & MCP connectors (integration layer)
 
+## Operational Metadata Standard
+
+The catalog is being normalized around a shared operational metadata model so
+users can answer the same practical questions across modules:
+
+- what this entry does
+- what systems it touches
+- what it needs to authenticate
+- what permissions it can exercise
+- what approval boundary applies
+
+The first rollouts are on `tools-mcp` and `agents`.
+
+`tools-mcp` now exposes:
+
+- connected system
+- capabilities
+- auth required
+- access level
+- trust boundary
+- approval boundary
+
+`agents` now exposes:
+
+- role
+- coordinates
+- autonomy level
+- approval boundary
+- outputs
+
+`skills` now exposes:
+
+- use when
+- execution mode
+- outputs
+- approval boundary
+
 - Guide article site:
   [ai-news-hub.performics-labs.com](https://ai-news-hub.performics-labs.com)
   (article title: The Agent Architect’s Playbook: Building AI Skills

--- a/agents/adtech/bi-insights-orchestrator/README.md
+++ b/agents/adtech/bi-insights-orchestrator/README.md
@@ -10,6 +10,17 @@ marketing analytics.
 - Surfaces anomalies and insight candidates.
 - Routes approved outputs into dashboard-ready reporting flows.
 
+## Operational metadata
+
+- Role: analytics orchestration agent for warehouse-backed BI reporting
+- Autonomy level: semi-autonomous
+- Approval boundary: may coordinate read-only analysis and draft reporting outputs; require human approval before any publish or stakeholder-distribution decision
+- Outputs:
+  - normalized KPI table
+  - anomaly summary with evidence
+  - publish recommendation
+  - risks and data limitations
+
 ## Before you start
 
 1. Install this agent package.

--- a/agents/adtech/bi-insights-orchestrator/agent.yaml
+++ b/agents/adtech/bi-insights-orchestrator/agent.yaml
@@ -30,6 +30,19 @@ dependencies:
   tools:
     - bigquery_sql
     - ga4_query
+operational:
+  role: Analytics orchestration agent for warehouse-backed BI reporting.
+  coordinates:
+    - Warehouse and platform metric collection
+    - KPI normalization across sources
+    - Dashboard and insight generation
+  autonomy_level: semi-autonomous
+  approval_boundary: May coordinate read-only data analysis and draft reporting outputs; require human approval before any publish or stakeholder-distribution decision.
+  outputs:
+    - Normalized KPI table
+    - Anomaly summary with evidence
+    - Publish recommendation
+    - Risks and data limitations
 verification:
   tests_min_prompts: 5
   security_reviewed: false

--- a/agents/marketing/campaign-qa-supervisor/README.md
+++ b/agents/marketing/campaign-qa-supervisor/README.md
@@ -9,6 +9,17 @@ Agent template for campaign QA gating with clear remediation outputs.
 - Returns pass/warn/fail with remediation actions.
 - Blocks launch recommendations on critical failures.
 
+## Operational metadata
+
+- Role: governance agent for campaign QA, tracking integrity, and launch readiness
+- Autonomy level: execution-capable-with-approval
+- Approval boundary: may assess launch readiness and draft remediation alerts; require human approval before overriding critical failures or taking live launch actions
+- Outputs:
+  - pass, warn, or fail decision
+  - critical blocker list
+  - remediation action list
+  - alert summary for escalation
+
 ## Before you start
 
 1. Install this agent package.

--- a/agents/marketing/campaign-qa-supervisor/agent.yaml
+++ b/agents/marketing/campaign-qa-supervisor/agent.yaml
@@ -28,6 +28,19 @@ dependencies:
   tools:
     - campaign_config_reader
     - slack_post
+operational:
+  role: Governance agent for campaign QA, tracking integrity, and launch readiness.
+  coordinates:
+    - Campaign payload validation
+    - Policy and naming checks
+    - Severity assessment and remediation routing
+  autonomy_level: execution-capable-with-approval
+  approval_boundary: May assess launch readiness and draft remediation alerts; require human approval before overriding critical failures or taking live launch actions.
+  outputs:
+    - Pass, warn, or fail decision
+    - Critical blocker list
+    - Remediation action list
+    - Alert summary for escalation
 verification:
   tests_min_prompts: 5
   security_reviewed: false

--- a/agents/marketing/weekly-performance-supervisor/README.md
+++ b/agents/marketing/weekly-performance-supervisor/README.md
@@ -10,6 +10,17 @@ QA-gated publish control.
 - Runs QA checks before publish.
 - Generates executive narrative only when QA passes.
 
+## Operational metadata
+
+- Role: weekly reporting supervisor for QA-gated performance review workflows
+- Autonomy level: semi-autonomous
+- Approval boundary: may coordinate reporting workflows and draft narratives after QA approval; require human approval before any external publish or stakeholder send
+- Outputs:
+  - publish decision
+  - dashboard package
+  - QA package
+  - executive narrative
+
 ## Before you start
 
 1. Install this agent package.

--- a/agents/marketing/weekly-performance-supervisor/agent.yaml
+++ b/agents/marketing/weekly-performance-supervisor/agent.yaml
@@ -30,6 +30,19 @@ dependencies:
   tools:
     - ga4_query
     - warehouse_query
+operational:
+  role: Weekly reporting supervisor for QA-gated performance review workflows.
+  coordinates:
+    - Dashboard generation
+    - QA gating and blocking decisions
+    - Executive narrative drafting after approval
+  autonomy_level: semi-autonomous
+  approval_boundary: May coordinate reporting workflows and draft narratives after QA approval; require human approval before any external publish or stakeholder send.
+  outputs:
+    - Publish decision
+    - Dashboard package
+    - QA package
+    - Executive narrative
 verification:
   tests_min_prompts: 5
   security_reviewed: false

--- a/apps/web/app/agents/[...id]/page.tsx
+++ b/apps/web/app/agents/[...id]/page.tsx
@@ -47,20 +47,68 @@ export default async function AgentDetailPage({ params }: { params: { id: string
 
       <section className="detail-grid">
         <article className="card detail-panel">
+          <h2>Operational Summary</h2>
+          <p><span className="meta">Role:</span> {entry.operational?.role ?? "Not documented"}</p>
+          <p><span className="meta">Autonomy level:</span> {entry.operational?.autonomy_level ?? "Not documented"}</p>
+          <p><span className="meta">Approval boundary:</span> {entry.operational?.approval_boundary ?? "Not documented"}</p>
+        </article>
+        <article className="card detail-panel">
           <h2>Status</h2>
           <p><span className={`catalog-status-badge is-${entry.readiness}`}>{formatReadinessLabel(entry.readiness)}</span></p>
           <p><span className="meta">Security reviewed:</span> {entry.security_reviewed ? "yes" : "no"}</p>
           <p><span className="meta">Lifecycle:</span> {entry.deprecated ? "Deprecated" : "Active"}</p>
         </article>
         <article className="card detail-panel">
-          <h2>Metadata</h2>
+          <h2>Runtime &amp; Dependencies</h2>
           <p><span className="meta">ID:</span> {entry.id}</p>
-          <p><span className="meta">Latest:</span> {entry.latest}</p>
           <p><span className="meta">Runtimes:</span> {entry.runtimes.join(", ")}</p>
+          <p><span className="meta">Skill dependencies:</span> {entry.dependencies?.skills?.length ?? 0}</p>
+          <p><span className="meta">Tool dependencies:</span> {entry.dependencies?.tools?.length ?? 0}</p>
           {entry.replaced_by ? <p><span className="meta">Replaced by:</span> {entry.replaced_by}</p> : null}
         </article>
         <article className="card detail-panel">
+          <h2>Coordinates</h2>
+          {entry.operational?.coordinates?.length ? (
+            <ul>
+              {entry.operational.coordinates.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>Not documented.</p>
+          )}
+        </article>
+        <article className="card detail-panel">
+          <h2>Outputs</h2>
+          {entry.operational?.outputs?.length ? (
+            <ul>
+              {entry.operational.outputs.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>Not documented.</p>
+          )}
+        </article>
+        <article className="card detail-panel">
+          <h2>Dependencies</h2>
+          {entry.dependencies?.skills?.length ? (
+            <p><span className="meta">Skills:</span> {entry.dependencies.skills.join(", ")}</p>
+          ) : (
+            <p><span className="meta">Skills:</span> Not documented</p>
+          )}
+          {entry.dependencies?.tools?.length ? (
+            <p><span className="meta">Tools:</span> {entry.dependencies.tools.join(", ")}</p>
+          ) : (
+            <p><span className="meta">Tools:</span> Not documented</p>
+          )}
+          {entry.dependencies?.apis?.length ? (
+            <p><span className="meta">APIs:</span> {entry.dependencies.apis.join(", ")}</p>
+          ) : null}
+        </article>
+        <article className="card detail-panel">
           <h2>Latest Version</h2>
+          <p><span className="meta">Latest:</span> {entry.latest}</p>
           <p><span className="meta">Released:</span> {latestVersion?.released_at.slice(0, 10) ?? "n/a"}</p>
           <p>
             <span className="meta">Manifest:</span>{" "}

--- a/apps/web/app/skills/[...id]/page.tsx
+++ b/apps/web/app/skills/[...id]/page.tsx
@@ -48,17 +48,41 @@ export default async function SkillDetailPage({ params }: { params: { id: string
 
       <section className="detail-grid">
         <article className="card detail-panel">
+          <h2>Operational Summary</h2>
+          <p><span className="meta">Use when:</span> {skill.operational?.use_when ?? "Not documented"}</p>
+          <p><span className="meta">Execution mode:</span> {skill.operational?.execution_mode ?? "Not documented"}</p>
+          <p><span className="meta">Approval boundary:</span> {skill.operational?.approval_boundary ?? "Not documented"}</p>
+        </article>
+        <article className="card detail-panel">
           <h2>Status</h2>
           <p><span className={`catalog-status-badge is-${skill.readiness}`}>{formatReadinessLabel(skill.readiness)}</span></p>
           <p><span className="meta">Security reviewed:</span> {skill.security_reviewed ? "yes" : "no"}</p>
           <p><span className="meta">Lifecycle:</span> {skill.deprecated ? "Deprecated" : "Active"}</p>
         </article>
         <article className="card detail-panel">
-          <h2>Metadata</h2>
+          <h2>Runtime &amp; Dependencies</h2>
           <p><span className="meta">ID:</span> {skill.id}</p>
-          <p><span className="meta">Latest:</span> {skill.latest}</p>
           <p><span className="meta">Runtimes:</span> {skill.runtimes.join(", ")}</p>
+          <p><span className="meta">Tool dependencies:</span> {skill.dependencies?.tools?.length ?? 0}</p>
+          <p><span className="meta">API dependencies:</span> {skill.dependencies?.apis?.length ?? 0}</p>
           {skill.replaced_by ? <p><span className="meta">Replaced by:</span> {skill.replaced_by}</p> : null}
+        </article>
+        <article className="card detail-panel">
+          <h2>Dependencies</h2>
+          <p><span className="meta">Tools:</span> {skill.dependencies?.tools?.length ? skill.dependencies.tools.join(", ") : "Not documented"}</p>
+          <p><span className="meta">APIs:</span> {skill.dependencies?.apis?.length ? skill.dependencies.apis.join(", ") : "Not documented"}</p>
+        </article>
+        <article className="card detail-panel">
+          <h2>Outputs</h2>
+          {skill.operational?.outputs?.length ? (
+            <ul>
+              {skill.operational.outputs.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>Not documented.</p>
+          )}
         </article>
       </section>
     </main>

--- a/apps/web/app/tools-mcp/[...id]/page.tsx
+++ b/apps/web/app/tools-mcp/[...id]/page.tsx
@@ -47,20 +47,46 @@ export default async function ToolDetailPage({ params }: { params: { id: string[
 
       <section className="detail-grid">
         <article className="card detail-panel">
+          <h2>Operational Summary</h2>
+          <p><span className="meta">Connected system:</span> {entry.operational?.connected_system ?? "Not documented"}</p>
+          <p><span className="meta">Access level:</span> {entry.operational?.access_level ?? "Not documented"}</p>
+          <p><span className="meta">Trust boundary:</span> {entry.operational?.trust_boundary ?? "Not documented"}</p>
+          <p><span className="meta">Approval boundary:</span> {entry.operational?.approval_boundary ?? "Not documented"}</p>
+        </article>
+        <article className="card detail-panel">
           <h2>Status</h2>
           <p><span className={`catalog-status-badge is-${entry.readiness}`}>{formatReadinessLabel(entry.readiness)}</span></p>
           <p><span className="meta">Security reviewed:</span> {entry.security_reviewed ? "yes" : "no"}</p>
           <p><span className="meta">Lifecycle:</span> {entry.deprecated ? "Deprecated" : "Active"}</p>
         </article>
         <article className="card detail-panel">
-          <h2>Metadata</h2>
+          <h2>Runtime &amp; Dependencies</h2>
           <p><span className="meta">ID:</span> {entry.id}</p>
-          <p><span className="meta">Latest:</span> {entry.latest}</p>
           <p><span className="meta">Runtimes:</span> {entry.runtimes.join(", ")}</p>
+          <p><span className="meta">Auth required:</span> {entry.operational?.auth_required?.length ? entry.operational.auth_required.join(", ") : "Not documented"}</p>
           {entry.replaced_by ? <p><span className="meta">Replaced by:</span> {entry.replaced_by}</p> : null}
         </article>
         <article className="card detail-panel">
+          <h2>Dependencies &amp; Setup</h2>
+          <p><span className="meta">MCP servers:</span> {entry.dependencies?.mcp_servers?.length ? entry.dependencies.mcp_servers.join(", ") : "Not documented"}</p>
+          <p><span className="meta">APIs:</span> {entry.dependencies?.apis?.length ? entry.dependencies.apis.join(", ") : "Not documented"}</p>
+          <p><span className="meta">Local tools:</span> {entry.dependencies?.tools?.length ? entry.dependencies.tools.join(", ") : "Not documented"}</p>
+        </article>
+        <article className="card detail-panel">
+          <h2>Capabilities</h2>
+          {entry.operational?.capabilities?.length ? (
+            <ul>
+              {entry.operational.capabilities.map((capability) => (
+                <li key={capability}>{capability}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>Not documented.</p>
+          )}
+        </article>
+        <article className="card detail-panel">
           <h2>Latest Version</h2>
+          <p><span className="meta">Latest:</span> {entry.latest}</p>
           <p><span className="meta">Released:</span> {latestVersion?.released_at.slice(0, 10) ?? "n/a"}</p>
           <p>
             <span className="meta">Manifest:</span>{" "}

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -30,6 +30,9 @@ test("skill detail copy-button smoke", async ({ page }) => {
   });
 
   await page.goto(sampleSkillPath);
+  await expect(page.getByRole("heading", { name: "Operational Summary" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Outputs" })).toBeVisible();
+  await expect(page.getByText("may-run-local-verification")).toBeVisible();
   const copyButtons = page.locator(".copy-button");
 
   await expect(copyButtons).toHaveCount(3);
@@ -44,6 +47,9 @@ test("agents route and detail smoke", async ({ page }) => {
   await page.goto(sampleAgentPath);
   await expect(page.getByRole("heading", { name: "Weekly Performance Supervisor" })).toBeVisible();
   await expect(page.getByText("Marketing Agents / Performance")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Operational Summary" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Coordinates" })).toBeVisible();
+  await expect(page.getByText("semi-autonomous")).toBeVisible();
 });
 
 test("plugins route and detail smoke", async ({ page }) => {
@@ -76,4 +82,7 @@ test("tools route and detail smoke", async ({ page }) => {
   await page.goto(sampleToolPath);
   await expect(page.getByRole("heading", { name: "GA4 MCP Connector" })).toBeVisible();
   await expect(page.getByText("tools-mcp/analytics").first()).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Operational Summary" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Capabilities" })).toBeVisible();
+  await expect(page.getByText("remote-mcp-server")).toBeVisible();
 });

--- a/apps/web/lib/registry.ts
+++ b/apps/web/lib/registry.ts
@@ -24,6 +24,26 @@ export type RegistryEntry = {
   security_reviewed: boolean;
   deprecated: boolean;
   replaced_by?: string;
+  operational?: {
+    connected_system?: string;
+    capabilities?: string[];
+    auth_required?: string[];
+    access_level?: string;
+    trust_boundary?: string;
+    approval_boundary?: string;
+    role?: string;
+    coordinates?: string[];
+    autonomy_level?: string;
+    outputs?: string[];
+    use_when?: string;
+    execution_mode?: string;
+  };
+  dependencies?: {
+    skills?: string[];
+    tools?: string[];
+    apis?: string[];
+    mcp_servers?: string[];
+  };
   includes?: {
     skills?: string[];
     agents?: string[];

--- a/docs/architecture-modules.md
+++ b/docs/architecture-modules.md
@@ -48,6 +48,42 @@ Detail routes:
 - Plugins: `plugin.yaml` validated by `shared/schemas/plugin.schema.json`
 - Tools: `tool.yaml` validated by `shared/schemas/tool.schema.json`
 
+## Operational Metadata Rollout
+
+The catalog is moving toward a shared operational metadata model so detail
+pages answer practical questions quickly:
+
+- what this entry touches
+- what permissions it needs
+- what trust boundary it crosses
+- what approval boundary applies
+
+The first implemented slices are `tools-mcp` and `agents`.
+
+`tools-mcp` now documents:
+
+- `connected_system`
+- `capabilities`
+- `auth_required`
+- `access_level`
+- `trust_boundary`
+- `approval_boundary`
+
+`agents` now documents:
+
+- `role`
+- `coordinates`
+- `autonomy_level`
+- `approval_boundary`
+- `outputs`
+
+`skills` now documents:
+
+- `use_when`
+- `execution_mode`
+- `outputs`
+- `approval_boundary`
+
 ## Registry Generation
 Build separate indexes from each top-level folder:
 - `skills/` -> `registry/skills-index.json`

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -78,6 +78,14 @@ func buildIndexFor(root, moduleDir, manifestName string) (Index, error) {
 			Deprecated:       m.Deprecated,
 			ReplacedBy:       m.ReplacedBy,
 		}
+		if hasOperational(m.Operational) {
+			operational := m.Operational
+			entry.Operational = &operational
+		}
+		if hasDependencies(m.Dependencies) {
+			dependencies := m.Dependencies
+			entry.Dependencies = &dependencies
+		}
 		if hasIncludes(m.Includes) {
 			includes := m.Includes
 			entry.Includes = &includes
@@ -111,6 +119,25 @@ func buildIndexFor(root, moduleDir, manifestName string) (Index, error) {
 
 func hasIncludes(includes IncludeSet) bool {
 	return len(includes.Skills) > 0 || len(includes.Agents) > 0 || len(includes.Tools) > 0 || len(includes.Hooks) > 0
+}
+
+func hasOperational(operational OperationalMetadata) bool {
+	return operational.ConnectedSystem != "" ||
+		len(operational.Capabilities) > 0 ||
+		len(operational.AuthRequired) > 0 ||
+		operational.AccessLevel != "" ||
+		operational.TrustBoundary != "" ||
+		operational.ApprovalBoundary != "" ||
+		operational.Role != "" ||
+		len(operational.Coordinates) > 0 ||
+		operational.AutonomyLevel != "" ||
+		len(operational.Outputs) > 0 ||
+		operational.UseWhen != "" ||
+		operational.ExecutionMode != ""
+}
+
+func hasDependencies(dependencies DependencySet) bool {
+	return len(dependencies.Skills) > 0 || len(dependencies.Tools) > 0 || len(dependencies.APIs) > 0 || len(dependencies.MCPServers) > 0
 }
 
 func hasRequirements(requires RequirementSet) bool {

--- a/internal/registry/builder_test.go
+++ b/internal/registry/builder_test.go
@@ -7,6 +7,61 @@ import (
 	"testing"
 )
 
+func TestBuildSkillsIndex(t *testing.T) {
+	root := t.TempDir()
+	entryDir := filepath.Join(root, "skills", "engineering", "demo-skill")
+	if err := os.MkdirAll(entryDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mf := `id: engineering/demo-skill
+name: Demo Skill
+description: Demo skill manifest used for index generation tests.
+version: 0.1.0
+released_at: "2026-03-30T00:00:00Z"
+category: engineering/code-maintenance
+tags:
+  - planning
+license: MIT
+author:
+  name: Tests
+runtimes:
+  - codex
+entrypoints:
+  skill_md: SKILL.md
+dependencies:
+  tools:
+    - rg
+operational:
+  use_when: Use when repo planning is needed.
+  execution_mode: read-only-local-inspection
+  outputs:
+    - Change strategy
+  approval_boundary: Safe for planning before edits.
+deprecated: false
+`
+	if err := os.WriteFile(filepath.Join(entryDir, "skill.yaml"), []byte(mf), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entryDir, "SKILL.md"), []byte("---\n# Demo\n"), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+
+	idx, err := BuildSkillsIndex(root)
+	if err != nil {
+		t.Fatalf("build index: %v", err)
+	}
+	if len(idx.Skills) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(idx.Skills))
+	}
+	entry := idx.Skills[0]
+	if entry.Operational == nil || entry.Operational.UseWhen != "Use when repo planning is needed." {
+		t.Fatalf("expected operational metadata in index, got %#v", entry.Operational)
+	}
+	if entry.Dependencies == nil || len(entry.Dependencies.Tools) != 1 {
+		t.Fatalf("expected dependencies in index, got %#v", entry.Dependencies)
+	}
+}
+
 func TestBuildAgentsIndex(t *testing.T) {
 	root := t.TempDir()
 	entryDir := filepath.Join(root, "agents", "marketing", "demo-agent")
@@ -28,6 +83,19 @@ runtimes:
   - codex
 entrypoints:
   spec: AGENT.md
+dependencies:
+  skills:
+    - adtech/dashboard-generator
+  tools:
+    - ga4_query
+operational:
+  role: Demo supervisor.
+  coordinates:
+    - Reporting
+  autonomy_level: semi-autonomous
+  approval_boundary: Approval required before publish.
+  outputs:
+    - Publish decision
 deprecated: false
 `
 	if err := os.WriteFile(filepath.Join(entryDir, "agent.yaml"), []byte(mf), 0o644); err != nil {
@@ -47,6 +115,12 @@ deprecated: false
 	entry := idx.Skills[0]
 	if entry.ID != "marketing/demo-agent" {
 		t.Fatalf("unexpected id: %s", entry.ID)
+	}
+	if entry.Operational == nil || entry.Operational.Role != "Demo supervisor." {
+		t.Fatalf("expected operational metadata in index, got %#v", entry.Operational)
+	}
+	if entry.Dependencies == nil || len(entry.Dependencies.Skills) != 1 {
+		t.Fatalf("expected dependencies in index, got %#v", entry.Dependencies)
 	}
 	if !strings.Contains(entry.Versions[0].ManifestURL, "/agents/marketing/demo-agent/agent.yaml") {
 		t.Fatalf("unexpected manifest url: %s", entry.Versions[0].ManifestURL)
@@ -77,6 +151,18 @@ runtimes:
   - codex
 entrypoints:
   spec: TOOL.md
+dependencies:
+  mcp_servers:
+    - demo-mcp
+operational:
+  connected_system: Demo Analytics
+  capabilities:
+    - Pull demo rows.
+  auth_required:
+    - Demo auth
+  access_level: read-only
+  trust_boundary: remote-mcp-server
+  approval_boundary: Safe for demo read-only queries.
 deprecated: false
 `
 	if err := os.WriteFile(filepath.Join(entryDir, "tool.yaml"), []byte(mf), 0o644); err != nil {
@@ -96,6 +182,12 @@ deprecated: false
 	entry := idx.Skills[0]
 	if entry.ID != "analytics/demo-tool" {
 		t.Fatalf("unexpected id: %s", entry.ID)
+	}
+	if entry.Operational == nil || entry.Operational.ConnectedSystem != "Demo Analytics" {
+		t.Fatalf("expected operational metadata in index, got %#v", entry.Operational)
+	}
+	if entry.Dependencies == nil || len(entry.Dependencies.MCPServers) != 1 {
+		t.Fatalf("expected dependencies in index, got %#v", entry.Dependencies)
 	}
 	if !strings.Contains(entry.Versions[0].ManifestURL, "/tools-mcp/analytics/demo-tool/tool.yaml") {
 		t.Fatalf("unexpected manifest url: %s", entry.Versions[0].ManifestURL)

--- a/internal/registry/manifest_parser.go
+++ b/internal/registry/manifest_parser.go
@@ -48,6 +48,28 @@ func ParseManifest(path string) (Manifest, error) {
 			item := strings.TrimSpace(strings.TrimPrefix(line, "    - "))
 			item = unquote(item)
 			switch nestedMapKey {
+			case "dependencies":
+				switch currentNestedListKey {
+				case "skills":
+					out.Dependencies.Skills = append(out.Dependencies.Skills, item)
+				case "tools":
+					out.Dependencies.Tools = append(out.Dependencies.Tools, item)
+				case "apis":
+					out.Dependencies.APIs = append(out.Dependencies.APIs, item)
+				case "mcp_servers":
+					out.Dependencies.MCPServers = append(out.Dependencies.MCPServers, item)
+				}
+			case "operational":
+				switch currentNestedListKey {
+				case "capabilities":
+					out.Operational.Capabilities = append(out.Operational.Capabilities, item)
+				case "auth_required":
+					out.Operational.AuthRequired = append(out.Operational.AuthRequired, item)
+				case "coordinates":
+					out.Operational.Coordinates = append(out.Operational.Coordinates, item)
+				case "outputs":
+					out.Operational.Outputs = append(out.Operational.Outputs, item)
+				}
 			case "includes":
 				switch currentNestedListKey {
 				case "skills":
@@ -81,8 +103,30 @@ func ParseManifest(path string) (Manifest, error) {
 				if len(nestedParts) == 2 {
 					nestedKey := strings.TrimSpace(nestedParts[0])
 					nestedValue := unquote(strings.TrimSpace(nestedParts[1]))
-					if nestedMapKey == "verification" && nestedKey == "security_reviewed" {
-						out.SecurityReviewed = strings.EqualFold(nestedValue, "true")
+					switch nestedMapKey {
+					case "verification":
+						if nestedKey == "security_reviewed" {
+							out.SecurityReviewed = strings.EqualFold(nestedValue, "true")
+						}
+					case "operational":
+						switch nestedKey {
+						case "connected_system":
+							out.Operational.ConnectedSystem = nestedValue
+						case "access_level":
+							out.Operational.AccessLevel = nestedValue
+						case "trust_boundary":
+							out.Operational.TrustBoundary = nestedValue
+						case "approval_boundary":
+							out.Operational.ApprovalBoundary = nestedValue
+						case "role":
+							out.Operational.Role = nestedValue
+						case "autonomy_level":
+							out.Operational.AutonomyLevel = nestedValue
+						case "use_when":
+							out.Operational.UseWhen = nestedValue
+						case "execution_mode":
+							out.Operational.ExecutionMode = nestedValue
+						}
 					}
 					currentNestedListKey = ""
 				}
@@ -140,7 +184,7 @@ func ParseManifest(path string) (Manifest, error) {
 			out.Deprecated = strings.EqualFold(value, "true")
 		case "replaced_by":
 			out.ReplacedBy = value
-		case "author", "entrypoints", "dependencies", "verification", "includes", "requires", "install":
+		case "author", "entrypoints", "dependencies", "verification", "includes", "requires", "install", "operational":
 			inNestedMap = true
 			nestedMapKey = key
 		}

--- a/internal/registry/manifest_parser_test.go
+++ b/internal/registry/manifest_parser_test.go
@@ -57,6 +57,179 @@ deprecated: false
 	}
 }
 
+func TestParseToolManifestOperationalMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tool.yaml")
+	content := `id: analytics/example-tool
+name: Example Tool
+description: Example tool manifest for operational metadata parsing.
+version: 0.1.0
+released_at: "2026-03-30T00:00:00Z"
+category: tools-mcp/analytics
+tags:
+  - analytics
+license: MIT
+author:
+  name: Example
+runtimes:
+  - codex
+dependencies:
+  mcp_servers:
+    - ga4
+operational:
+  connected_system: Google Analytics 4
+  capabilities:
+    - Pull sessions by dimension.
+    - Return normalized rows for dashboard input.
+  auth_required:
+    - GA4 property access via authenticated MCP runtime
+  access_level: read-only
+  trust_boundary: remote-mcp-server
+  approval_boundary: Safe for read-only analytics retrieval only.
+verification:
+  security_reviewed: false
+deprecated: false
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	m, err := ParseManifest(path)
+	if err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	if m.Operational.ConnectedSystem != "Google Analytics 4" {
+		t.Fatalf("unexpected connected system: %s", m.Operational.ConnectedSystem)
+	}
+	if len(m.Operational.Capabilities) != 2 {
+		t.Fatalf("unexpected capabilities: %#v", m.Operational.Capabilities)
+	}
+	if len(m.Operational.AuthRequired) != 1 {
+		t.Fatalf("unexpected auth requirements: %#v", m.Operational.AuthRequired)
+	}
+	if m.Operational.AccessLevel != "read-only" {
+		t.Fatalf("unexpected access level: %s", m.Operational.AccessLevel)
+	}
+	if m.Operational.TrustBoundary != "remote-mcp-server" {
+		t.Fatalf("unexpected trust boundary: %s", m.Operational.TrustBoundary)
+	}
+	if len(m.Dependencies.MCPServers) != 1 || m.Dependencies.MCPServers[0] != "ga4" {
+		t.Fatalf("unexpected dependencies: %#v", m.Dependencies)
+	}
+}
+
+func TestParseAgentManifestOperationalMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	content := `id: marketing/example-agent
+name: Example Agent
+description: Example agent manifest for operational metadata parsing.
+version: 0.1.0
+released_at: "2026-03-30T00:00:00Z"
+category: marketing-agents/performance
+tags:
+  - reporting
+license: MIT
+author:
+  name: Example
+runtimes:
+  - codex
+dependencies:
+  skills:
+    - adtech/dashboard-generator
+  tools:
+    - ga4_query
+operational:
+  role: Weekly reporting supervisor.
+  coordinates:
+    - Dashboard generation
+    - QA gating
+  autonomy_level: semi-autonomous
+  approval_boundary: Require approval before external distribution.
+  outputs:
+    - Publish decision
+    - Executive narrative
+verification:
+  security_reviewed: false
+deprecated: false
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	m, err := ParseManifest(path)
+	if err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	if m.Operational.Role != "Weekly reporting supervisor." {
+		t.Fatalf("unexpected role: %s", m.Operational.Role)
+	}
+	if m.Operational.AutonomyLevel != "semi-autonomous" {
+		t.Fatalf("unexpected autonomy level: %s", m.Operational.AutonomyLevel)
+	}
+	if len(m.Operational.Coordinates) != 2 {
+		t.Fatalf("unexpected coordinates: %#v", m.Operational.Coordinates)
+	}
+	if len(m.Operational.Outputs) != 2 {
+		t.Fatalf("unexpected outputs: %#v", m.Operational.Outputs)
+	}
+	if len(m.Dependencies.Skills) != 1 || m.Dependencies.Skills[0] != "adtech/dashboard-generator" {
+		t.Fatalf("unexpected skill dependencies: %#v", m.Dependencies)
+	}
+}
+
+func TestParseSkillManifestOperationalMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "skill.yaml")
+	content := `id: engineering/example-skill
+name: Example Skill
+description: Example skill manifest for operational metadata parsing.
+version: 0.1.0
+released_at: "2026-03-30T00:00:00Z"
+category: engineering/code-maintenance
+tags:
+  - planning
+license: MIT
+author:
+  name: Example
+runtimes:
+  - codex
+dependencies:
+  tools:
+    - rg
+operational:
+  use_when: Use when repo scope analysis is needed before edits.
+  execution_mode: read-only-local-inspection
+  outputs:
+    - Change strategy
+    - Verification command list
+  approval_boundary: Safe for inspection and planning before edits.
+verification:
+  security_reviewed: false
+deprecated: false
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	m, err := ParseManifest(path)
+	if err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	if m.Operational.UseWhen != "Use when repo scope analysis is needed before edits." {
+		t.Fatalf("unexpected use_when: %s", m.Operational.UseWhen)
+	}
+	if m.Operational.ExecutionMode != "read-only-local-inspection" {
+		t.Fatalf("unexpected execution mode: %s", m.Operational.ExecutionMode)
+	}
+	if len(m.Operational.Outputs) != 2 {
+		t.Fatalf("unexpected outputs: %#v", m.Operational.Outputs)
+	}
+	if len(m.Dependencies.Tools) != 1 || m.Dependencies.Tools[0] != "rg" {
+		t.Fatalf("unexpected tool dependencies: %#v", m.Dependencies)
+	}
+}
+
 func TestParsePluginManifestIncludesAndRequires(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "plugin.yaml")

--- a/internal/registry/types.go
+++ b/internal/registry/types.go
@@ -12,8 +12,32 @@ type Manifest struct {
 	SecurityReviewed bool
 	Deprecated       bool
 	ReplacedBy       string
+	Operational      OperationalMetadata
+	Dependencies     DependencySet
 	Includes         IncludeSet
 	Requires         RequirementSet
+}
+
+type OperationalMetadata struct {
+	ConnectedSystem  string   `json:"connected_system,omitempty"`
+	Capabilities     []string `json:"capabilities,omitempty"`
+	AuthRequired     []string `json:"auth_required,omitempty"`
+	AccessLevel      string   `json:"access_level,omitempty"`
+	TrustBoundary    string   `json:"trust_boundary,omitempty"`
+	ApprovalBoundary string   `json:"approval_boundary,omitempty"`
+	Role             string   `json:"role,omitempty"`
+	Coordinates      []string `json:"coordinates,omitempty"`
+	AutonomyLevel    string   `json:"autonomy_level,omitempty"`
+	Outputs          []string `json:"outputs,omitempty"`
+	UseWhen          string   `json:"use_when,omitempty"`
+	ExecutionMode    string   `json:"execution_mode,omitempty"`
+}
+
+type DependencySet struct {
+	Skills     []string `json:"skills,omitempty"`
+	Tools      []string `json:"tools,omitempty"`
+	APIs       []string `json:"apis,omitempty"`
+	MCPServers []string `json:"mcp_servers,omitempty"`
 }
 
 type IncludeSet struct {
@@ -35,20 +59,22 @@ type Index struct {
 }
 
 type SkillEntry struct {
-	ID               string          `json:"id"`
-	Name             string          `json:"name"`
-	Description      string          `json:"description"`
-	Category         string          `json:"category"`
-	Latest           string          `json:"latest"`
-	Versions         []VersionEntry  `json:"versions"`
-	Runtimes         []string        `json:"runtimes"`
-	Tags             []string        `json:"tags"`
-	Readiness        string          `json:"readiness"`
-	SecurityReviewed bool            `json:"security_reviewed"`
-	Deprecated       bool            `json:"deprecated"`
-	ReplacedBy       string          `json:"replaced_by,omitempty"`
-	Includes         *IncludeSet     `json:"includes,omitempty"`
-	Requires         *RequirementSet `json:"requires,omitempty"`
+	ID               string               `json:"id"`
+	Name             string               `json:"name"`
+	Description      string               `json:"description"`
+	Category         string               `json:"category"`
+	Latest           string               `json:"latest"`
+	Versions         []VersionEntry       `json:"versions"`
+	Runtimes         []string             `json:"runtimes"`
+	Tags             []string             `json:"tags"`
+	Readiness        string               `json:"readiness"`
+	SecurityReviewed bool                 `json:"security_reviewed"`
+	Deprecated       bool                 `json:"deprecated"`
+	ReplacedBy       string               `json:"replaced_by,omitempty"`
+	Operational      *OperationalMetadata `json:"operational,omitempty"`
+	Dependencies     *DependencySet       `json:"dependencies,omitempty"`
+	Includes         *IncludeSet          `json:"includes,omitempty"`
+	Requires         *RequirementSet      `json:"requires,omitempty"`
 }
 
 type VersionEntry struct {

--- a/registry/agents-index.json
+++ b/registry/agents-index.json
@@ -14,7 +14,7 @@
           "released_at": "2026-03-02T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/agents/adtech/bi-insights-orchestrator/agent.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/bi-insights-orchestrator/0.1.0.tar.gz",
-          "sha256": "87084e1dfb9321ffae095eaf851a3b13415c8320323fb6772a655d13099eadca"
+          "sha256": "d5be1ccaca95295c2e516aad05b7b3a40531ba298cde3c49c9410ae8db556517"
         }
       ],
       "runtimes": [
@@ -29,7 +29,34 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May coordinate read-only data analysis and draft reporting outputs; require human approval before any publish or stakeholder-distribution decision.",
+        "role": "Analytics orchestration agent for warehouse-backed BI reporting.",
+        "coordinates": [
+          "Warehouse and platform metric collection",
+          "KPI normalization across sources",
+          "Dashboard and insight generation"
+        ],
+        "autonomy_level": "semi-autonomous",
+        "outputs": [
+          "Normalized KPI table",
+          "Anomaly summary with evidence",
+          "Publish recommendation",
+          "Risks and data limitations"
+        ]
+      },
+      "dependencies": {
+        "skills": [
+          "adtech/analyst-copilot-bigquery-redshift",
+          "adtech/dashboard-generator",
+          "adtech/dashboard-qa-checker"
+        ],
+        "tools": [
+          "bigquery_sql",
+          "ga4_query"
+        ]
+      }
     },
     {
       "id": "marketing/campaign-qa-supervisor",
@@ -43,7 +70,7 @@
           "released_at": "2026-03-02T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/agents/marketing/campaign-qa-supervisor/agent.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/campaign-qa-supervisor/0.1.0.tar.gz",
-          "sha256": "322d35a70c0913c992bd065d2791758616dea462d847b73598ef6639ce327e66"
+          "sha256": "30b75a2f94f47727bfa59cb80965555edad853f9e28c55147a7268616bb9c32e"
         }
       ],
       "runtimes": [
@@ -58,7 +85,32 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May assess launch readiness and draft remediation alerts; require human approval before overriding critical failures or taking live launch actions.",
+        "role": "Governance agent for campaign QA, tracking integrity, and launch readiness.",
+        "coordinates": [
+          "Campaign payload validation",
+          "Policy and naming checks",
+          "Severity assessment and remediation routing"
+        ],
+        "autonomy_level": "execution-capable-with-approval",
+        "outputs": [
+          "Pass, warn, or fail decision",
+          "Critical blocker list",
+          "Remediation action list",
+          "Alert summary for escalation"
+        ]
+      },
+      "dependencies": {
+        "skills": [
+          "adtech/policy-brand-compliance-checker"
+        ],
+        "tools": [
+          "campaign_config_reader",
+          "slack_post"
+        ]
+      }
     },
     {
       "id": "marketing/weekly-performance-supervisor",
@@ -72,7 +124,7 @@
           "released_at": "2026-03-02T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/agents/marketing/weekly-performance-supervisor/agent.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/weekly-performance-supervisor/0.1.0.tar.gz",
-          "sha256": "40dad67f9624f7c238542a22943b8ee391e3df9f2c9a876102bfc63f4c5f8da5"
+          "sha256": "7c1381b204cc9fe23d9e5c75e2304d91833bb1c571f7727cec7eb2ac7906542c"
         }
       ],
       "runtimes": [
@@ -87,7 +139,34 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May coordinate reporting workflows and draft narratives after QA approval; require human approval before any external publish or stakeholder send.",
+        "role": "Weekly reporting supervisor for QA-gated performance review workflows.",
+        "coordinates": [
+          "Dashboard generation",
+          "QA gating and blocking decisions",
+          "Executive narrative drafting after approval"
+        ],
+        "autonomy_level": "semi-autonomous",
+        "outputs": [
+          "Publish decision",
+          "Dashboard package",
+          "QA package",
+          "Executive narrative"
+        ]
+      },
+      "dependencies": {
+        "skills": [
+          "adtech/dashboard-generator",
+          "adtech/dashboard-qa-checker",
+          "adtech/executive-narrative-writer"
+        ],
+        "tools": [
+          "ga4_query",
+          "warehouse_query"
+        ]
+      }
     }
   ]
 }

--- a/registry/index.json
+++ b/registry/index.json
@@ -14,7 +14,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/analyst-copilot-bigquery-redshift/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/analyst-copilot-bigquery-redshift/0.1.0.tar.gz",
-          "sha256": "8ba663e9403a1c5e18a8b95500f4080dff3e480447cb8ae3814b19f55b652687"
+          "sha256": "b6dae5254cd078ab30415f00de3c12c920becf640f76196fa7f6c6cdb866afde"
         }
       ],
       "runtimes": [
@@ -30,7 +30,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for read-only analysis and SQL drafting; require human approval before executing queries against production warehouses.",
+        "outputs": [
+          "SQL draft",
+          "Metric logic notes",
+          "Stakeholder summary"
+        ],
+        "use_when": "Use when an analyst question needs safe SQL drafting, metric validation, and stakeholder-ready findings across BigQuery or Redshift.",
+        "execution_mode": "read-only-local-inspection"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "adtech/brand-rag-memory-bootstrap",
@@ -44,7 +59,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/brand-rag-memory-bootstrap/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/brand-rag-memory-bootstrap/0.1.0.tar.gz",
-          "sha256": "64c1551dfb816cbb4eacd7f5bae1a45dd322dcf0a9bdcd771ecc9ecbed44188d"
+          "sha256": "4004d705d2ff3099cac2a367806a933e31b6a6aefe8640526dd6ccca955c193d"
         }
       ],
       "runtimes": [
@@ -61,7 +76,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for planning and document classification; require human approval before indexing sensitive or unapproved source material.",
+        "outputs": [
+          "Source inventory",
+          "Metadata schema",
+          "Refresh plan"
+        ],
+        "use_when": "Use when you need to structure approved brand, campaign, and policy documents into a retrieval-ready memory layer.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "adtech/dashboard-generator",
@@ -75,7 +105,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/dashboard-generator/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/dashboard-generator/0.1.0.tar.gz",
-          "sha256": "e0b5283ce8bb3d2d5c5d149dc164d9095e8535c8c52840fc0c8d73311c4aa665"
+          "sha256": "8a7f83d626d0fd42583db59076a313c68e290ea1067776d3af3988abf7fa5b27"
         }
       ],
       "runtimes": [
@@ -91,7 +121,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for report generation from validated inputs; require human approval before publishing external dashboard outputs.",
+        "outputs": [
+          "Dashboard package",
+          "KPI table",
+          "Action panel"
+        ],
+        "use_when": "Use when normalized performance tables need to be turned into deterministic weekly dashboard sections.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "adtech/dashboard-qa-checker",
@@ -105,7 +150,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/dashboard-qa-checker/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/dashboard-qa-checker/0.1.0.tar.gz",
-          "sha256": "6503483b9c90ceb17a964954f9cbd35c4103915512e4f415cdb553975f6e14e5"
+          "sha256": "83fb0b6eba1f6a909147d32ac7db3bdaf4e22875c2d1314f34a970b169a02f2a"
         }
       ],
       "runtimes": [
@@ -121,7 +166,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for read-only QA evaluation; require human approval before overriding critical failures.",
+        "outputs": [
+          "QA result",
+          "Blocking reasons",
+          "Alert payload"
+        ],
+        "use_when": "Use when a dashboard or BI package needs freshness, completeness, reconciliation, and anomaly checks before publish.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "adtech/executive-narrative-writer",
@@ -135,7 +195,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/executive-narrative-writer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/executive-narrative-writer/0.1.0.tar.gz",
-          "sha256": "9645db97cf9337f29ee41217d03e887e41abd763739340930014c41f58403bc6"
+          "sha256": "cebf9b90a68f2e96261ca7d2d4eb40dc0044484f6a8e2d63182ce5d8e02132b1"
         }
       ],
       "runtimes": [
@@ -151,7 +211,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for drafting narrative from approved inputs; require human approval before stakeholder distribution.",
+        "outputs": [
+          "Executive summary",
+          "Risk notes",
+          "Action recommendations"
+        ],
+        "use_when": "Use when QA-approved BI outputs need to be converted into concise executive narrative and action framing.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "adtech/playwright-agentic-e2e",
@@ -165,7 +240,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/playwright-agentic-e2e/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/playwright-agentic-e2e/0.1.0.tar.gz",
-          "sha256": "fe21689cd37baa5e7a0d3adf9809f6d0d40004e525d553893d6357b19b942252"
+          "sha256": "ac7a119e98ba6e42005d74c3a2080242113beb737e9cf7ce0afa6e3bb8b37c70"
         }
       ],
       "runtimes": [
@@ -182,7 +257,24 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May run local test commands and propose fixes; require human approval before deleting tests or broadening coverage scope.",
+        "outputs": [
+          "Playwright spec",
+          "Run summary",
+          "Healing suggestions"
+        ],
+        "use_when": "Use when a web app needs Playwright smoke coverage, failure diagnosis, and minimal healing suggestions.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "node",
+          "pnpm",
+          "npx"
+        ]
+      }
     },
     {
       "id": "adtech/playwright-vscode-loop-codex",
@@ -196,7 +288,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/playwright-vscode-loop-codex/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/playwright-vscode-loop-codex/0.1.0.tar.gz",
-          "sha256": "8659f15552be13c06cee94710e4bbe3b62031cdd37ad207ab1eb8825f007c617"
+          "sha256": "3109b45ce75ed42ace064148db29e9c4cd1ff711a223268f598512829414c40b"
         }
       ],
       "runtimes": [
@@ -213,7 +305,24 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May run local QA workflows and propose test updates; require human approval before accepting broad healing changes.",
+        "outputs": [
+          "Test plan",
+          "Generated spec",
+          "Healing notes"
+        ],
+        "use_when": "Use when Codex is orchestrating a VS Code-compatible Playwright planner, generator, and healer loop.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "node",
+          "npx",
+          "playwright"
+        ]
+      }
     },
     {
       "id": "adtech/policy-brand-compliance-checker",
@@ -227,7 +336,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/policy-brand-compliance-checker/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/policy-brand-compliance-checker/0.1.0.tar.gz",
-          "sha256": "0298e115ffc9c6a1d1fefb1dd91c946d12fe6d7b54023fc96dddce56be767b48"
+          "sha256": "9d084f5643ff4bd200caeacb597fb43bc299a77747bb6a54c01232e2bc9ed7c1"
         }
       ],
       "runtimes": [
@@ -243,7 +352,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for analysis and recommendation; require human approval before changing live assets or overriding blocked findings.",
+        "outputs": [
+          "Findings table",
+          "Severity ranking",
+          "Launch recommendation"
+        ],
+        "use_when": "Use when ad copy, URLs, or tracking conventions need policy and brand validation before launch.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "adtech/weekly-performance-review-bi",
@@ -257,7 +381,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/weekly-performance-review-bi/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/weekly-performance-review-bi/0.1.0.tar.gz",
-          "sha256": "836587a6370e8284cccd4b3633aacf12c948367863bef840019314ef485f82e8"
+          "sha256": "6b4fb369f7dae082276eb6aae757c1368eb4a88bac6c250490f8c37110ef0378"
         }
       ],
       "runtimes": [
@@ -274,7 +398,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for orchestrating read-only reporting steps; require human approval before external publication.",
+        "outputs": [
+          "Publish decision",
+          "QA package",
+          "Narrative package"
+        ],
+        "use_when": "Use when weekly BI reporting needs deterministic orchestration across dashboard generation, QA, and narrative drafting.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "agentops/harness-regression-evaluator",
@@ -288,7 +427,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/agentops/harness-regression-evaluator/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/agentops/harness-regression-evaluator/0.1.0.tar.gz",
-          "sha256": "f0a99c9757b65498bec9defa96cbf752c17e6980311efc97dd15d5dc7622a49a"
+          "sha256": "564251d06db3f5f5b3f611e4b94d57ff05e6e965d0f230d1bcc9726129f7b6d4"
         }
       ],
       "runtimes": [
@@ -304,7 +443,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for harness evaluation; require human approval before applying accepted harness changes.",
+        "outputs": [
+          "Evaluation summary",
+          "Regression findings",
+          "Adopt or reject recommendation"
+        ],
+        "use_when": "Use when proposed harness changes need benchmark and red-team evaluation before adoption.",
+        "execution_mode": "may-run-local-verification"
+      }
     },
     {
       "id": "agentops/harness-run-reflection",
@@ -318,7 +467,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/agentops/harness-run-reflection/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/agentops/harness-run-reflection/0.1.0.tar.gz",
-          "sha256": "b52a1a85d25afd7605b371827786175449d0a84c5c23a218d6d8954ce44671c1"
+          "sha256": "943057c634d65a4c2636f33e896d678f1825879543843878099a840639b179ef"
         }
       ],
       "runtimes": [
@@ -334,7 +483,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for harness analysis; must not widen scope into production code changes on its own.",
+        "outputs": [
+          "Reflection report",
+          "Failure patterns",
+          "Improvement candidates"
+        ],
+        "use_when": "Use when recent agent run logs need review for repeated misses, skipped skills, and inefficient loops.",
+        "execution_mode": "analysis-only"
+      }
     },
     {
       "id": "agentops/harness-skill-proposal",
@@ -348,7 +507,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/agentops/harness-skill-proposal/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/agentops/harness-skill-proposal/0.1.0.tar.gz",
-          "sha256": "dcf1a8d53d2ab5442b1c53e9926bf5f37a4a03403e3a8dc1c1c10f81bf1c5647"
+          "sha256": "c4fc626488ff0e8d477fa486451109c446f803bafc11e95031d52b912e620587"
         }
       ],
       "runtimes": [
@@ -364,7 +523,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for proposal drafting inside harness-owned assets; require human approval before any change outside harness scope.",
+        "outputs": [
+          "Proposed skill changes",
+          "Boundary notes",
+          "Rationale summary"
+        ],
+        "use_when": "Use when repeated harness failures justify drafting new or revised harness skills and policy text.",
+        "execution_mode": "analysis-only"
+      }
     },
     {
       "id": "engineering/code-change-verification",
@@ -378,7 +547,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/engineering/code-change-verification/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/engineering/code-change-verification/0.1.0.tar.gz",
-          "sha256": "da7d0b562984a1665e16698341e352a5f6b0a9e7d2ad0461d222b9ada7b49183"
+          "sha256": "22f665578aab9a2b0a1bdb0c251a8bf2b3aba0d4e1543941ebcf47163528befd"
         }
       ],
       "runtimes": [
@@ -394,7 +563,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May run local verification commands; require human approval before retrying destructive setup or environment-changing commands.",
+        "outputs": [
+          "Verification report",
+          "Failed command summary",
+          "Residual risk note"
+        ],
+        "use_when": "Use when a code change needs stack-aware lint, typecheck, build, and test verification based on touched files.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "bash"
+        ]
+      }
     },
     {
       "id": "engineering/coverage-gap-reporter",
@@ -408,7 +592,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/engineering/coverage-gap-reporter/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/engineering/coverage-gap-reporter/0.1.0.tar.gz",
-          "sha256": "8e6fc7d2016f030dfd834a4d2bac090275eeb9dc851f085540a2d5ed1f3b28d2"
+          "sha256": "48024d23ebcf530d80a34ff330b45e0143be4956e0d73a4dbc1fe8aa737b086d"
         }
       ],
       "runtimes": [
@@ -424,7 +608,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for coverage analysis and recommendation; require human approval before modifying CI coverage gates.",
+        "outputs": [
+          "Coverage gap report",
+          "Risk-ranked files",
+          "Suggested tests"
+        ],
+        "use_when": "Use when coverage artifacts need to be mapped to changed files and uncovered regression risk.",
+        "execution_mode": "analysis-only"
+      }
     },
     {
       "id": "engineering/implementation-strategy",
@@ -438,7 +632,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/engineering/implementation-strategy/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/engineering/implementation-strategy/0.1.0.tar.gz",
-          "sha256": "48aece1a138bfc6c274ae5bc219ff2d7087a4ae16af3b867c93837e5db1852af"
+          "sha256": "1e5403e7862a995a518ee44d6e30b5d0c2ce154e7e7ade99834fe60a1000f500"
         }
       ],
       "runtimes": [
@@ -454,7 +648,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for repo inspection and planning; does not require write access and should precede code edits.",
+        "outputs": [
+          "Change strategy",
+          "Impacted files",
+          "Verification command list"
+        ],
+        "use_when": "Use when a repository needs scope analysis, impact mapping, and change planning before edits begin.",
+        "execution_mode": "read-only-local-inspection"
+      },
+      "dependencies": {
+        "tools": [
+          "rg"
+        ]
+      }
     },
     {
       "id": "engineering/pr-review-and-draft",
@@ -468,7 +677,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/engineering/pr-review-and-draft/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/engineering/pr-review-and-draft/0.1.0.tar.gz",
-          "sha256": "294e9e9a28c80e8178d04e4d546d4535c298fba186807278dc47c456a8b12e14"
+          "sha256": "cd62e89ef3a9319f10297ee8bd7ad2bc097ed6c8d8b49a58eb3a6d961df5ae27"
         }
       ],
       "runtimes": [
@@ -484,7 +693,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for review and drafting; require human approval before applying code changes based on review findings.",
+        "outputs": [
+          "Review findings",
+          "Risk summary",
+          "PR draft"
+        ],
+        "use_when": "Use when code changes need correctness, performance, security, and test review plus a structured PR draft.",
+        "execution_mode": "read-only-local-inspection"
+      }
     },
     {
       "id": "engineering/test-gap-analyzer",
@@ -498,7 +717,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/engineering/test-gap-analyzer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/engineering/test-gap-analyzer/0.1.0.tar.gz",
-          "sha256": "5fecdb83f38d57bd8a79bc9a3be77a569d17e5b0501444d48a1cbd0dbca4b1aa"
+          "sha256": "69aea5860b143dd7636c8669022bd55ac7639bbdc6f557139b3ba9c48f4dba33"
         }
       ],
       "runtimes": [
@@ -514,7 +733,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for inspection and recommendation; require human approval before broadening test scope or changing suites.",
+        "outputs": [
+          "Missing test scenarios",
+          "Risk ranking",
+          "Suggested next tests"
+        ],
+        "use_when": "Use when changed code needs missing unit, integration, regression, and edge-case scenarios identified.",
+        "execution_mode": "read-only-local-inspection"
+      }
     },
     {
       "id": "marketing/ab-test-planner-analyzer",
@@ -528,7 +757,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ab-test-planner-analyzer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ab-test-planner-analyzer/0.1.0.tar.gz",
-          "sha256": "51d6bdeb5261331cdcb7b23da8c8a7c926cec32796747670b53863b044ff8623"
+          "sha256": "085db550c13d2719092a7f5d939e28d1a184bd353c2b2f75f567156a61d7cd3b"
         }
       ],
       "runtimes": [
@@ -545,7 +774,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for planning and analysis; require human approval before launching experiments or changing traffic allocation.",
+        "outputs": [
+          "Experiment plan",
+          "Decision framework",
+          "Analysis summary"
+        ],
+        "use_when": "Use when an A/B test needs explicit hypotheses, sample-size assumptions, and decision rules.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/ai-output-eval-scorecard",
@@ -559,7 +803,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ai-output-eval-scorecard/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ai-output-eval-scorecard/0.1.0.tar.gz",
-          "sha256": "fd567640fedf2e053392ff2bf85f708595019cb5550d162bee73d340502be507"
+          "sha256": "2ede4bad097be375886cbbf1a15a44403f63aa425e52ecd0a02c3880c6a9a2c9"
         }
       ],
       "runtimes": [
@@ -576,7 +820,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for evaluation and recommendation; require human approval before approving externally visible copy.",
+        "outputs": [
+          "Scorecard",
+          "Verdict",
+          "Rewrite recommendations"
+        ],
+        "use_when": "Use when AI-generated marketing outputs need repeatable scoring across quality, compliance, and actionability.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/creative-workshop-pmax-reels",
@@ -590,7 +849,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/creative-workshop-pmax-reels/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creative-workshop-pmax-reels/0.1.0.tar.gz",
-          "sha256": "dbdcac3bb53a412349f5e83f1d6e7a0144dbc8099863facabf509a26177bfda8"
+          "sha256": "527becb3b9f86eafd6641e27441336e3cc498a297d41e167747de4cdcedb93c3"
         }
       ],
       "runtimes": [
@@ -606,7 +865,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for draft creative generation; require human approval before publishing or trafficking assets.",
+        "outputs": [
+          "Creative variants",
+          "Angle summary",
+          "Compliance notes"
+        ],
+        "use_when": "Use when you need platform-ready creative variants for Google PMax and Meta Reels with bounded formatting checks.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/cross-channel-budget-pacing-agent",
@@ -620,7 +894,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/cross-channel-budget-pacing-agent/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/cross-channel-budget-pacing-agent/0.1.0.tar.gz",
-          "sha256": "5dea3e1335e309c891e2ea28bfb98c975c47d4812a544f5980608c2bc0f6fd34"
+          "sha256": "638f68e3024a2c7404cf05fdcd6f5b10fc2a0a36567c1c8b8ea998c600617e27"
         }
       ],
       "runtimes": [
@@ -637,7 +911,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for analysis and recommendation; require human approval before changing live budgets.",
+        "outputs": [
+          "Pacing summary",
+          "Anomaly list",
+          "Reallocation plan"
+        ],
+        "use_when": "Use when pacing and efficiency signals across channels need bounded reallocation recommendations.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/dynamic-creative-rules-engine",
@@ -651,7 +940,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/dynamic-creative-rules-engine/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/dynamic-creative-rules-engine/0.1.0.tar.gz",
-          "sha256": "578d6115038f6bbdd3d230ed4f1ffad8941f3556b60747cbac9ccc15e3a3eed0"
+          "sha256": "74c348cd7bc68f525acb112a33ad784e1ea1ba047cd4a39f9444bcf6f1899e2f"
         }
       ],
       "runtimes": [
@@ -668,7 +957,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for rule design and evaluation; require human approval before deploying personalization logic.",
+        "outputs": [
+          "Ruleset",
+          "Blocked combinations",
+          "Test matrix"
+        ],
+        "use_when": "Use when audience-aware creative assembly rules need to be defined under brand and policy constraints.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/lifecycle-experiment-planner",
@@ -682,7 +986,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/lifecycle-experiment-planner/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/lifecycle-experiment-planner/0.1.0.tar.gz",
-          "sha256": "5ff0c3ab6205443cf3ca12b402581ae32d3d1d45aabceb8f047eb383dcdcfd73"
+          "sha256": "4ea9b15b727772214ebf952fdf4532388b8c49e4494f84c04504bbcd62a4c73d"
         }
       ],
       "runtimes": [
@@ -698,7 +1002,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for planning; require human approval before launching lifecycle experiments or changing user journeys.",
+        "outputs": [
+          "Hypothesis plan",
+          "Sample-size guidance",
+          "Stop criteria"
+        ],
+        "use_when": "Use when a lifecycle experiment needs statistical assumptions, stop rules, and guardrail metrics defined clearly.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/lifecycle-journey-trigger-designer",
@@ -712,7 +1031,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/lifecycle-journey-trigger-designer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/lifecycle-journey-trigger-designer/0.1.0.tar.gz",
-          "sha256": "04de39a058fae73fe1ec4c44a05901d6d08054446b1428808d29c1271bb21f0c"
+          "sha256": "67da9be48bc1901c1b0f8e10f9f4d5d782216277fde770a1c6e2b3642751cbd7"
         }
       ],
       "runtimes": [
@@ -729,7 +1048,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for planning and design; require human approval before activating live messaging journeys.",
+        "outputs": [
+          "Journey blueprint",
+          "Trigger rules",
+          "Measurement plan"
+        ],
+        "use_when": "Use when lifecycle entry, progression, and suppression rules need to be designed with measurement plans.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/meta-google-weekly-performance-review",
@@ -743,7 +1077,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/meta-google-weekly-performance-review/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/meta-google-weekly-performance-review/0.1.0.tar.gz",
-          "sha256": "ffb2174126c35ce575ce2dbfa90f42425fba849e9cac2dea816114ce14fa680d"
+          "sha256": "9b274e77aaf6b68c40bc37541109f5093128fa38bba9923b3f57e508e7b6a6a5"
         }
       ],
       "runtimes": [
@@ -759,7 +1093,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for read-only analysis and reporting; require human approval before using outputs to make live media changes.",
+        "outputs": [
+          "KPI summary",
+          "Insight list",
+          "Recommended actions"
+        ],
+        "use_when": "Use when weekly performance across Meta and Google Ads needs KPI comparison and prioritized actions.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/seo-paid-search-synergy",
@@ -773,7 +1122,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/seo-paid-search-synergy/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/seo-paid-search-synergy/0.1.0.tar.gz",
-          "sha256": "ce3f88909c5ffbd907efd28e1f5f18cc76d9a35827435131e7e5276f70183327"
+          "sha256": "2447b75b96b39bf3a71c36626d9321e8e0f220b31ddbf413df55155951dbbcc4"
         }
       ],
       "runtimes": [
@@ -789,7 +1138,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for planning and opportunity analysis; require human approval before launching paid search changes.",
+        "outputs": [
+          "Keyword clusters",
+          "Ad group recommendations",
+          "Experiment plan"
+        ],
+        "use_when": "Use when SEO winners need to be translated into paid search opportunities and test-ready keyword structures.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "security/dependency-supply-chain-audit",
@@ -803,7 +1167,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/security/dependency-supply-chain-audit/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/security/dependency-supply-chain-audit/0.1.0.tar.gz",
-          "sha256": "909f4fd9f6dabcbdc8fa8aa3e23e941e96aca6e88220ba64508ef12cffd8e103"
+          "sha256": "4d7d1c41be650480a044e806fb8ab4984a54298e76cf6245f55745bba51ae962"
         }
       ],
       "runtimes": [
@@ -819,7 +1183,23 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May run local scanners and review package risk; require human approval before removing dependencies or changing production lockfiles.",
+        "outputs": [
+          "Dependency findings",
+          "Risk ranking",
+          "Mitigation recommendations"
+        ],
+        "use_when": "Use when manifests and lockfiles need vulnerability, provenance, and package risk review before trust is granted.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "trivy",
+          "osv-scanner"
+        ]
+      }
     },
     {
       "id": "security/environment-risk-assessment",
@@ -833,7 +1213,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/security/environment-risk-assessment/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/security/environment-risk-assessment/0.1.0.tar.gz",
-          "sha256": "38db7c5067156df723fa95b60117d99b3fbc4704b1a4f14a6c390d57d3ae2ebb"
+          "sha256": "4199db513316791a71e37d87e95447ef5d334f20e3f1dabc320612b916a6d36f"
         }
       ],
       "runtimes": [
@@ -849,7 +1229,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for inspection and recommendation; require human approval before changing runtime isolation or credential policies.",
+        "outputs": [
+          "Environment risk review",
+          "Escalation reasons",
+          "Isolation recommendations"
+        ],
+        "use_when": "Use when you need to assess whether the current runtime is safe for autonomous agent execution.",
+        "execution_mode": "read-only-local-inspection"
+      }
     },
     {
       "id": "security/handle-untrusted-content",
@@ -863,7 +1253,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/security/handle-untrusted-content/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/security/handle-untrusted-content/0.1.0.tar.gz",
-          "sha256": "001abfeef3257cf76ef684c619d7ccb583e77b0ab4fcf421fc9ac841d1843b66"
+          "sha256": "eabef3c1bff3ab9df17f03e8c32e324d60fec96ae667583134d9d41df368d6d4"
         }
       ],
       "runtimes": [
@@ -879,7 +1269,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for analysis and escalation only; must not trigger shell, network, or write actions on its own.",
+        "outputs": [
+          "Risk triage",
+          "Quarantined instructions",
+          "Escalation recommendation"
+        ],
+        "use_when": "Use when logs, tickets, webpages, or MCP outputs may contain prompt injection or unsafe instructions.",
+        "execution_mode": "analysis-only"
+      }
     },
     {
       "id": "security/secrets-and-credential-hygiene",
@@ -893,7 +1293,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/security/secrets-and-credential-hygiene/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/security/secrets-and-credential-hygiene/0.1.0.tar.gz",
-          "sha256": "b2abe6263ae52829044221380b6562665ad453a0db916019674588ff18872995"
+          "sha256": "7ed458691a13d3c69a68ebf16e15687235db192d1cfae1d33c206d7d8771f790"
         }
       ],
       "runtimes": [
@@ -909,7 +1309,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May run local secret scanners and redact findings; require human approval before revocation or rotation actions.",
+        "outputs": [
+          "Secret findings",
+          "Severity matrix",
+          "Remediation steps"
+        ],
+        "use_when": "Use when diffs or repository context need secret scanning and credential exposure review.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "gitleaks"
+        ]
+      }
     }
   ]
 }

--- a/registry/plugins-index.json
+++ b/registry/plugins-index.json
@@ -14,7 +14,7 @@
           "released_at": "2026-03-29T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/ad-creative-plugin/plugin.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ad-creative-plugin/0.1.0.tar.gz",
-          "sha256": "f2498bf8a018b038d78175a096d4b9bfbf7c2591817e2cce0842ac3f5f83d11b"
+          "sha256": "2e0ac40d1b124f095b7197b471f9e10e1ef27d412456ce639f49c43cbb767a5a"
         }
       ],
       "runtimes": [
@@ -66,7 +66,7 @@
           "released_at": "2026-03-28T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/campaign-audit-plugin/plugin.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/campaign-audit-plugin/0.1.0.tar.gz",
-          "sha256": "3e3c99ccd02a9ec054a0b2f565ef049a54ba40e0cf2b6545a1c20f093344147f"
+          "sha256": "e9142087f217444e7fcd1037d54bc690d99e1ae2702867b1fa36282d20172d8c"
         }
       ],
       "runtimes": [
@@ -121,7 +121,7 @@
           "released_at": "2026-03-29T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/competitive-intelligence-plugin/plugin.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/competitive-intelligence-plugin/0.1.0.tar.gz",
-          "sha256": "31e12e863d8c988e3cf36bc98895fbe248e08058d47cb018ba4ba105745ff893"
+          "sha256": "a09c2a682364ceec1a89b33ff31a7cff9b0ee1a68e6228cc340ba007136897a9"
         }
       ],
       "runtimes": [
@@ -166,7 +166,7 @@
           "released_at": "2026-03-28T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/content-repurposing-plugin/plugin.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/content-repurposing-plugin/0.1.0.tar.gz",
-          "sha256": "ed0ed17b6bb3abe25cbf01c1003553fb041d989fb21360aa05cb79bba6f8799c"
+          "sha256": "04ab2636ccf8bdd3bfc5972773bad09dd4b4c5e007291eb3d582300cfc9652c6"
         }
       ],
       "runtimes": [
@@ -211,7 +211,7 @@
           "released_at": "2026-03-29T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/page-speed-technical-seo-plugin/plugin.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/page-speed-technical-seo-plugin/0.1.0.tar.gz",
-          "sha256": "248cf0b00e3119ffadb97203b95f36334f459aebe0278bb1690b352c55fa7df3"
+          "sha256": "55137c2907b0e8e84772b2e1b960484887b883a8469ff9d564336bb2a2a18cd1"
         }
       ],
       "runtimes": [
@@ -262,7 +262,7 @@
           "released_at": "2026-03-28T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/performance-reporting-plugin/plugin.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/performance-reporting-plugin/0.1.0.tar.gz",
-          "sha256": "bdd1b6df0636227b1378ec301a09b2cab3ede7689e5b1743d706b44b4e6a539f"
+          "sha256": "d6d9e93b3f7bed4f44888ad99ad1619ebba54535c4703b6378a3a5e35a33d449"
         }
       ],
       "runtimes": [

--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -14,7 +14,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/analyst-copilot-bigquery-redshift/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/analyst-copilot-bigquery-redshift/0.1.0.tar.gz",
-          "sha256": "8ba663e9403a1c5e18a8b95500f4080dff3e480447cb8ae3814b19f55b652687"
+          "sha256": "b6dae5254cd078ab30415f00de3c12c920becf640f76196fa7f6c6cdb866afde"
         }
       ],
       "runtimes": [
@@ -30,7 +30,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for read-only analysis and SQL drafting; require human approval before executing queries against production warehouses.",
+        "outputs": [
+          "SQL draft",
+          "Metric logic notes",
+          "Stakeholder summary"
+        ],
+        "use_when": "Use when an analyst question needs safe SQL drafting, metric validation, and stakeholder-ready findings across BigQuery or Redshift.",
+        "execution_mode": "read-only-local-inspection"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "adtech/brand-rag-memory-bootstrap",
@@ -44,7 +59,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/brand-rag-memory-bootstrap/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/brand-rag-memory-bootstrap/0.1.0.tar.gz",
-          "sha256": "64c1551dfb816cbb4eacd7f5bae1a45dd322dcf0a9bdcd771ecc9ecbed44188d"
+          "sha256": "4004d705d2ff3099cac2a367806a933e31b6a6aefe8640526dd6ccca955c193d"
         }
       ],
       "runtimes": [
@@ -61,7 +76,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for planning and document classification; require human approval before indexing sensitive or unapproved source material.",
+        "outputs": [
+          "Source inventory",
+          "Metadata schema",
+          "Refresh plan"
+        ],
+        "use_when": "Use when you need to structure approved brand, campaign, and policy documents into a retrieval-ready memory layer.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "adtech/dashboard-generator",
@@ -75,7 +105,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/dashboard-generator/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/dashboard-generator/0.1.0.tar.gz",
-          "sha256": "e0b5283ce8bb3d2d5c5d149dc164d9095e8535c8c52840fc0c8d73311c4aa665"
+          "sha256": "8a7f83d626d0fd42583db59076a313c68e290ea1067776d3af3988abf7fa5b27"
         }
       ],
       "runtimes": [
@@ -91,7 +121,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for report generation from validated inputs; require human approval before publishing external dashboard outputs.",
+        "outputs": [
+          "Dashboard package",
+          "KPI table",
+          "Action panel"
+        ],
+        "use_when": "Use when normalized performance tables need to be turned into deterministic weekly dashboard sections.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "adtech/dashboard-qa-checker",
@@ -105,7 +150,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/dashboard-qa-checker/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/dashboard-qa-checker/0.1.0.tar.gz",
-          "sha256": "6503483b9c90ceb17a964954f9cbd35c4103915512e4f415cdb553975f6e14e5"
+          "sha256": "83fb0b6eba1f6a909147d32ac7db3bdaf4e22875c2d1314f34a970b169a02f2a"
         }
       ],
       "runtimes": [
@@ -121,7 +166,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for read-only QA evaluation; require human approval before overriding critical failures.",
+        "outputs": [
+          "QA result",
+          "Blocking reasons",
+          "Alert payload"
+        ],
+        "use_when": "Use when a dashboard or BI package needs freshness, completeness, reconciliation, and anomaly checks before publish.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "adtech/executive-narrative-writer",
@@ -135,7 +195,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/executive-narrative-writer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/executive-narrative-writer/0.1.0.tar.gz",
-          "sha256": "9645db97cf9337f29ee41217d03e887e41abd763739340930014c41f58403bc6"
+          "sha256": "cebf9b90a68f2e96261ca7d2d4eb40dc0044484f6a8e2d63182ce5d8e02132b1"
         }
       ],
       "runtimes": [
@@ -151,7 +211,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for drafting narrative from approved inputs; require human approval before stakeholder distribution.",
+        "outputs": [
+          "Executive summary",
+          "Risk notes",
+          "Action recommendations"
+        ],
+        "use_when": "Use when QA-approved BI outputs need to be converted into concise executive narrative and action framing.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "adtech/playwright-agentic-e2e",
@@ -165,7 +240,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/playwright-agentic-e2e/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/playwright-agentic-e2e/0.1.0.tar.gz",
-          "sha256": "fe21689cd37baa5e7a0d3adf9809f6d0d40004e525d553893d6357b19b942252"
+          "sha256": "ac7a119e98ba6e42005d74c3a2080242113beb737e9cf7ce0afa6e3bb8b37c70"
         }
       ],
       "runtimes": [
@@ -182,7 +257,24 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May run local test commands and propose fixes; require human approval before deleting tests or broadening coverage scope.",
+        "outputs": [
+          "Playwright spec",
+          "Run summary",
+          "Healing suggestions"
+        ],
+        "use_when": "Use when a web app needs Playwright smoke coverage, failure diagnosis, and minimal healing suggestions.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "node",
+          "pnpm",
+          "npx"
+        ]
+      }
     },
     {
       "id": "adtech/playwright-vscode-loop-codex",
@@ -196,7 +288,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/playwright-vscode-loop-codex/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/playwright-vscode-loop-codex/0.1.0.tar.gz",
-          "sha256": "8659f15552be13c06cee94710e4bbe3b62031cdd37ad207ab1eb8825f007c617"
+          "sha256": "3109b45ce75ed42ace064148db29e9c4cd1ff711a223268f598512829414c40b"
         }
       ],
       "runtimes": [
@@ -213,7 +305,24 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May run local QA workflows and propose test updates; require human approval before accepting broad healing changes.",
+        "outputs": [
+          "Test plan",
+          "Generated spec",
+          "Healing notes"
+        ],
+        "use_when": "Use when Codex is orchestrating a VS Code-compatible Playwright planner, generator, and healer loop.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "node",
+          "npx",
+          "playwright"
+        ]
+      }
     },
     {
       "id": "adtech/policy-brand-compliance-checker",
@@ -227,7 +336,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/policy-brand-compliance-checker/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/policy-brand-compliance-checker/0.1.0.tar.gz",
-          "sha256": "0298e115ffc9c6a1d1fefb1dd91c946d12fe6d7b54023fc96dddce56be767b48"
+          "sha256": "9d084f5643ff4bd200caeacb597fb43bc299a77747bb6a54c01232e2bc9ed7c1"
         }
       ],
       "runtimes": [
@@ -243,7 +352,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for analysis and recommendation; require human approval before changing live assets or overriding blocked findings.",
+        "outputs": [
+          "Findings table",
+          "Severity ranking",
+          "Launch recommendation"
+        ],
+        "use_when": "Use when ad copy, URLs, or tracking conventions need policy and brand validation before launch.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "adtech/weekly-performance-review-bi",
@@ -257,7 +381,7 @@
           "released_at": "2026-02-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/weekly-performance-review-bi/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/weekly-performance-review-bi/0.1.0.tar.gz",
-          "sha256": "836587a6370e8284cccd4b3633aacf12c948367863bef840019314ef485f82e8"
+          "sha256": "6b4fb369f7dae082276eb6aae757c1368eb4a88bac6c250490f8c37110ef0378"
         }
       ],
       "runtimes": [
@@ -274,7 +398,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for orchestrating read-only reporting steps; require human approval before external publication.",
+        "outputs": [
+          "Publish decision",
+          "QA package",
+          "Narrative package"
+        ],
+        "use_when": "Use when weekly BI reporting needs deterministic orchestration across dashboard generation, QA, and narrative drafting.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "agentops/harness-regression-evaluator",
@@ -288,7 +427,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/agentops/harness-regression-evaluator/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/agentops/harness-regression-evaluator/0.1.0.tar.gz",
-          "sha256": "f0a99c9757b65498bec9defa96cbf752c17e6980311efc97dd15d5dc7622a49a"
+          "sha256": "564251d06db3f5f5b3f611e4b94d57ff05e6e965d0f230d1bcc9726129f7b6d4"
         }
       ],
       "runtimes": [
@@ -304,7 +443,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for harness evaluation; require human approval before applying accepted harness changes.",
+        "outputs": [
+          "Evaluation summary",
+          "Regression findings",
+          "Adopt or reject recommendation"
+        ],
+        "use_when": "Use when proposed harness changes need benchmark and red-team evaluation before adoption.",
+        "execution_mode": "may-run-local-verification"
+      }
     },
     {
       "id": "agentops/harness-run-reflection",
@@ -318,7 +467,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/agentops/harness-run-reflection/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/agentops/harness-run-reflection/0.1.0.tar.gz",
-          "sha256": "b52a1a85d25afd7605b371827786175449d0a84c5c23a218d6d8954ce44671c1"
+          "sha256": "943057c634d65a4c2636f33e896d678f1825879543843878099a840639b179ef"
         }
       ],
       "runtimes": [
@@ -334,7 +483,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for harness analysis; must not widen scope into production code changes on its own.",
+        "outputs": [
+          "Reflection report",
+          "Failure patterns",
+          "Improvement candidates"
+        ],
+        "use_when": "Use when recent agent run logs need review for repeated misses, skipped skills, and inefficient loops.",
+        "execution_mode": "analysis-only"
+      }
     },
     {
       "id": "agentops/harness-skill-proposal",
@@ -348,7 +507,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/agentops/harness-skill-proposal/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/agentops/harness-skill-proposal/0.1.0.tar.gz",
-          "sha256": "dcf1a8d53d2ab5442b1c53e9926bf5f37a4a03403e3a8dc1c1c10f81bf1c5647"
+          "sha256": "c4fc626488ff0e8d477fa486451109c446f803bafc11e95031d52b912e620587"
         }
       ],
       "runtimes": [
@@ -364,7 +523,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for proposal drafting inside harness-owned assets; require human approval before any change outside harness scope.",
+        "outputs": [
+          "Proposed skill changes",
+          "Boundary notes",
+          "Rationale summary"
+        ],
+        "use_when": "Use when repeated harness failures justify drafting new or revised harness skills and policy text.",
+        "execution_mode": "analysis-only"
+      }
     },
     {
       "id": "engineering/code-change-verification",
@@ -378,7 +547,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/engineering/code-change-verification/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/engineering/code-change-verification/0.1.0.tar.gz",
-          "sha256": "da7d0b562984a1665e16698341e352a5f6b0a9e7d2ad0461d222b9ada7b49183"
+          "sha256": "22f665578aab9a2b0a1bdb0c251a8bf2b3aba0d4e1543941ebcf47163528befd"
         }
       ],
       "runtimes": [
@@ -394,7 +563,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May run local verification commands; require human approval before retrying destructive setup or environment-changing commands.",
+        "outputs": [
+          "Verification report",
+          "Failed command summary",
+          "Residual risk note"
+        ],
+        "use_when": "Use when a code change needs stack-aware lint, typecheck, build, and test verification based on touched files.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "bash"
+        ]
+      }
     },
     {
       "id": "engineering/coverage-gap-reporter",
@@ -408,7 +592,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/engineering/coverage-gap-reporter/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/engineering/coverage-gap-reporter/0.1.0.tar.gz",
-          "sha256": "8e6fc7d2016f030dfd834a4d2bac090275eeb9dc851f085540a2d5ed1f3b28d2"
+          "sha256": "48024d23ebcf530d80a34ff330b45e0143be4956e0d73a4dbc1fe8aa737b086d"
         }
       ],
       "runtimes": [
@@ -424,7 +608,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for coverage analysis and recommendation; require human approval before modifying CI coverage gates.",
+        "outputs": [
+          "Coverage gap report",
+          "Risk-ranked files",
+          "Suggested tests"
+        ],
+        "use_when": "Use when coverage artifacts need to be mapped to changed files and uncovered regression risk.",
+        "execution_mode": "analysis-only"
+      }
     },
     {
       "id": "engineering/implementation-strategy",
@@ -438,7 +632,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/engineering/implementation-strategy/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/engineering/implementation-strategy/0.1.0.tar.gz",
-          "sha256": "48aece1a138bfc6c274ae5bc219ff2d7087a4ae16af3b867c93837e5db1852af"
+          "sha256": "1e5403e7862a995a518ee44d6e30b5d0c2ce154e7e7ade99834fe60a1000f500"
         }
       ],
       "runtimes": [
@@ -454,7 +648,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for repo inspection and planning; does not require write access and should precede code edits.",
+        "outputs": [
+          "Change strategy",
+          "Impacted files",
+          "Verification command list"
+        ],
+        "use_when": "Use when a repository needs scope analysis, impact mapping, and change planning before edits begin.",
+        "execution_mode": "read-only-local-inspection"
+      },
+      "dependencies": {
+        "tools": [
+          "rg"
+        ]
+      }
     },
     {
       "id": "engineering/pr-review-and-draft",
@@ -468,7 +677,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/engineering/pr-review-and-draft/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/engineering/pr-review-and-draft/0.1.0.tar.gz",
-          "sha256": "294e9e9a28c80e8178d04e4d546d4535c298fba186807278dc47c456a8b12e14"
+          "sha256": "cd62e89ef3a9319f10297ee8bd7ad2bc097ed6c8d8b49a58eb3a6d961df5ae27"
         }
       ],
       "runtimes": [
@@ -484,7 +693,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for review and drafting; require human approval before applying code changes based on review findings.",
+        "outputs": [
+          "Review findings",
+          "Risk summary",
+          "PR draft"
+        ],
+        "use_when": "Use when code changes need correctness, performance, security, and test review plus a structured PR draft.",
+        "execution_mode": "read-only-local-inspection"
+      }
     },
     {
       "id": "engineering/test-gap-analyzer",
@@ -498,7 +717,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/engineering/test-gap-analyzer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/engineering/test-gap-analyzer/0.1.0.tar.gz",
-          "sha256": "5fecdb83f38d57bd8a79bc9a3be77a569d17e5b0501444d48a1cbd0dbca4b1aa"
+          "sha256": "69aea5860b143dd7636c8669022bd55ac7639bbdc6f557139b3ba9c48f4dba33"
         }
       ],
       "runtimes": [
@@ -514,7 +733,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for inspection and recommendation; require human approval before broadening test scope or changing suites.",
+        "outputs": [
+          "Missing test scenarios",
+          "Risk ranking",
+          "Suggested next tests"
+        ],
+        "use_when": "Use when changed code needs missing unit, integration, regression, and edge-case scenarios identified.",
+        "execution_mode": "read-only-local-inspection"
+      }
     },
     {
       "id": "marketing/ab-test-planner-analyzer",
@@ -528,7 +757,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ab-test-planner-analyzer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ab-test-planner-analyzer/0.1.0.tar.gz",
-          "sha256": "51d6bdeb5261331cdcb7b23da8c8a7c926cec32796747670b53863b044ff8623"
+          "sha256": "085db550c13d2719092a7f5d939e28d1a184bd353c2b2f75f567156a61d7cd3b"
         }
       ],
       "runtimes": [
@@ -545,7 +774,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for planning and analysis; require human approval before launching experiments or changing traffic allocation.",
+        "outputs": [
+          "Experiment plan",
+          "Decision framework",
+          "Analysis summary"
+        ],
+        "use_when": "Use when an A/B test needs explicit hypotheses, sample-size assumptions, and decision rules.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/ai-output-eval-scorecard",
@@ -559,7 +803,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ai-output-eval-scorecard/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ai-output-eval-scorecard/0.1.0.tar.gz",
-          "sha256": "fd567640fedf2e053392ff2bf85f708595019cb5550d162bee73d340502be507"
+          "sha256": "2ede4bad097be375886cbbf1a15a44403f63aa425e52ecd0a02c3880c6a9a2c9"
         }
       ],
       "runtimes": [
@@ -576,7 +820,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for evaluation and recommendation; require human approval before approving externally visible copy.",
+        "outputs": [
+          "Scorecard",
+          "Verdict",
+          "Rewrite recommendations"
+        ],
+        "use_when": "Use when AI-generated marketing outputs need repeatable scoring across quality, compliance, and actionability.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/creative-workshop-pmax-reels",
@@ -590,7 +849,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/creative-workshop-pmax-reels/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creative-workshop-pmax-reels/0.1.0.tar.gz",
-          "sha256": "dbdcac3bb53a412349f5e83f1d6e7a0144dbc8099863facabf509a26177bfda8"
+          "sha256": "527becb3b9f86eafd6641e27441336e3cc498a297d41e167747de4cdcedb93c3"
         }
       ],
       "runtimes": [
@@ -606,7 +865,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for draft creative generation; require human approval before publishing or trafficking assets.",
+        "outputs": [
+          "Creative variants",
+          "Angle summary",
+          "Compliance notes"
+        ],
+        "use_when": "Use when you need platform-ready creative variants for Google PMax and Meta Reels with bounded formatting checks.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/cross-channel-budget-pacing-agent",
@@ -620,7 +894,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/cross-channel-budget-pacing-agent/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/cross-channel-budget-pacing-agent/0.1.0.tar.gz",
-          "sha256": "5dea3e1335e309c891e2ea28bfb98c975c47d4812a544f5980608c2bc0f6fd34"
+          "sha256": "638f68e3024a2c7404cf05fdcd6f5b10fc2a0a36567c1c8b8ea998c600617e27"
         }
       ],
       "runtimes": [
@@ -637,7 +911,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for analysis and recommendation; require human approval before changing live budgets.",
+        "outputs": [
+          "Pacing summary",
+          "Anomaly list",
+          "Reallocation plan"
+        ],
+        "use_when": "Use when pacing and efficiency signals across channels need bounded reallocation recommendations.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/dynamic-creative-rules-engine",
@@ -651,7 +940,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/dynamic-creative-rules-engine/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/dynamic-creative-rules-engine/0.1.0.tar.gz",
-          "sha256": "578d6115038f6bbdd3d230ed4f1ffad8941f3556b60747cbac9ccc15e3a3eed0"
+          "sha256": "74c348cd7bc68f525acb112a33ad784e1ea1ba047cd4a39f9444bcf6f1899e2f"
         }
       ],
       "runtimes": [
@@ -668,7 +957,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for rule design and evaluation; require human approval before deploying personalization logic.",
+        "outputs": [
+          "Ruleset",
+          "Blocked combinations",
+          "Test matrix"
+        ],
+        "use_when": "Use when audience-aware creative assembly rules need to be defined under brand and policy constraints.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/lifecycle-experiment-planner",
@@ -682,7 +986,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/lifecycle-experiment-planner/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/lifecycle-experiment-planner/0.1.0.tar.gz",
-          "sha256": "5ff0c3ab6205443cf3ca12b402581ae32d3d1d45aabceb8f047eb383dcdcfd73"
+          "sha256": "4ea9b15b727772214ebf952fdf4532388b8c49e4494f84c04504bbcd62a4c73d"
         }
       ],
       "runtimes": [
@@ -698,7 +1002,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for planning; require human approval before launching lifecycle experiments or changing user journeys.",
+        "outputs": [
+          "Hypothesis plan",
+          "Sample-size guidance",
+          "Stop criteria"
+        ],
+        "use_when": "Use when a lifecycle experiment needs statistical assumptions, stop rules, and guardrail metrics defined clearly.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/lifecycle-journey-trigger-designer",
@@ -712,7 +1031,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/lifecycle-journey-trigger-designer/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/lifecycle-journey-trigger-designer/0.1.0.tar.gz",
-          "sha256": "04de39a058fae73fe1ec4c44a05901d6d08054446b1428808d29c1271bb21f0c"
+          "sha256": "67da9be48bc1901c1b0f8e10f9f4d5d782216277fde770a1c6e2b3642751cbd7"
         }
       ],
       "runtimes": [
@@ -729,7 +1048,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for planning and design; require human approval before activating live messaging journeys.",
+        "outputs": [
+          "Journey blueprint",
+          "Trigger rules",
+          "Measurement plan"
+        ],
+        "use_when": "Use when lifecycle entry, progression, and suppression rules need to be designed with measurement plans.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/meta-google-weekly-performance-review",
@@ -743,7 +1077,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/meta-google-weekly-performance-review/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/meta-google-weekly-performance-review/0.1.0.tar.gz",
-          "sha256": "ffb2174126c35ce575ce2dbfa90f42425fba849e9cac2dea816114ce14fa680d"
+          "sha256": "9b274e77aaf6b68c40bc37541109f5093128fa38bba9923b3f57e508e7b6a6a5"
         }
       ],
       "runtimes": [
@@ -759,7 +1093,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for read-only analysis and reporting; require human approval before using outputs to make live media changes.",
+        "outputs": [
+          "KPI summary",
+          "Insight list",
+          "Recommended actions"
+        ],
+        "use_when": "Use when weekly performance across Meta and Google Ads needs KPI comparison and prioritized actions.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "marketing/seo-paid-search-synergy",
@@ -773,7 +1122,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/seo-paid-search-synergy/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/seo-paid-search-synergy/0.1.0.tar.gz",
-          "sha256": "ce3f88909c5ffbd907efd28e1f5f18cc76d9a35827435131e7e5276f70183327"
+          "sha256": "2447b75b96b39bf3a71c36626d9321e8e0f220b31ddbf413df55155951dbbcc4"
         }
       ],
       "runtimes": [
@@ -789,7 +1138,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for planning and opportunity analysis; require human approval before launching paid search changes.",
+        "outputs": [
+          "Keyword clusters",
+          "Ad group recommendations",
+          "Experiment plan"
+        ],
+        "use_when": "Use when SEO winners need to be translated into paid search opportunities and test-ready keyword structures.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
     },
     {
       "id": "security/dependency-supply-chain-audit",
@@ -803,7 +1167,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/security/dependency-supply-chain-audit/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/security/dependency-supply-chain-audit/0.1.0.tar.gz",
-          "sha256": "909f4fd9f6dabcbdc8fa8aa3e23e941e96aca6e88220ba64508ef12cffd8e103"
+          "sha256": "4d7d1c41be650480a044e806fb8ab4984a54298e76cf6245f55745bba51ae962"
         }
       ],
       "runtimes": [
@@ -819,7 +1183,23 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May run local scanners and review package risk; require human approval before removing dependencies or changing production lockfiles.",
+        "outputs": [
+          "Dependency findings",
+          "Risk ranking",
+          "Mitigation recommendations"
+        ],
+        "use_when": "Use when manifests and lockfiles need vulnerability, provenance, and package risk review before trust is granted.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "trivy",
+          "osv-scanner"
+        ]
+      }
     },
     {
       "id": "security/environment-risk-assessment",
@@ -833,7 +1213,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/security/environment-risk-assessment/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/security/environment-risk-assessment/0.1.0.tar.gz",
-          "sha256": "38db7c5067156df723fa95b60117d99b3fbc4704b1a4f14a6c390d57d3ae2ebb"
+          "sha256": "4199db513316791a71e37d87e95447ef5d334f20e3f1dabc320612b916a6d36f"
         }
       ],
       "runtimes": [
@@ -849,7 +1229,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for inspection and recommendation; require human approval before changing runtime isolation or credential policies.",
+        "outputs": [
+          "Environment risk review",
+          "Escalation reasons",
+          "Isolation recommendations"
+        ],
+        "use_when": "Use when you need to assess whether the current runtime is safe for autonomous agent execution.",
+        "execution_mode": "read-only-local-inspection"
+      }
     },
     {
       "id": "security/handle-untrusted-content",
@@ -863,7 +1253,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/security/handle-untrusted-content/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/security/handle-untrusted-content/0.1.0.tar.gz",
-          "sha256": "001abfeef3257cf76ef684c619d7ccb583e77b0ab4fcf421fc9ac841d1843b66"
+          "sha256": "eabef3c1bff3ab9df17f03e8c32e324d60fec96ae667583134d9d41df368d6d4"
         }
       ],
       "runtimes": [
@@ -879,7 +1269,17 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for analysis and escalation only; must not trigger shell, network, or write actions on its own.",
+        "outputs": [
+          "Risk triage",
+          "Quarantined instructions",
+          "Escalation recommendation"
+        ],
+        "use_when": "Use when logs, tickets, webpages, or MCP outputs may contain prompt injection or unsafe instructions.",
+        "execution_mode": "analysis-only"
+      }
     },
     {
       "id": "security/secrets-and-credential-hygiene",
@@ -893,7 +1293,7 @@
           "released_at": "2026-03-19T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/security/secrets-and-credential-hygiene/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/security/secrets-and-credential-hygiene/0.1.0.tar.gz",
-          "sha256": "b2abe6263ae52829044221380b6562665ad453a0db916019674588ff18872995"
+          "sha256": "7ed458691a13d3c69a68ebf16e15687235db192d1cfae1d33c206d7d8771f790"
         }
       ],
       "runtimes": [
@@ -909,7 +1309,22 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May run local secret scanners and redact findings; require human approval before revocation or rotation actions.",
+        "outputs": [
+          "Secret findings",
+          "Severity matrix",
+          "Remediation steps"
+        ],
+        "use_when": "Use when diffs or repository context need secret scanning and credential exposure review.",
+        "execution_mode": "may-run-local-verification"
+      },
+      "dependencies": {
+        "tools": [
+          "gitleaks"
+        ]
+      }
     }
   ]
 }

--- a/registry/tools-index.json
+++ b/registry/tools-index.json
@@ -14,7 +14,7 @@
           "released_at": "2026-03-02T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/ads/meta-ads-mcp-connector/tool.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/ads/meta-ads-mcp-connector/0.1.0.tar.gz",
-          "sha256": "ff1ade3ce21346ebebb2470e075528519b4173aca32225bbd7831e2122520d37"
+          "sha256": "207ef9c8569ef7dcb036c97829030ec3decb129cd3a17acb0d50478a588072e9"
         }
       ],
       "runtimes": [
@@ -29,7 +29,26 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "connected_system": "Meta Ads",
+        "capabilities": [
+          "Pull campaign, ad set, and ad metrics for fixed reporting windows.",
+          "Return spend, delivery, click, and conversion fields in normalized rows.",
+          "Preserve source timestamps for QA and freshness validation."
+        ],
+        "auth_required": [
+          "Meta Ads account scope via authenticated MCP runtime"
+        ],
+        "access_level": "read-only",
+        "trust_boundary": "remote-mcp-server",
+        "approval_boundary": "Safe for reporting queries only; require human approval before pairing with any workflow that can modify campaigns, budgets, or creative state."
+      },
+      "dependencies": {
+        "mcp_servers": [
+          "meta-ads"
+        ]
+      }
     },
     {
       "id": "analytics/ga4-mcp-connector",
@@ -43,7 +62,7 @@
           "released_at": "2026-03-02T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/analytics/ga4-mcp-connector/tool.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/analytics/ga4-mcp-connector/0.1.0.tar.gz",
-          "sha256": "7eb4e30ea92d68a580afe63ceaf1c24cea5f60b60ecac0de53d733af293faae1"
+          "sha256": "cba19f8f653c7ae47277f74df3167ed6f13d14a6994febc42e3a1d4623298cd5"
         }
       ],
       "runtimes": [
@@ -58,7 +77,26 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "connected_system": "Google Analytics 4",
+        "capabilities": [
+          "Pull sessions, users, conversions, and revenue by allowed dimensions.",
+          "Query fixed date windows for period comparisons and dashboard inputs.",
+          "Return normalized analytics payloads for downstream skills and agents."
+        ],
+        "auth_required": [
+          "GA4 property access via authenticated MCP runtime"
+        ],
+        "access_level": "read-only",
+        "trust_boundary": "remote-mcp-server",
+        "approval_boundary": "Safe for read-only analytics retrieval; require human approval before combining with any workflow that writes back to ad platforms or reporting systems."
+      },
+      "dependencies": {
+        "mcp_servers": [
+          "ga4"
+        ]
+      }
     },
     {
       "id": "warehouse/bigquery-mcp-query-runner",
@@ -72,7 +110,7 @@
           "released_at": "2026-03-02T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/warehouse/bigquery-mcp-query-runner/tool.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/warehouse/bigquery-mcp-query-runner/0.1.0.tar.gz",
-          "sha256": "8cbdafb2f2aa032e8cf36c3ea5db03b2c76a21857c5d06a5cdc59a4a1b29d14f"
+          "sha256": "909e25c4ee2cc2b29a3393e31f5a6d26443af0b7cc08e29ffe0ae38fcc192be5"
         }
       ],
       "runtimes": [
@@ -87,7 +125,26 @@
       ],
       "readiness": "experimental",
       "security_reviewed": false,
-      "deprecated": false
+      "deprecated": false,
+      "operational": {
+        "connected_system": "Google BigQuery",
+        "capabilities": [
+          "Execute parameterized read-only SQL templates for analytics workflows.",
+          "Return typed warehouse rows for BI transformations and reporting.",
+          "Enforce query guardrails such as timeout, limits, and statement restrictions."
+        ],
+        "auth_required": [
+          "BigQuery dataset access via authenticated MCP runtime"
+        ],
+        "access_level": "read-only",
+        "trust_boundary": "remote-mcp-server",
+        "approval_boundary": "Safe for parameterized read-only queries; require human approval before broadening dataset scope or enabling any non-read-only SQL path."
+      },
+      "dependencies": {
+        "mcp_servers": [
+          "bigquery"
+        ]
+      }
     }
   ]
 }

--- a/shared/schemas/agent.schema.json
+++ b/shared/schemas/agent.schema.json
@@ -152,6 +152,50 @@
         }
       }
     },
+    "operational": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "role": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 160
+        },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 160
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "autonomy_level": {
+          "type": "string",
+          "enum": [
+            "advisory",
+            "semi-autonomous",
+            "execution-capable-with-approval"
+          ]
+        },
+        "approval_boundary": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 240
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 160
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      }
+    },
     "verification": {
       "type": "object",
       "additionalProperties": false,

--- a/shared/schemas/registry-index.schema.json
+++ b/shared/schemas/registry-index.schema.json
@@ -108,6 +108,110 @@
             "type": "string",
             "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
           },
+          "operational": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "connected_system": {
+                "type": "string",
+                "minLength": 2
+              },
+              "capabilities": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 3
+                },
+                "uniqueItems": true
+              },
+              "auth_required": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 2
+                },
+                "uniqueItems": true
+              },
+              "access_level": {
+                "type": "string"
+              },
+              "trust_boundary": {
+                "type": "string"
+              },
+              "approval_boundary": {
+                "type": "string",
+                "minLength": 5
+              },
+              "role": {
+                "type": "string",
+                "minLength": 3
+              },
+              "coordinates": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 3
+                },
+                "uniqueItems": true
+              },
+              "autonomy_level": {
+                "type": "string"
+              },
+              "outputs": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 3
+                },
+                "uniqueItems": true
+              },
+              "use_when": {
+                "type": "string",
+                "minLength": 5
+              },
+              "execution_mode": {
+                "type": "string"
+              }
+            }
+          },
+          "dependencies": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "skills": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+                },
+                "uniqueItems": true
+              },
+              "tools": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true
+              },
+              "apis": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true
+              },
+              "mcp_servers": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true
+              }
+            }
+          },
           "includes": {
             "type": "object",
             "additionalProperties": false,

--- a/shared/schemas/skill.schema.json
+++ b/shared/schemas/skill.schema.json
@@ -169,6 +169,41 @@
         }
       }
     },
+    "operational": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "use_when": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 240
+        },
+        "execution_mode": {
+          "type": "string",
+          "enum": [
+            "analysis-only",
+            "read-only-local-inspection",
+            "may-run-local-verification",
+            "may-propose-edits"
+          ]
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 160
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "approval_boundary": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 240
+        }
+      }
+    },
     "verification": {
       "type": "object",
       "additionalProperties": false,

--- a/shared/schemas/tool.schema.json
+++ b/shared/schemas/tool.schema.json
@@ -156,6 +156,58 @@
         }
       }
     },
+    "operational": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "connected_system": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 120
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 160
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "auth_required": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 120
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "access_level": {
+          "type": "string",
+          "enum": [
+            "read-only",
+            "read-write",
+            "admin-sensitive"
+          ]
+        },
+        "trust_boundary": {
+          "type": "string",
+          "enum": [
+            "local-tool",
+            "remote-mcp-server",
+            "third-party-hosted"
+          ]
+        },
+        "approval_boundary": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 240
+        }
+      }
+    },
     "verification": {
       "type": "object",
       "additionalProperties": false,

--- a/skills/adtech/analyst-copilot-bigquery-redshift/skill.yaml
+++ b/skills/adtech/analyst-copilot-bigquery-redshift/skill.yaml
@@ -28,6 +28,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when an analyst question needs safe SQL drafting, metric validation, and stakeholder-ready findings across BigQuery or Redshift.
+  execution_mode: read-only-local-inspection
+  outputs:
+    - SQL draft
+    - Metric logic notes
+    - Stakeholder summary
+  approval_boundary: Safe for read-only analysis and SQL drafting; require human approval before executing queries against production warehouses.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: true

--- a/skills/adtech/brand-rag-memory-bootstrap/skill.yaml
+++ b/skills/adtech/brand-rag-memory-bootstrap/skill.yaml
@@ -27,6 +27,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when you need to structure approved brand, campaign, and policy documents into a retrieval-ready memory layer.
+  execution_mode: analysis-only
+  outputs:
+    - Source inventory
+    - Metadata schema
+    - Refresh plan
+  approval_boundary: Safe for planning and document classification; require human approval before indexing sensitive or unapproved source material.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/adtech/dashboard-generator/skill.yaml
+++ b/skills/adtech/dashboard-generator/skill.yaml
@@ -27,6 +27,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when normalized performance tables need to be turned into deterministic weekly dashboard sections.
+  execution_mode: may-run-local-verification
+  outputs:
+    - Dashboard package
+    - KPI table
+    - Action panel
+  approval_boundary: Safe for report generation from validated inputs; require human approval before publishing external dashboard outputs.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/adtech/dashboard-qa-checker/skill.yaml
+++ b/skills/adtech/dashboard-qa-checker/skill.yaml
@@ -27,6 +27,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when a dashboard or BI package needs freshness, completeness, reconciliation, and anomaly checks before publish.
+  execution_mode: may-run-local-verification
+  outputs:
+    - QA result
+    - Blocking reasons
+    - Alert payload
+  approval_boundary: Safe for read-only QA evaluation; require human approval before overriding critical failures.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/adtech/executive-narrative-writer/skill.yaml
+++ b/skills/adtech/executive-narrative-writer/skill.yaml
@@ -27,6 +27,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when QA-approved BI outputs need to be converted into concise executive narrative and action framing.
+  execution_mode: analysis-only
+  outputs:
+    - Executive summary
+    - Risk notes
+    - Action recommendations
+  approval_boundary: Safe for drafting narrative from approved inputs; require human approval before stakeholder distribution.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/adtech/playwright-agentic-e2e/skill.yaml
+++ b/skills/adtech/playwright-agentic-e2e/skill.yaml
@@ -30,6 +30,14 @@ dependencies:
     - node
     - pnpm
     - npx
+operational:
+  use_when: Use when a web app needs Playwright smoke coverage, failure diagnosis, and minimal healing suggestions.
+  execution_mode: may-run-local-verification
+  outputs:
+    - Playwright spec
+    - Run summary
+    - Healing suggestions
+  approval_boundary: May run local test commands and propose fixes; require human approval before deleting tests or broadening coverage scope.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/adtech/playwright-vscode-loop-codex/skill.yaml
+++ b/skills/adtech/playwright-vscode-loop-codex/skill.yaml
@@ -30,6 +30,14 @@ dependencies:
     - node
     - npx
     - playwright
+operational:
+  use_when: Use when Codex is orchestrating a VS Code-compatible Playwright planner, generator, and healer loop.
+  execution_mode: may-run-local-verification
+  outputs:
+    - Test plan
+    - Generated spec
+    - Healing notes
+  approval_boundary: May run local QA workflows and propose test updates; require human approval before accepting broad healing changes.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/adtech/policy-brand-compliance-checker/skill.yaml
+++ b/skills/adtech/policy-brand-compliance-checker/skill.yaml
@@ -28,6 +28,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when ad copy, URLs, or tracking conventions need policy and brand validation before launch.
+  execution_mode: may-run-local-verification
+  outputs:
+    - Findings table
+    - Severity ranking
+    - Launch recommendation
+  approval_boundary: Safe for analysis and recommendation; require human approval before changing live assets or overriding blocked findings.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: true

--- a/skills/adtech/weekly-performance-review-bi/skill.yaml
+++ b/skills/adtech/weekly-performance-review-bi/skill.yaml
@@ -27,6 +27,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when weekly BI reporting needs deterministic orchestration across dashboard generation, QA, and narrative drafting.
+  execution_mode: analysis-only
+  outputs:
+    - Publish decision
+    - QA package
+    - Narrative package
+  approval_boundary: Safe for orchestrating read-only reporting steps; require human approval before external publication.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/agentops/harness-regression-evaluator/skill.yaml
+++ b/skills/agentops/harness-regression-evaluator/skill.yaml
@@ -25,6 +25,14 @@ entrypoints:
   tests: tests/test-prompts.md
   scripts_dir: scripts
   examples_dir: examples
+operational:
+  use_when: Use when proposed harness changes need benchmark and red-team evaluation before adoption.
+  execution_mode: may-run-local-verification
+  outputs:
+    - Evaluation summary
+    - Regression findings
+    - Adopt or reject recommendation
+  approval_boundary: Safe for harness evaluation; require human approval before applying accepted harness changes.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/agentops/harness-run-reflection/skill.yaml
+++ b/skills/agentops/harness-run-reflection/skill.yaml
@@ -25,6 +25,14 @@ entrypoints:
   tests: tests/test-prompts.md
   scripts_dir: scripts
   examples_dir: examples
+operational:
+  use_when: Use when recent agent run logs need review for repeated misses, skipped skills, and inefficient loops.
+  execution_mode: analysis-only
+  outputs:
+    - Reflection report
+    - Failure patterns
+    - Improvement candidates
+  approval_boundary: Safe for harness analysis; must not widen scope into production code changes on its own.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/agentops/harness-skill-proposal/skill.yaml
+++ b/skills/agentops/harness-skill-proposal/skill.yaml
@@ -25,6 +25,14 @@ entrypoints:
   tests: tests/test-prompts.md
   scripts_dir: scripts
   examples_dir: examples
+operational:
+  use_when: Use when repeated harness failures justify drafting new or revised harness skills and policy text.
+  execution_mode: analysis-only
+  outputs:
+    - Proposed skill changes
+    - Boundary notes
+    - Rationale summary
+  approval_boundary: Safe for proposal drafting inside harness-owned assets; require human approval before any change outside harness scope.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/engineering/code-change-verification/skill.yaml
+++ b/skills/engineering/code-change-verification/skill.yaml
@@ -28,6 +28,14 @@ entrypoints:
 dependencies:
   tools:
     - bash
+operational:
+  use_when: Use when a code change needs stack-aware lint, typecheck, build, and test verification based on touched files.
+  execution_mode: may-run-local-verification
+  outputs:
+    - Verification report
+    - Failed command summary
+    - Residual risk note
+  approval_boundary: May run local verification commands; require human approval before retrying destructive setup or environment-changing commands.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/engineering/coverage-gap-reporter/skill.yaml
+++ b/skills/engineering/coverage-gap-reporter/skill.yaml
@@ -25,6 +25,14 @@ entrypoints:
   tests: tests/test-prompts.md
   scripts_dir: scripts
   examples_dir: examples
+operational:
+  use_when: Use when coverage artifacts need to be mapped to changed files and uncovered regression risk.
+  execution_mode: analysis-only
+  outputs:
+    - Coverage gap report
+    - Risk-ranked files
+    - Suggested tests
+  approval_boundary: Safe for coverage analysis and recommendation; require human approval before modifying CI coverage gates.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/engineering/implementation-strategy/skill.yaml
+++ b/skills/engineering/implementation-strategy/skill.yaml
@@ -28,6 +28,14 @@ entrypoints:
 dependencies:
   tools:
     - rg
+operational:
+  use_when: Use when a repository needs scope analysis, impact mapping, and change planning before edits begin.
+  execution_mode: read-only-local-inspection
+  outputs:
+    - Change strategy
+    - Impacted files
+    - Verification command list
+  approval_boundary: Safe for repo inspection and planning; does not require write access and should precede code edits.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/engineering/pr-review-and-draft/skill.yaml
+++ b/skills/engineering/pr-review-and-draft/skill.yaml
@@ -25,6 +25,14 @@ entrypoints:
   tests: tests/test-prompts.md
   scripts_dir: scripts
   examples_dir: examples
+operational:
+  use_when: Use when code changes need correctness, performance, security, and test review plus a structured PR draft.
+  execution_mode: read-only-local-inspection
+  outputs:
+    - Review findings
+    - Risk summary
+    - PR draft
+  approval_boundary: Safe for review and drafting; require human approval before applying code changes based on review findings.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/engineering/test-gap-analyzer/skill.yaml
+++ b/skills/engineering/test-gap-analyzer/skill.yaml
@@ -25,6 +25,14 @@ entrypoints:
   tests: tests/test-prompts.md
   scripts_dir: scripts
   examples_dir: examples
+operational:
+  use_when: Use when changed code needs missing unit, integration, regression, and edge-case scenarios identified.
+  execution_mode: read-only-local-inspection
+  outputs:
+    - Missing test scenarios
+    - Risk ranking
+    - Suggested next tests
+  approval_boundary: Safe for inspection and recommendation; require human approval before broadening test scope or changing suites.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/marketing/ab-test-planner-analyzer/skill.yaml
+++ b/skills/marketing/ab-test-planner-analyzer/skill.yaml
@@ -27,6 +27,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when an A/B test needs explicit hypotheses, sample-size assumptions, and decision rules.
+  execution_mode: analysis-only
+  outputs:
+    - Experiment plan
+    - Decision framework
+    - Analysis summary
+  approval_boundary: Safe for planning and analysis; require human approval before launching experiments or changing traffic allocation.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/marketing/ai-output-eval-scorecard/skill.yaml
+++ b/skills/marketing/ai-output-eval-scorecard/skill.yaml
@@ -27,6 +27,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when AI-generated marketing outputs need repeatable scoring across quality, compliance, and actionability.
+  execution_mode: analysis-only
+  outputs:
+    - Scorecard
+    - Verdict
+    - Rewrite recommendations
+  approval_boundary: Safe for evaluation and recommendation; require human approval before approving externally visible copy.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/marketing/creative-workshop-pmax-reels/skill.yaml
+++ b/skills/marketing/creative-workshop-pmax-reels/skill.yaml
@@ -28,6 +28,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when you need platform-ready creative variants for Google PMax and Meta Reels with bounded formatting checks.
+  execution_mode: may-run-local-verification
+  outputs:
+    - Creative variants
+    - Angle summary
+    - Compliance notes
+  approval_boundary: Safe for draft creative generation; require human approval before publishing or trafficking assets.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: true

--- a/skills/marketing/cross-channel-budget-pacing-agent/skill.yaml
+++ b/skills/marketing/cross-channel-budget-pacing-agent/skill.yaml
@@ -27,6 +27,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when pacing and efficiency signals across channels need bounded reallocation recommendations.
+  execution_mode: analysis-only
+  outputs:
+    - Pacing summary
+    - Anomaly list
+    - Reallocation plan
+  approval_boundary: Safe for analysis and recommendation; require human approval before changing live budgets.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/marketing/dynamic-creative-rules-engine/skill.yaml
+++ b/skills/marketing/dynamic-creative-rules-engine/skill.yaml
@@ -27,6 +27,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when audience-aware creative assembly rules need to be defined under brand and policy constraints.
+  execution_mode: analysis-only
+  outputs:
+    - Ruleset
+    - Blocked combinations
+    - Test matrix
+  approval_boundary: Safe for rule design and evaluation; require human approval before deploying personalization logic.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/marketing/lifecycle-experiment-planner/skill.yaml
+++ b/skills/marketing/lifecycle-experiment-planner/skill.yaml
@@ -28,6 +28,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when a lifecycle experiment needs statistical assumptions, stop rules, and guardrail metrics defined clearly.
+  execution_mode: may-run-local-verification
+  outputs:
+    - Hypothesis plan
+    - Sample-size guidance
+    - Stop criteria
+  approval_boundary: Safe for planning; require human approval before launching lifecycle experiments or changing user journeys.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: true

--- a/skills/marketing/lifecycle-journey-trigger-designer/skill.yaml
+++ b/skills/marketing/lifecycle-journey-trigger-designer/skill.yaml
@@ -27,6 +27,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when lifecycle entry, progression, and suppression rules need to be designed with measurement plans.
+  execution_mode: analysis-only
+  outputs:
+    - Journey blueprint
+    - Trigger rules
+    - Measurement plan
+  approval_boundary: Safe for planning and design; require human approval before activating live messaging journeys.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/marketing/meta-google-weekly-performance-review/skill.yaml
+++ b/skills/marketing/meta-google-weekly-performance-review/skill.yaml
@@ -27,6 +27,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when weekly performance across Meta and Google Ads needs KPI comparison and prioritized actions.
+  execution_mode: may-run-local-verification
+  outputs:
+    - KPI summary
+    - Insight list
+    - Recommended actions
+  approval_boundary: Safe for read-only analysis and reporting; require human approval before using outputs to make live media changes.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: true

--- a/skills/marketing/seo-paid-search-synergy/skill.yaml
+++ b/skills/marketing/seo-paid-search-synergy/skill.yaml
@@ -28,6 +28,14 @@ entrypoints:
 dependencies:
   tools:
     - python3
+operational:
+  use_when: Use when SEO winners need to be translated into paid search opportunities and test-ready keyword structures.
+  execution_mode: may-run-local-verification
+  outputs:
+    - Keyword clusters
+    - Ad group recommendations
+    - Experiment plan
+  approval_boundary: Safe for planning and opportunity analysis; require human approval before launching paid search changes.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: true

--- a/skills/security/dependency-supply-chain-audit/skill.yaml
+++ b/skills/security/dependency-supply-chain-audit/skill.yaml
@@ -29,6 +29,14 @@ dependencies:
   tools:
     - trivy
     - osv-scanner
+operational:
+  use_when: Use when manifests and lockfiles need vulnerability, provenance, and package risk review before trust is granted.
+  execution_mode: may-run-local-verification
+  outputs:
+    - Dependency findings
+    - Risk ranking
+    - Mitigation recommendations
+  approval_boundary: May run local scanners and review package risk; require human approval before removing dependencies or changing production lockfiles.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/security/environment-risk-assessment/skill.yaml
+++ b/skills/security/environment-risk-assessment/skill.yaml
@@ -25,6 +25,14 @@ entrypoints:
   tests: tests/test-prompts.md
   scripts_dir: scripts
   examples_dir: examples
+operational:
+  use_when: Use when you need to assess whether the current runtime is safe for autonomous agent execution.
+  execution_mode: read-only-local-inspection
+  outputs:
+    - Environment risk review
+    - Escalation reasons
+    - Isolation recommendations
+  approval_boundary: Safe for inspection and recommendation; require human approval before changing runtime isolation or credential policies.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/security/handle-untrusted-content/skill.yaml
+++ b/skills/security/handle-untrusted-content/skill.yaml
@@ -25,6 +25,14 @@ entrypoints:
   tests: tests/test-prompts.md
   scripts_dir: scripts
   examples_dir: examples
+operational:
+  use_when: Use when logs, tickets, webpages, or MCP outputs may contain prompt injection or unsafe instructions.
+  execution_mode: analysis-only
+  outputs:
+    - Risk triage
+    - Quarantined instructions
+    - Escalation recommendation
+  approval_boundary: Safe for analysis and escalation only; must not trigger shell, network, or write actions on its own.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/skills/security/secrets-and-credential-hygiene/skill.yaml
+++ b/skills/security/secrets-and-credential-hygiene/skill.yaml
@@ -28,6 +28,14 @@ entrypoints:
 dependencies:
   tools:
     - gitleaks
+operational:
+  use_when: Use when diffs or repository context need secret scanning and credential exposure review.
+  execution_mode: may-run-local-verification
+  outputs:
+    - Secret findings
+    - Severity matrix
+    - Remediation steps
+  approval_boundary: May run local secret scanners and redact findings; require human approval before revocation or rotation actions.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/tools-mcp/ads/meta-ads-mcp-connector/README.md
+++ b/tools-mcp/ads/meta-ads-mcp-connector/README.md
@@ -18,6 +18,14 @@ analysis and reporting.
 - Returns spend, impressions, clicks, and conversions.
 - Preserves source timestamps for QA checks.
 
+## Operational metadata
+
+- Connected system: Meta Ads
+- Access level: read-only
+- Trust boundary: remote MCP server
+- Auth required: authenticated Meta Ads account scope in your MCP runtime
+- Approval boundary: safe for reporting queries only; require human approval before pairing this connector with workflows that can modify campaigns, budgets, or creative state
+
 ## Before you start
 
 1. Confirm Meta ad account ID scope.

--- a/tools-mcp/ads/meta-ads-mcp-connector/tool.yaml
+++ b/tools-mcp/ads/meta-ads-mcp-connector/tool.yaml
@@ -25,6 +25,17 @@ entrypoints:
 dependencies:
   mcp_servers:
     - meta-ads
+operational:
+  connected_system: Meta Ads
+  capabilities:
+    - Pull campaign, ad set, and ad metrics for fixed reporting windows.
+    - Return spend, delivery, click, and conversion fields in normalized rows.
+    - Preserve source timestamps for QA and freshness validation.
+  auth_required:
+    - Meta Ads account scope via authenticated MCP runtime
+  access_level: read-only
+  trust_boundary: remote-mcp-server
+  approval_boundary: Safe for reporting queries only; require human approval before pairing with any workflow that can modify campaigns, budgets, or creative state.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/tools-mcp/analytics/ga4-mcp-connector/README.md
+++ b/tools-mcp/analytics/ga4-mcp-connector/README.md
@@ -17,6 +17,14 @@ structured format.
 - Supports fixed date windows for period comparison.
 - Returns normalized output for skills and agents.
 
+## Operational metadata
+
+- Connected system: Google Analytics 4
+- Access level: read-only
+- Trust boundary: remote MCP server
+- Auth required: authenticated GA4 property access in your MCP runtime
+- Approval boundary: safe for read-only analytics retrieval; require human approval before combining this connector with workflows that write to external systems
+
 ## Before you start
 
 1. Confirm GA4 property ID.

--- a/tools-mcp/analytics/ga4-mcp-connector/tool.yaml
+++ b/tools-mcp/analytics/ga4-mcp-connector/tool.yaml
@@ -25,6 +25,17 @@ entrypoints:
 dependencies:
   mcp_servers:
     - ga4
+operational:
+  connected_system: Google Analytics 4
+  capabilities:
+    - Pull sessions, users, conversions, and revenue by allowed dimensions.
+    - Query fixed date windows for period comparisons and dashboard inputs.
+    - Return normalized analytics payloads for downstream skills and agents.
+  auth_required:
+    - GA4 property access via authenticated MCP runtime
+  access_level: read-only
+  trust_boundary: remote-mcp-server
+  approval_boundary: Safe for read-only analytics retrieval; require human approval before combining with any workflow that writes back to ad platforms or reporting systems.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/tools-mcp/warehouse/bigquery-mcp-query-runner/README.md
+++ b/tools-mcp/warehouse/bigquery-mcp-query-runner/README.md
@@ -18,6 +18,14 @@ through MCP.
 - Enforces read-only query behavior.
 - Returns typed rows for analytics skills and agents.
 
+## Operational metadata
+
+- Connected system: Google BigQuery
+- Access level: read-only
+- Trust boundary: remote MCP server
+- Auth required: authenticated dataset access in your MCP runtime
+- Approval boundary: safe for parameterized read-only queries; require human approval before broadening dataset scope or enabling any non-read-only SQL path
+
 ## Before you start
 
 1. Confirm dataset/table access.

--- a/tools-mcp/warehouse/bigquery-mcp-query-runner/tool.yaml
+++ b/tools-mcp/warehouse/bigquery-mcp-query-runner/tool.yaml
@@ -25,6 +25,17 @@ entrypoints:
 dependencies:
   mcp_servers:
     - bigquery
+operational:
+  connected_system: Google BigQuery
+  capabilities:
+    - Execute parameterized read-only SQL templates for analytics workflows.
+    - Return typed warehouse rows for BI transformations and reporting.
+    - Enforce query guardrails such as timeout, limits, and statement restrictions.
+  auth_required:
+    - BigQuery dataset access via authenticated MCP runtime
+  access_level: read-only
+  trust_boundary: remote-mcp-server
+  approval_boundary: Safe for parameterized read-only queries; require human approval before broadening dataset scope or enabling any non-read-only SQL path.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false


### PR DESCRIPTION
## Summary

This PR completes a cross-module operational metadata rollout across the catalog and aligns the detail-page UX around a shared decision-making model.

The main goal was to make every module answer the same practical questions more clearly:

- what this entry does
- when to use it
- what it depends on
- what permissions or trust boundary it crosses
- what outputs it produces
- what approval boundary applies

This work now covers:

- `tools-mcp`
- `agents`
- `skills`

Plugins were already ahead of the other modules and now fit into the same broader model.

---

## What changed

### 1. Tools / MCP operational metadata

Added tool-level operational metadata support across schema, registry, and UI:

- `connected_system`
- `capabilities`
- `auth_required`
- `access_level`
- `trust_boundary`
- `approval_boundary`

Also surfaced existing manifest dependencies in the registry/UI:
- `mcp_servers`
- `apis`
- `tools`

All 3 current tool entries were backfilled with this metadata.

Tool detail pages now show:
- `Operational Summary`
- `Status`
- `Runtime & Dependencies`
- `Dependencies & Setup`
- `Capabilities`
- `Latest Version`

---

### 2. Agent operational metadata

Added agent-level operational metadata support:

- `role`
- `coordinates`
- `autonomy_level`
- `approval_boundary`
- `outputs`

Also fixed dependency propagation so agent manifests now carry through to the registry/UI for:
- `skills`
- `tools`
- `apis`

All 3 current agents were backfilled with this metadata.

Agent detail pages now show:
- `Operational Summary`
- `Status`
- `Runtime & Dependencies`
- `Coordinates`
- `Outputs`
- `Dependencies`
- `Latest Version`

---

### 3. Skill operational metadata

Added skill-level operational metadata support:

- `use_when`
- `execution_mode`
- `outputs`
- `approval_boundary`

Backfilled all `30` current skill manifests with a first-pass operational block.

Skill detail pages now show:
- `Operational Summary`
- `Status`
- `Runtime & Dependencies`
- `Dependencies`
- `Outputs`

This is the biggest practical improvement for the skills catalog because the previous detail pages were still relatively shallow.

---

### 4. Detail page normalization

The detail views for `skills`, `agents`, and `tools-mcp` now follow a more consistent panel order:

1. `Operational Summary`
2. `Status`
3. `Runtime & Dependencies`
4. module-specific behavior panels
5. `Latest Version` where applicable

This makes the catalog feel more coherent as a product rather than a collection of separate page styles.

---

### 5. Docs updated

Updated documentation to define and explain the cross-module metadata model:

- `README.md`
- `docs/architecture-modules.md`

This now documents the current rollout state:

- tools: implemented
- agents: implemented
- skills: implemented

---

### 6. Stronger verification / smoke coverage

Extended the existing smoke coverage so the new operational metadata UI is actually guarded in CI.

Added/updated assertions for:

#### Skills
- `Operational Summary`
- `Outputs`
- sample execution-mode text

#### Agents
- `Operational Summary`
- `Coordinates`
- sample autonomy-level text

#### Tools
- `Operational Summary`
- `Capabilities`
- sample trust-boundary text

This ensures the rollout is not just schema-deep; the surfaced UI is also now part of the smoke contract.

---

## Files changed

### Schemas
- `shared/schemas/skill.schema.json`
- `shared/schemas/agent.schema.json`
- `shared/schemas/tool.schema.json`
- `shared/schemas/registry-index.schema.json`

### Registry parsing / generation
- `internal/registry/types.go`
- `internal/registry/manifest_parser.go`
- `internal/registry/builder.go`

### Registry tests
- `internal/registry/manifest_parser_test.go`
- `internal/registry/builder_test.go`

### Web
- `apps/web/lib/registry.ts`
- `apps/web/app/skills/[...id]/page.tsx`
- `apps/web/app/agents/[...id]/page.tsx`
- `apps/web/app/tools-mcp/[...id]/page.tsx`
- `apps/web/e2e/smoke.spec.ts`

### Content backfill
- all 3 `tools-mcp/*/*/tool.yaml`
- all 3 `tools-mcp/*/*/README.md`
- all 3 `agents/*/*/agent.yaml`
- all 3 `agents/*/*/README.md`
- all 30 `skills/*/*/skill.yaml`

### Docs
- `README.md`
- `docs/architecture-modules.md`

### Generated outputs
- `registry/skills-index.json`
- `registry/agents-index.json`
- `registry/tools-index.json`
- `registry/plugins-index.json`
- `registry/index.json`

---

## Validation

Passed locally:

- `GOCACHE=/tmp/go-build GOTMPDIR=/tmp go run ./cmd/registry-builder`
- `GOCACHE=/tmp/go-build GOTMPDIR=/tmp go test ./internal/registry ./cmd/registry-builder ./cmd/skills-hub ./internal/installer ./internal/plugins`
- `bash scripts/validate-manifests.sh`
- `rm -rf apps/web/.next && pnpm --dir apps/web build`

Additional check:
- verified `30/30` skill manifests now include the new `operational` block

---

## Why this matters

Before this PR, plugins had become the clearest module in the catalog, but the base modules still left too many practical questions unanswered:

- what exactly does this do?
- is it read-only or not?
- what does it depend on?
- what trust boundary does it cross?
- what can it output?
- what requires approval?

After this PR, `skills`, `agents`, and `tools-mcp` all answer those questions more consistently in both:
- manifest/registry data
- detail-page UI

This is a structural improvement to catalog usability, not just a copy pass.

