### PR TITLE
Add ad-platform security pack for governed marketing agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The first rollouts are on `tools-mcp` and `agents`.
 
 ## Current Scope
 
-### Skills (32)
+### Skills (34)
 
 1. `meta-google-weekly-performance-review` (Beginner)
 2. `creative-workshop-pmax-reels` (Intermediate)
@@ -102,20 +102,24 @@ The first rollouts are on `tools-mcp` and `agents`.
 30. `agentops/harness-regression-evaluator` (Harness Evaluation)
 31. `agentops/agent-control-plane-review` (Harness Governance)
 32. `security/marketing-agent-risk-review` (Runtime Hardening)
+33. `security/ad-platform-agent-auth-review` (Runtime Hardening)
+34. `agentops/ad-platform-policy-gate-designer` (Harness Governance)
 
-### Agents (4)
+### Agents (5)
 
 1. `marketing/weekly-performance-supervisor`
 2. `marketing/campaign-qa-supervisor`
 3. `adtech/bi-insights-orchestrator`
 4. `agentops/agent-control-plane-supervisor`
+5. `adtech/ad-platform-control-plane-supervisor`
 
-### Tools & MCP (4)
+### Tools & MCP (5)
 
 1. `analytics/ga4-mcp-connector`
 2. `ads/meta-ads-mcp-connector`
 3. `warehouse/bigquery-mcp-query-runner`
 4. `agentops/agent-control-plane-server`
+5. `adtech/ad-platform-executor-template`
 
 ### Plugins (9)
 
@@ -172,6 +176,10 @@ The first rollouts are on `tools-mcp` and `agents`.
 - `security/marketing-agent-risk-review`
 - `agentops/agent-control-plane-supervisor`
 - `agentops/agent-control-plane-server`
+- `security/ad-platform-agent-auth-review`
+- `agentops/ad-platform-policy-gate-designer`
+- `adtech/ad-platform-control-plane-supervisor`
+- `adtech/ad-platform-executor-template`
 
 ## Definition of done for each module entry
 

--- a/agents/adtech/ad-platform-control-plane-supervisor/AGENT.md
+++ b/agents/adtech/ad-platform-control-plane-supervisor/AGENT.md
@@ -1,0 +1,68 @@
+# Ad Platform Control Plane Supervisor
+
+## Role
+
+This agent supervises readiness for DV360, Google Ads, and adjacent ad-platform agents. It is intended for workflows where an agent can read campaign state, propose changes, and potentially execute approved writes through a narrow executor.
+
+It is advisory. It does not grant credentials, approve live changes, or execute platform writes.
+
+## Workflow
+
+1. Intake the agent design.
+   - Capture platform, credential model, workspace boundaries, actions, tool list, approval flow, and audit state.
+
+2. Run `security/ad-platform-agent-auth-review`.
+   - Classify OAuth, service identity, token storage, workspace isolation, and read/write separation risk.
+
+3. Run `agentops/ad-platform-policy-gate-designer`.
+   - Create action thresholds, approval rules, deny rules, bounded grant fields, and audit evidence requirements.
+
+4. Check executor readiness.
+   - Confirm write actions go through `adtech/ad-platform-executor-template` or an equivalent executor.
+   - Confirm executor can validate current state, queue same-entity writes, verify post-write state, and store rollback evidence.
+
+5. Produce a readiness decision.
+   - Read-only safe.
+   - Plan-only only.
+   - Approval-gated writes possible.
+   - Blocked until controls are added.
+
+## Output format
+
+```md
+# Ad Platform Control Plane Supervisor Report
+
+## Decision
+Read-only safe / Plan-only only / Approval-gated writes possible / Blocked
+
+## Summary
+Short explanation grounded in the evidence.
+
+## Auth and trust-zone findings
+| Area | Status | Required change |
+| --- | --- | --- |
+
+## Policy gates
+| Action | Auto-execute | Approval required | Deny when |
+| --- | --- | --- | --- |
+
+## Executor readiness
+- [ ] Structured change plans only
+- [ ] Scoped execution grants
+- [ ] Current-state validation
+- [ ] Same-entity queueing
+- [ ] Post-write verification
+- [ ] Rollback patch
+- [ ] Audit event
+
+## Required before production writes
+1. ...
+```
+
+## Guardrails
+
+- Do not recommend direct LLM access to ad-platform write credentials.
+- Do not approve live bid, budget, targeting, audience, tracking, or feed changes.
+- Treat personal OAuth used for agent writes as a risk unless mediated by brokered access and scoped execution grants.
+- Block production writes when policy enforcement, approval records, or rollback evidence are missing.
+- Recommend read-only or plan-only mode when platform permissions or scopes are unclear.

--- a/agents/adtech/ad-platform-control-plane-supervisor/README.md
+++ b/agents/adtech/ad-platform-control-plane-supervisor/README.md
@@ -1,0 +1,5 @@
+# Ad Platform Control Plane Supervisor
+
+An advisory supervisor agent for teams building DV360, Google Ads, and related ad-platform automation.
+
+It coordinates authentication review, policy gate design, executor readiness, approval mapping, audit requirements, and rollback planning.

--- a/agents/adtech/ad-platform-control-plane-supervisor/agent.yaml
+++ b/agents/adtech/ad-platform-control-plane-supervisor/agent.yaml
@@ -1,0 +1,52 @@
+id: adtech/ad-platform-control-plane-supervisor
+name: Ad Platform Control Plane Supervisor
+description: Advisory supervisor for DV360 and Google Ads agents, coordinating auth review, policy gates, executor readiness, approvals, audit, and rollback planning.
+version: 0.1.0
+released_at: "2026-05-06T00:00:00Z"
+category: adtech-agents/governance
+tags:
+  - adtech
+  - control-plane
+  - dv360
+  - google-ads
+  - governance
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: AGENT.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  skills:
+    - security/ad-platform-agent-auth-review
+    - agentops/ad-platform-policy-gate-designer
+    - agentops/agent-control-plane-review
+  tools:
+    - ad_platform_executor_template
+    - agent_control_plane_server
+operational:
+  role: Governance supervisor for ad-platform agents that read, propose, approve, and execute campaign changes.
+  coordinates:
+    - Ad-platform auth review
+    - Policy gate design
+    - Executor-readiness review
+    - Audit and rollback checklist
+  autonomy_level: advisory
+  approval_boundary: May recommend readiness and governance changes; must not approve live writes, grant credentials, or execute ad-platform changes.
+  outputs:
+    - Deployment readiness decision
+    - Auth and policy gap list
+    - Approval map
+    - Executor and rollback checklist
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/agents/adtech/ad-platform-control-plane-supervisor/config/governance.example.json
+++ b/agents/adtech/ad-platform-control-plane-supervisor/config/governance.example.json
@@ -1,0 +1,19 @@
+{
+  "default_mode": "plan_only",
+  "allowed_modes": ["read_only", "plan_only", "approval_gated_writes"],
+  "blocked_without": [
+    "brokered_credentials",
+    "read_write_separation",
+    "policy_engine",
+    "approval_records_for_high_risk_actions",
+    "audit_and_rollback"
+  ],
+  "high_risk_actions": [
+    "budget_increase",
+    "bid_increase_above_threshold",
+    "targeting_broadening",
+    "audience_expansion",
+    "tracking_change",
+    "product_feed_publish"
+  ]
+}

--- a/agents/adtech/ad-platform-control-plane-supervisor/examples/input.json
+++ b/agents/adtech/ad-platform-control-plane-supervisor/examples/input.json
@@ -1,0 +1,10 @@
+{
+  "agent_name": "google-ads-budget-agent",
+  "platforms": ["Google Ads", "BigQuery"],
+  "credential_model": "user_oauth_via_backend",
+  "actions": ["read_campaign_state", "propose_budget_shift", "apply_budget_shift"],
+  "workspace_scope": "one client, three Google Ads accounts",
+  "approval_flow": "approval required above 10 percent budget increase",
+  "executor": "custom API service, no rollback patch yet",
+  "audit": "records proposed change and API response"
+}

--- a/agents/adtech/ad-platform-control-plane-supervisor/examples/output.json
+++ b/agents/adtech/ad-platform-control-plane-supervisor/examples/output.json
@@ -1,0 +1,14 @@
+{
+  "decision": "plan-only only",
+  "summary": "The workflow has useful planning capability, but approval-gated writes should wait until brokered credentials, executor rollback, and full audit evidence are implemented.",
+  "required_before_production_writes": [
+    "Map user OAuth grants to workspace-scoped internal execution grants.",
+    "Separate read-only campaign analysis tools from write-capable executor tools.",
+    "Add rollback patch generation to the executor.",
+    "Record policy decision, approver, execution grant, API payload, and post-write verification."
+  ],
+  "recommended_policy_gates": [
+    {"action": "budget_increase", "auto_execute": false, "approval_required": "always", "deny_when": "daily delta exceeds configured ceiling"},
+    {"action": "budget_decrease", "auto_execute": "below threshold", "approval_required": "above threshold", "deny_when": "campaign is in protected launch window"}
+  ]
+}

--- a/agents/adtech/ad-platform-control-plane-supervisor/tests/test-prompts.md
+++ b/agents/adtech/ad-platform-control-plane-supervisor/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Supervise readiness for a DV360 line-item agent that can propose and apply targeting diffs.
+2. Decide whether a Google Ads budget agent with user OAuth and no rollback can move to approval-gated writes.
+3. Produce an approval map for an agent that changes bids, budgets, audiences, and campaign status.
+4. Review executor readiness for a platform service that applies approved campaign changes but does not queue same-entity writes.
+5. Create a production-readiness checklist for a multi-client ad-platform agent control plane.

--- a/registry/agents-index.json
+++ b/registry/agents-index.json
@@ -1,7 +1,66 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-04-26T00:00:00Z",
+  "generated_at": "2026-05-06T00:00:00Z",
   "skills": [
+    {
+      "id": "adtech/ad-platform-control-plane-supervisor",
+      "name": "Ad Platform Control Plane Supervisor",
+      "description": "Advisory supervisor for DV360 and Google Ads agents, coordinating auth review, policy gates, executor readiness, approvals, audit, and rollback planning.",
+      "category": "adtech-agents/governance",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-05-06T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/agents/adtech/ad-platform-control-plane-supervisor/agent.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/ad-platform-control-plane-supervisor/0.1.0.tar.gz",
+          "sha256": "448631cfba43166109009a9860aba98cb5073c0fa4bc714cbd74e93324b4d726"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "adtech",
+        "control-plane",
+        "dv360",
+        "google-ads",
+        "governance"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May recommend readiness and governance changes; must not approve live writes, grant credentials, or execute ad-platform changes.",
+        "role": "Governance supervisor for ad-platform agents that read, propose, approve, and execute campaign changes.",
+        "coordinates": [
+          "Ad-platform auth review",
+          "Policy gate design",
+          "Executor-readiness review",
+          "Audit and rollback checklist"
+        ],
+        "autonomy_level": "advisory",
+        "outputs": [
+          "Deployment readiness decision",
+          "Auth and policy gap list",
+          "Approval map",
+          "Executor and rollback checklist"
+        ]
+      },
+      "dependencies": {
+        "skills": [
+          "security/ad-platform-agent-auth-review",
+          "agentops/ad-platform-policy-gate-designer",
+          "agentops/agent-control-plane-review"
+        ],
+        "tools": [
+          "ad_platform_executor_template",
+          "agent_control_plane_server"
+        ]
+      }
+    },
     {
       "id": "adtech/bi-insights-orchestrator",
       "name": "BI Insights Orchestrator",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,6 +1,6 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-04-26T00:00:00Z",
+  "generated_at": "2026-05-06T00:00:00Z",
   "skills": [
     {
       "id": "adtech/analyst-copilot-bigquery-redshift",
@@ -413,6 +413,48 @@
         "tools": [
           "python3"
         ]
+      }
+    },
+    {
+      "id": "agentops/ad-platform-policy-gate-designer",
+      "name": "Ad Platform Policy Gate Designer",
+      "description": "Design policy gates, approval thresholds, deny rules, and bounded execution rules for marketing agents that change bids, budgets, targeting, audiences, feeds, or tracking.",
+      "category": "agentops/harness-governance",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-05-06T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/agentops/ad-platform-policy-gate-designer/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/agentops/ad-platform-policy-gate-designer/0.1.0.tar.gz",
+          "sha256": "21915f623744e408439a1197579920e3d1c47505f177749ebb02a44a5aa4808a"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "adtech",
+        "policy",
+        "approvals",
+        "dv360",
+        "google-ads"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Analysis-only; must not change live policy, approve campaign changes, or execute platform writes.",
+        "outputs": [
+          "Policy gate table",
+          "Approval threshold map",
+          "Deny rule set",
+          "Audit evidence checklist"
+        ],
+        "use_when": "Use when defining what an ad-platform agent may auto-execute, what requires approval, and what must be denied.",
+        "execution_mode": "analysis-only"
       }
     },
     {
@@ -1194,6 +1236,48 @@
         "tools": [
           "python3"
         ]
+      }
+    },
+    {
+      "id": "security/ad-platform-agent-auth-review",
+      "name": "Ad Platform Agent Auth Review",
+      "description": "Review DV360, Google Ads, and similar ad-platform agents for personal OAuth risk, workspace scoping, token storage, read/write separation, and approval readiness.",
+      "category": "security/runtime-hardening",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-05-06T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/security/ad-platform-agent-auth-review/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/security/ad-platform-agent-auth-review/0.1.0.tar.gz",
+          "sha256": "bd3088243aefcbfec577a438cf1fbd08d2850f0c4fa9da114b18545b74835f9f"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "adtech",
+        "oauth",
+        "google-ads",
+        "dv360",
+        "auth-review"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Analysis-only; must not create tokens, change OAuth scopes, approve access, or execute ad-platform writes.",
+        "outputs": [
+          "Authentication risk report",
+          "Trust-zone recommendation",
+          "Read/write separation checklist",
+          "Approval-gated execution recommendation"
+        ],
+        "use_when": "Use before an agent reads or writes to DV360, Google Ads, Meta Ads, product feeds, or commerce/analytics APIs using OAuth or service credentials.",
+        "execution_mode": "analysis-only"
       }
     },
     {

--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -1,6 +1,6 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-04-26T00:00:00Z",
+  "generated_at": "2026-05-06T00:00:00Z",
   "skills": [
     {
       "id": "adtech/analyst-copilot-bigquery-redshift",
@@ -413,6 +413,48 @@
         "tools": [
           "python3"
         ]
+      }
+    },
+    {
+      "id": "agentops/ad-platform-policy-gate-designer",
+      "name": "Ad Platform Policy Gate Designer",
+      "description": "Design policy gates, approval thresholds, deny rules, and bounded execution rules for marketing agents that change bids, budgets, targeting, audiences, feeds, or tracking.",
+      "category": "agentops/harness-governance",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-05-06T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/agentops/ad-platform-policy-gate-designer/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/agentops/ad-platform-policy-gate-designer/0.1.0.tar.gz",
+          "sha256": "21915f623744e408439a1197579920e3d1c47505f177749ebb02a44a5aa4808a"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "adtech",
+        "policy",
+        "approvals",
+        "dv360",
+        "google-ads"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Analysis-only; must not change live policy, approve campaign changes, or execute platform writes.",
+        "outputs": [
+          "Policy gate table",
+          "Approval threshold map",
+          "Deny rule set",
+          "Audit evidence checklist"
+        ],
+        "use_when": "Use when defining what an ad-platform agent may auto-execute, what requires approval, and what must be denied.",
+        "execution_mode": "analysis-only"
       }
     },
     {
@@ -1194,6 +1236,48 @@
         "tools": [
           "python3"
         ]
+      }
+    },
+    {
+      "id": "security/ad-platform-agent-auth-review",
+      "name": "Ad Platform Agent Auth Review",
+      "description": "Review DV360, Google Ads, and similar ad-platform agents for personal OAuth risk, workspace scoping, token storage, read/write separation, and approval readiness.",
+      "category": "security/runtime-hardening",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-05-06T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/security/ad-platform-agent-auth-review/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/security/ad-platform-agent-auth-review/0.1.0.tar.gz",
+          "sha256": "bd3088243aefcbfec577a438cf1fbd08d2850f0c4fa9da114b18545b74835f9f"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "adtech",
+        "oauth",
+        "google-ads",
+        "dv360",
+        "auth-review"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Analysis-only; must not create tokens, change OAuth scopes, approve access, or execute ad-platform writes.",
+        "outputs": [
+          "Authentication risk report",
+          "Trust-zone recommendation",
+          "Read/write separation checklist",
+          "Approval-gated execution recommendation"
+        ],
+        "use_when": "Use before an agent reads or writes to DV360, Google Ads, Meta Ads, product feeds, or commerce/analytics APIs using OAuth or service credentials.",
+        "execution_mode": "analysis-only"
       }
     },
     {

--- a/registry/tools-index.json
+++ b/registry/tools-index.json
@@ -1,6 +1,6 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-04-26T00:00:00Z",
+  "generated_at": "2026-05-06T00:00:00Z",
   "skills": [
     {
       "id": "ads/meta-ads-mcp-connector",
@@ -47,6 +47,65 @@
       "dependencies": {
         "mcp_servers": [
           "meta-ads"
+        ]
+      }
+    },
+    {
+      "id": "adtech/ad-platform-executor-template",
+      "name": "Ad Platform Executor Template",
+      "description": "MCP/tool template for a narrow DV360 and Google Ads executor that applies only approved, policy-checked campaign changes and records rollback evidence.",
+      "category": "tools-mcp/adtech",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-05-06T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/adtech/ad-platform-executor-template/tool.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/ad-platform-executor-template/0.1.0.tar.gz",
+          "sha256": "70173ebda5b24505a2635153a2db1b16fe21f724a4945d38c3f846224ca63b0e"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "adtech",
+        "executor",
+        "dv360",
+        "google-ads",
+        "rollback"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "connected_system": "DV360 and Google Ads API execution layer",
+        "capabilities": [
+          "Read current campaign or line item state before execution.",
+          "Validate approved change plans against policy and current platform state.",
+          "Apply bounded bid, budget, targeting, or status changes.",
+          "Verify post-write state and create rollback patches."
+        ],
+        "auth_required": [
+          "Brokered Google API credentials",
+          "Scoped execution grant",
+          "Approval token for medium and high-risk writes"
+        ],
+        "access_level": "read-write",
+        "trust_boundary": "remote-mcp-server",
+        "approval_boundary": "Applies only policy-approved bounded writes; high-risk changes require human approval and rollback evidence."
+      },
+      "dependencies": {
+        "tools": [
+          "authorization_broker",
+          "policy_engine",
+          "audit_log"
+        ],
+        "apis": [
+          "Google Ads API",
+          "Display \u0026 Video 360 API"
         ]
       }
     },

--- a/shared/policies/ad-platform/policy.example.json
+++ b/shared/policies/ad-platform/policy.example.json
@@ -1,0 +1,33 @@
+{
+  "policy_version": "ad-platform-control-plane-v0.1",
+  "default_effect": "deny",
+  "rules": [
+    {
+      "id": "read-aggregate-state-allow",
+      "when": {"access": "read", "data_class": "aggregate_campaign_state"},
+      "effect": "allow"
+    },
+    {
+      "id": "small-bid-decrease-auto-allow",
+      "when": {"action": "apply_bid_delta", "delta_percent_lte": 5, "direction": "decrease"},
+      "effect": "allow"
+    },
+    {
+      "id": "budget-increase-requires-approval",
+      "when": {"action": "increase_budget"},
+      "effect": "allow_with_approval",
+      "approval_role": "channel_owner"
+    },
+    {
+      "id": "targeting-broadening-requires-approval",
+      "when": {"action": "broaden_targeting"},
+      "effect": "allow_with_approval",
+      "approval_role": "activation_lead"
+    },
+    {
+      "id": "cross-workspace-write-deny",
+      "when": {"scope_violation": "workspace_mismatch"},
+      "effect": "deny"
+    }
+  ]
+}

--- a/shared/schemas/ad-platform/audit-event.schema.json
+++ b/shared/schemas/ad-platform/audit-event.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Ad Platform Audit Event",
+  "type": "object",
+  "required": ["event_id", "plan_id", "agent_id", "platform", "workspace_id", "advertiser_id", "status", "timestamp", "policy_decision"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "plan_id": {"type": "string"},
+    "agent_id": {"type": "string"},
+    "platform": {"type": "string"},
+    "workspace_id": {"type": "string"},
+    "advertiser_id": {"type": "string"},
+    "entity_type": {"type": "string"},
+    "entity_id": {"type": "string"},
+    "status": {"type": "string", "enum": ["proposed", "validated", "approved", "executed", "rejected", "failed", "rolled_back"]},
+    "policy_decision": {"type": "string"},
+    "approval_id": {"type": "string"},
+    "execution_grant_id": {"type": "string"},
+    "api_request_id": {"type": "string"},
+    "pre_image_hash": {"type": "string"},
+    "post_image_hash": {"type": "string"},
+    "rollback_patch_id": {"type": "string"},
+    "timestamp": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": true
+}

--- a/shared/schemas/ad-platform/change-plan.schema.json
+++ b/shared/schemas/ad-platform/change-plan.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Ad Platform Change Plan",
+  "type": "object",
+  "required": ["plan_id", "agent_id", "platform", "workspace_id", "advertiser_id", "entity_type", "entity_id", "action", "proposed_diff", "risk_tier"],
+  "properties": {
+    "plan_id": {"type": "string"},
+    "agent_id": {"type": "string"},
+    "platform": {"type": "string", "enum": ["google_ads", "dv360", "meta_ads", "merchant_center", "other"]},
+    "workspace_id": {"type": "string"},
+    "advertiser_id": {"type": "string"},
+    "entity_type": {"type": "string"},
+    "entity_id": {"type": "string"},
+    "action": {"type": "string"},
+    "current_state_hash": {"type": "string"},
+    "proposed_diff": {"type": "object"},
+    "expected_impact": {"type": "string"},
+    "rationale": {"type": "string"},
+    "risk_tier": {"type": "string", "enum": ["low", "medium", "high", "blocked"]},
+    "requires_approval": {"type": "boolean"}
+  },
+  "additionalProperties": true
+}

--- a/skills/agentops/ad-platform-policy-gate-designer/README.md
+++ b/skills/agentops/ad-platform-policy-gate-designer/README.md
@@ -1,0 +1,5 @@
+# Ad Platform Policy Gate Designer
+
+A governance skill for translating campaign-risk rules into concrete policy gates for ad-platform agents.
+
+It produces threshold tables, approval maps, deny rules, bounded-grant fields, and audit requirements for DV360, Google Ads, and adjacent marketing platforms.

--- a/skills/agentops/ad-platform-policy-gate-designer/SKILL.md
+++ b/skills/agentops/ad-platform-policy-gate-designer/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: ad-platform-policy-gate-designer
+description: Design approval gates, auto-execution thresholds, deny rules, and audit requirements for DV360, Google Ads, and ad-platform agent writes.
+---
+
+# Ad Platform Policy Gate Designer
+
+## When to use
+
+Use this skill when a team needs concrete governance rules for an agent that can propose or execute ad-platform changes.
+
+Typical triggers:
+
+- "What Google Ads actions can this agent auto-execute?"
+- "Which DV360 changes need human approval?"
+- "Design policy gates for bid, budget, and targeting changes."
+- "Create deny rules for regulated categories or sensitive markets."
+- "Turn our campaign-risk policy into executable thresholds."
+
+## Inputs required
+
+Collect:
+
+- Platforms and entity types: account, advertiser, campaign, insertion order, line item, ad group, keyword, audience, feed item.
+- Action types: bid, budget, status, targeting, audience, creative, feed, tracking.
+- Business context: client, market, spend tier, regulated category, SLA.
+- Existing approval owners and escalation paths.
+- Risk thresholds: budget delta, bid delta, audience expansion, geo expansion, pacing variance.
+- Rollback and audit requirements.
+
+## Workflow
+
+1. Classify actions by risk.
+   - Low: read-only, recommendation-only, status summaries, small reversible bid changes.
+   - Medium: bounded bid/budget edits, narrow targeting edits, non-publishing feed drafts.
+   - High: budget increases, targeting broadening, audience expansion, live publishing, tracking changes.
+   - Blocked: cross-client actions, unscoped exports, forbidden categories, policy overrides by agent.
+
+2. Convert risk into gates.
+   - Auto-execute only when action is low risk, scoped, reversible, and below thresholds.
+   - Route medium/high risk to named approvers.
+   - Deny actions that violate scope or organisational policy.
+
+3. Define bounded execution grants.
+   - Include workspace, platform, advertiser, entity, allowed action, max delta, expiry, and approval id.
+
+4. Define audit evidence.
+   - Require current state, proposed diff, policy decision, approval decision, execution payload, post-write state, and rollback patch.
+
+5. Produce implementation-ready policy tables.
+
+## Output format
+
+```md
+# Ad Platform Policy Gates
+
+## Risk model
+| Risk tier | Definition | Examples |
+| --- | --- | --- |
+
+## Policy gates
+| Action | Auto-execute | Approval required | Deny when | Audit evidence |
+| --- | --- | --- | --- | --- |
+
+## Thresholds
+| Metric | Low-risk range | Approval threshold | Block threshold |
+| --- | --- | --- | --- |
+
+## Bounded grant fields
+- workspace_id
+- platform
+- advertiser_id
+- entity_type
+- entity_id
+- allowed_action
+- max_delta
+- expires_at
+- approval_id
+
+## Engineering notes
+1. ...
+```
+
+## Guardrails
+
+- Do not approve or execute live campaign changes.
+- Do not make policy less strict than the user's stated organisational baseline.
+- Treat missing client/workspace/advertiser scoping as a blocker for auto-execution.
+- Require approval for targeting expansion, budget increases, tracking changes, and regulated-category changes by default.
+- Recommend denial when rollback or post-write verification is unavailable for risky writes.

--- a/skills/agentops/ad-platform-policy-gate-designer/examples/output.json
+++ b/skills/agentops/ad-platform-policy-gate-designer/examples/output.json
@@ -1,0 +1,13 @@
+{
+  "risk_model": {
+    "low": "Read-only or small reversible changes inside scoped workspace thresholds.",
+    "medium": "Bounded writes that affect delivery or pacing but have rollback support.",
+    "high": "Budget increases, targeting expansion, tracking changes, publishing, or sensitive categories.",
+    "blocked": "Cross-client writes, unscoped exports, missing rollback for risky writes, or policy overrides."
+  },
+  "thresholds": [
+    {"metric": "bid_delta", "low_risk": "<= 5% decrease or <= 3% increase", "approval": "> low-risk threshold", "block": "> 20%"},
+    {"metric": "budget_increase", "low_risk": "none", "approval": "any increase", "block": "> 20% daily delta"}
+  ],
+  "bounded_grant_required_fields": ["workspace_id", "platform", "advertiser_id", "entity_type", "entity_id", "allowed_action", "max_delta", "expires_at", "approval_id"]
+}

--- a/skills/agentops/ad-platform-policy-gate-designer/examples/policy-table.md
+++ b/skills/agentops/ad-platform-policy-gate-designer/examples/policy-table.md
@@ -1,0 +1,9 @@
+# Example Policy Gates
+
+| Action | Auto-execute | Approval required | Deny when |
+| --- | --- | --- | --- |
+| Bid decrease | <= 5% and reversible | > 5% | Entity not scoped to workspace |
+| Bid increase | <= 3% on low-spend entity | > 3% | Sensitive category without owner approval |
+| Budget increase | Never by default | Any increase | > 20% daily delta |
+| Targeting narrowing | <= approved taxonomy | Broad taxonomy change | Cross-client audience use |
+| Targeting broadening | Never by default | Any broadening | Regulated or sensitive market without specialist approval |

--- a/skills/agentops/ad-platform-policy-gate-designer/skill.yaml
+++ b/skills/agentops/ad-platform-policy-gate-designer/skill.yaml
@@ -1,0 +1,40 @@
+id: agentops/ad-platform-policy-gate-designer
+name: Ad Platform Policy Gate Designer
+description: Design policy gates, approval thresholds, deny rules, and bounded execution rules for marketing agents that change bids, budgets, targeting, audiences, feeds, or tracking.
+version: 0.1.0
+released_at: "2026-05-06T00:00:00Z"
+category: agentops/harness-governance
+tags:
+  - adtech
+  - policy
+  - approvals
+  - dv360
+  - google-ads
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+operational:
+  use_when: Use when defining what an ad-platform agent may auto-execute, what requires approval, and what must be denied.
+  execution_mode: analysis-only
+  outputs:
+    - Policy gate table
+    - Approval threshold map
+    - Deny rule set
+    - Audit evidence checklist
+  approval_boundary: Analysis-only; must not change live policy, approve campaign changes, or execute platform writes.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/agentops/ad-platform-policy-gate-designer/tests/test-prompts.md
+++ b/skills/agentops/ad-platform-policy-gate-designer/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Design policy gates for a Google Ads agent that can propose bid changes, pause keywords, and increase campaign budgets.
+2. Create approval thresholds for a DV360 line-item optimisation agent that may narrow or broaden targeting.
+3. Define deny rules for an agent working across regulated healthcare campaigns in multiple markets.
+4. Turn this policy into bounded execution-grant fields for a campaign budget shift workflow.
+5. Build an audit checklist for an agent that can apply approved targeting diffs through an executor service.

--- a/skills/security/ad-platform-agent-auth-review/README.md
+++ b/skills/security/ad-platform-agent-auth-review/README.md
@@ -1,0 +1,5 @@
+# Ad Platform Agent Auth Review
+
+A review skill for DV360, Google Ads, and other marketing agents that need platform credentials.
+
+It helps teams identify personal OAuth risk, broad advertiser access, weak token storage, missing read/write separation, and missing approval gates before an agent receives write access.

--- a/skills/security/ad-platform-agent-auth-review/SKILL.md
+++ b/skills/security/ad-platform-agent-auth-review/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: ad-platform-agent-auth-review
+description: Review DV360, Google Ads, and similar marketing agents for unsafe OAuth, broad platform access, weak token handling, missing read/write separation, and missing approval gates.
+---
+
+# Ad Platform Agent Auth Review
+
+## When to use
+
+Use this skill when a team is building or reviewing an agent that connects to DV360, Google Ads, Meta Ads, Merchant Center, product feeds, analytics warehouses, or other marketing platforms with OAuth, API keys, or service credentials.
+
+Typical triggers:
+
+- "Our agent uses a user's Google OAuth token; is that safe?"
+- "Can this DV360 agent move from read-only to write access?"
+- "How should we scope Google Ads access for an optimisation agent?"
+- "What auth risks exist before this agent changes bids, budgets, or targeting?"
+- "Should this agent use personal OAuth, service account, or brokered access?"
+
+## Inputs required
+
+Collect:
+
+- Platforms connected: DV360, Google Ads, Meta Ads, Merchant Center, warehouse, CRM, CMS.
+- Credential type: personal OAuth, service account, API key, app token, internal execution grant.
+- Requested scopes and actual platform permissions.
+- Advertiser/workspace/client mapping.
+- Actions: read, propose, approve, execute, rollback.
+- Token storage location and rotation process.
+- Whether the LLM can see tokens, tool outputs, or raw API credentials.
+- Current approval and audit flow.
+
+## Workflow
+
+1. Map the credential chain.
+   - Identify who grants access, where refresh credentials live, and which component retrieves execution credentials.
+   - Flag any path where the LLM sees long-lived credentials.
+
+2. Check scope and workspace isolation.
+   - Compare token/platform access with the agent's actual task.
+   - Flag access that crosses client, brand, market, advertiser, or workspace boundaries without explicit mapping.
+
+3. Check identity model.
+   - Identify whether API writes appear as a human user, service identity, or agent-specific identity.
+   - Flag misleading audit trails where a human identity masks an agent action.
+
+4. Check read/write separation.
+   - Confirm read-only analysis and write-capable execution use separate permissions and components.
+   - Flag single-token designs that can both inspect and mutate campaigns.
+
+5. Check approval readiness.
+   - Identify high-risk actions: budget increases, bid changes, targeting expansion, audience edits, product-feed updates, tracking changes, publishing.
+   - Require step-up approval or bounded execution grants for these actions.
+
+6. Check audit and rollback readiness.
+   - Confirm the system records current state, proposed diff, policy decision, approver, execution payload, post-write verification, and rollback patch.
+
+## Output format
+
+```md
+# Ad Platform Agent Auth Review
+
+## Decision
+Read-only safe / Plan-only only / Approval-gated writes possible / Blocked
+
+## Auth risk summary
+- Credential model:
+- Scope fit:
+- Workspace isolation:
+- Token handling:
+- Audit identity:
+
+## Findings
+| Area | Status | Evidence | Required change |
+| --- | --- | --- | --- |
+
+## Recommended trust zone design
+| Zone | Component | Allowed access |
+| --- | --- | --- |
+| User identity | ... | ... |
+| Control plane | ... | ... |
+| Agent runtime | ... | ... |
+| Execution zone | ... | ... |
+
+## Required before write access
+1. ...
+```
+
+## Guardrails
+
+- Do not approve OAuth scopes or platform access.
+- Do not create, rotate, expose, or request secrets.
+- Do not recommend direct LLM access to long-lived refresh tokens, service keys, or API credentials.
+- Treat personal OAuth used for agent writes as a production risk unless mediated by a broker and scoped per workspace.
+- Treat bid, budget, targeting, audience, product-feed, and tracking changes as write-risk actions by default.
+
+## Failure modes
+
+- If scopes are unknown, mark scope fit as unknown and recommend plan-only/read-only mode.
+- If platform permissions exceed the agent task, recommend broker-level scoping before writes.
+- If audit identity records only a human user for agent actions, mark audit identity as partial or misleading.

--- a/skills/security/ad-platform-agent-auth-review/examples/input.json
+++ b/skills/security/ad-platform-agent-auth-review/examples/input.json
@@ -1,0 +1,13 @@
+{
+  "agent_name": "dv360-line-item-optimizer",
+  "platforms": ["DV360", "BigQuery"],
+  "credential_model": "personal_google_oauth",
+  "requested_scopes": ["https://www.googleapis.com/auth/display-video"],
+  "user_access": ["advertiser_uk", "advertiser_fr", "advertiser_de"],
+  "intended_scope": ["advertiser_uk"],
+  "actions": ["read_line_item_state", "propose_bid_delta", "apply_bid_delta"],
+  "token_storage": "backend database, encrypted at rest",
+  "llm_secret_exposure": "no raw token in prompt, tool can call API directly",
+  "approval_flow": "manager approval for budget changes only",
+  "audit": "records API response and user email"
+}

--- a/skills/security/ad-platform-agent-auth-review/examples/output.json
+++ b/skills/security/ad-platform-agent-auth-review/examples/output.json
@@ -1,0 +1,17 @@
+{
+  "decision": "plan-only only",
+  "auth_risk_summary": {
+    "credential_model": "personal OAuth used for write-capable agent flow",
+    "scope_fit": "over-broad for intended advertiser",
+    "workspace_isolation": "missing broker-level mapping",
+    "token_handling": "token stored outside prompt but direct tool access is too broad",
+    "audit_identity": "misleading because writes appear under the human user"
+  },
+  "required_before_write_access": [
+    "Introduce an authorization broker that maps the Google grant to advertiser_uk only.",
+    "Separate read-only tools from write-capable executor tools.",
+    "Require approval for bid deltas above threshold and all targeting expansion.",
+    "Record agent id, proposed diff, policy decision, approver, execution payload, and rollback patch."
+  ],
+  "recommended_mode": "read-only analysis plus structured change proposals until broker and executor are implemented"
+}

--- a/skills/security/ad-platform-agent-auth-review/skill.yaml
+++ b/skills/security/ad-platform-agent-auth-review/skill.yaml
@@ -1,0 +1,40 @@
+id: security/ad-platform-agent-auth-review
+name: Ad Platform Agent Auth Review
+description: Review DV360, Google Ads, and similar ad-platform agents for personal OAuth risk, workspace scoping, token storage, read/write separation, and approval readiness.
+version: 0.1.0
+released_at: "2026-05-06T00:00:00Z"
+category: security/runtime-hardening
+tags:
+  - adtech
+  - oauth
+  - google-ads
+  - dv360
+  - auth-review
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+operational:
+  use_when: Use before an agent reads or writes to DV360, Google Ads, Meta Ads, product feeds, or commerce/analytics APIs using OAuth or service credentials.
+  execution_mode: analysis-only
+  outputs:
+    - Authentication risk report
+    - Trust-zone recommendation
+    - Read/write separation checklist
+    - Approval-gated execution recommendation
+  approval_boundary: Analysis-only; must not create tokens, change OAuth scopes, approve access, or execute ad-platform writes.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/security/ad-platform-agent-auth-review/tests/test-prompts.md
+++ b/skills/security/ad-platform-agent-auth-review/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Review a Google Ads optimisation agent that uses one analyst's OAuth token to read and write across six client accounts.
+2. Assess whether a DV360 agent can safely apply bid changes when it stores refresh tokens in the backend and logs only the user email.
+3. Identify auth risks for a campaign agent that reads BigQuery, writes Google Ads budgets, and has no separate executor service.
+4. Recommend a trust-zone model for an agent that proposes targeting changes but should never see raw Google refresh tokens.
+5. Decide whether a service-account-based Google Ads agent is ready for approval-gated writes when it lacks rollback logging.

--- a/tools-mcp/adtech/ad-platform-executor-template/README.md
+++ b/tools-mcp/adtech/ad-platform-executor-template/README.md
@@ -1,0 +1,5 @@
+# Ad Platform Executor Template
+
+A tool/MCP template for applying approved DV360 and Google Ads changes safely.
+
+This is intentionally narrow: the agent plans, policy validates, and the executor writes only bounded, approved changes with audit and rollback evidence.

--- a/tools-mcp/adtech/ad-platform-executor-template/TOOL.md
+++ b/tools-mcp/adtech/ad-platform-executor-template/TOOL.md
@@ -1,0 +1,71 @@
+# Ad Platform Executor Template
+
+## Purpose
+
+This template defines a narrow executor for DV360, Google Ads, and similar ad-platform writes. The executor applies only structured, policy-approved changes. It should not expose broad platform APIs directly to an LLM.
+
+## Capabilities
+
+### `read_campaign_state`
+
+Reads current state for a scoped account, advertiser, campaign, line item, ad group, keyword, audience, or feed item.
+
+### `validate_change_plan`
+
+Checks a structured change plan against current platform state, policy decision, approval record, and bounded execution grant.
+
+### `apply_approved_change`
+
+Applies one approved bid, budget, targeting, status, feed, or tracking change through the relevant platform API.
+
+### `apply_bulk_targeting_change`
+
+Applies a validated bulk targeting diff. For DV360, queue updates to the same line item and prefer bulk edit operations where supported.
+
+### `rollback_last_execution`
+
+Uses stored pre-image and rollback patch to revert the last execution when supported by the platform and policy.
+
+## Expected input shape
+
+```json
+{
+  "change_plan_id": "plan_123",
+  "execution_grant": {
+    "workspace_id": "client-123",
+    "platform": "dv360",
+    "advertiser_id": "987654",
+    "entity_type": "line_item",
+    "entity_id": "li_456",
+    "allowed_action": "apply_bid_delta",
+    "max_delta_percent": 10,
+    "expires_at": "2026-05-06T18:00:00Z",
+    "approval_id": "approval_abc"
+  },
+  "proposed_diff": {
+    "field": "bid",
+    "from": 1.2,
+    "to": 1.08,
+    "delta_percent": -10
+  }
+}
+```
+
+## Required execution sequence
+
+1. Resolve the scoped execution grant.
+2. Retrieve current platform state.
+3. Confirm the proposed diff still applies to current state.
+4. Confirm policy and approval are valid.
+5. Apply the API write.
+6. Verify post-write state.
+7. Store audit event and rollback patch.
+
+## Guardrails
+
+- Do not accept free-form natural-language write requests.
+- Do not expose raw Google refresh tokens, service-account keys, or API credentials to the agent runtime.
+- Do not execute without a valid scoped grant and policy decision.
+- Do not execute medium/high-risk changes without approval evidence.
+- Do not run concurrent writes against the same DV360 line item; queue or merge them.
+- Do not hide API failures. Return structured failure reasons and preserve pre-image state.

--- a/tools-mcp/adtech/ad-platform-executor-template/examples/approved-change.json
+++ b/tools-mcp/adtech/ad-platform-executor-template/examples/approved-change.json
@@ -1,0 +1,21 @@
+{
+  "change_plan_id": "plan_123",
+  "policy_decision": "allow_with_approval",
+  "approval_id": "approval_abc",
+  "execution_grant": {
+    "workspace_id": "client-123",
+    "platform": "dv360",
+    "advertiser_id": "987654",
+    "entity_type": "line_item",
+    "entity_id": "li_456",
+    "allowed_action": "apply_bid_delta",
+    "max_delta_percent": 10,
+    "expires_at": "2026-05-06T18:00:00Z"
+  },
+  "proposed_diff": {
+    "field": "bid",
+    "from": 1.2,
+    "to": 1.08,
+    "delta_percent": -10
+  }
+}

--- a/tools-mcp/adtech/ad-platform-executor-template/examples/execution-result.json
+++ b/tools-mcp/adtech/ad-platform-executor-template/examples/execution-result.json
@@ -1,0 +1,10 @@
+{
+  "status": "executed",
+  "platform": "dv360",
+  "entity_id": "li_456",
+  "api_request_id": "req_789",
+  "pre_image_hash": "sha256:pre",
+  "post_image_hash": "sha256:post",
+  "rollback_patch_id": "rollback_123",
+  "audit_event_id": "evt_456"
+}

--- a/tools-mcp/adtech/ad-platform-executor-template/tests/test-prompts.md
+++ b/tools-mcp/adtech/ad-platform-executor-template/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Validate an approved DV360 bid-change plan before execution and explain each required check.
+2. Describe how the executor should handle two queued targeting updates for the same DV360 line item.
+3. Define the API boundary for applying a Google Ads budget change only after policy approval.
+4. Produce a structured failure response for an expired execution grant.
+5. Explain how rollback evidence should be recorded after a campaign status change.

--- a/tools-mcp/adtech/ad-platform-executor-template/tool.yaml
+++ b/tools-mcp/adtech/ad-platform-executor-template/tool.yaml
@@ -1,0 +1,53 @@
+id: adtech/ad-platform-executor-template
+name: Ad Platform Executor Template
+description: MCP/tool template for a narrow DV360 and Google Ads executor that applies only approved, policy-checked campaign changes and records rollback evidence.
+version: 0.1.0
+released_at: "2026-05-06T00:00:00Z"
+category: tools-mcp/adtech
+tags:
+  - adtech
+  - executor
+  - dv360
+  - google-ads
+  - rollback
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: TOOL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  apis:
+    - Google Ads API
+    - Display & Video 360 API
+  tools:
+    - authorization_broker
+    - policy_engine
+    - audit_log
+operational:
+  connected_system: DV360 and Google Ads API execution layer
+  capabilities:
+    - Read current campaign or line item state before execution.
+    - Validate approved change plans against policy and current platform state.
+    - Apply bounded bid, budget, targeting, or status changes.
+    - Verify post-write state and create rollback patches.
+  auth_required:
+    - Brokered Google API credentials
+    - Scoped execution grant
+    - Approval token for medium and high-risk writes
+  access_level: read-write
+  trust_boundary: remote-mcp-server
+  approval_boundary: Applies only policy-approved bounded writes; high-risk changes require human approval and rollback evidence.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false


### PR DESCRIPTION
## Summary

This PR adds an ad-platform security pack for governed DV360, Google Ads, and broader marketing-agent automation.

The pack turns the new secure marketing agents architecture into reusable registry assets: auth review skills, policy-gate design, a narrow executor template, a supervisor agent, shared schemas, and example policy.

## Added

### Skills

- `security/ad-platform-agent-auth-review`
  - Reviews ad-platform agents for personal OAuth risk, broad platform access, unsafe token handling, missing workspace scoping, weak read/write separation, and missing approval gates.

- `agentops/ad-platform-policy-gate-designer`
  - Helps define approval thresholds, deny rules, bounded execution grants, and audit requirements for bid, budget, targeting, audience, feed, and tracking changes.

### Tool / MCP template

- `adtech/ad-platform-executor-template`
  - Defines a narrow executor contract for applying only approved, policy-checked ad-platform writes.
  - Includes patterns for current-state validation, scoped execution grants, post-write verification, rollback patches, and same-entity queueing.

### Agent template

- `adtech/ad-platform-control-plane-supervisor`
  - Coordinates auth review, policy gate design, executor readiness, approval mapping, audit requirements, and rollback planning.

### Shared assets

- `shared/schemas/ad-platform/change-plan.schema.json`
- `shared/schemas/ad-platform/audit-event.schema.json`
- `shared/policies/ad-platform/policy.example.json`

## Registry updates

Regenerated:

- `registry/skills-index.json`
- `registry/agents-index.json`
- `registry/tools-index.json`
- `registry/index.json`

README counts now reflect:

- Skills: 34
- Agents: 5
- Tools & MCP: 5

