### PR TITLE
Add creative operating system pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The first rollouts are on `tools-mcp` and `agents`.
 
 ## Current Scope
 
-### Skills (34)
+### Skills (39)
 
 1. `meta-google-weekly-performance-review` (Beginner)
 2. `creative-workshop-pmax-reels` (Intermediate)
@@ -104,14 +104,20 @@ The first rollouts are on `tools-mcp` and `agents`.
 32. `security/marketing-agent-risk-review` (Runtime Hardening)
 33. `security/ad-platform-agent-auth-review` (Runtime Hardening)
 34. `agentops/ad-platform-policy-gate-designer` (Harness Governance)
+35. `marketing/creative-operating-system-audit` (Creative Ops / Anti-Slop)
+36. `marketing/utility-campaign-concept-designer` (Creative Ops / Utility)
+37. `marketing/product-as-media-mapper` (Creative Ops / Owned Surfaces)
+38. `marketing/cultural-timing-signal-triage` (Creative Ops / Cultural Timing)
+39. `marketing/creator-strategy-brief` (Creator Ops)
 
-### Agents (5)
+### Agents (6)
 
 1. `marketing/weekly-performance-supervisor`
 2. `marketing/campaign-qa-supervisor`
 3. `adtech/bi-insights-orchestrator`
 4. `agentops/agent-control-plane-supervisor`
 5. `adtech/ad-platform-control-plane-supervisor`
+6. `marketing/creative-operating-system-supervisor`
 
 ### Tools & MCP (5)
 
@@ -180,6 +186,12 @@ The first rollouts are on `tools-mcp` and `agents`.
 - `agentops/ad-platform-policy-gate-designer`
 - `adtech/ad-platform-control-plane-supervisor`
 - `adtech/ad-platform-executor-template`
+- `marketing/creative-operating-system-audit`
+- `marketing/utility-campaign-concept-designer`
+- `marketing/product-as-media-mapper`
+- `marketing/cultural-timing-signal-triage`
+- `marketing/creator-strategy-brief`
+- `marketing/creative-operating-system-supervisor`
 
 ## Definition of done for each module entry
 
@@ -218,6 +230,8 @@ registry/
   skills-index.json
   agents-index.json
   tools-index.json
+packs/
+  creative-operating-system/
 apps/
   web/
 shared/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ We publish reusable building blocks across four modules:
 - plugins (installable composition layer)
 - tools & MCP connectors (integration layer)
 
-`packs/` contains documentation-only playbooks that curate existing catalog entries. Packs are not installable modules.
+`packs/` contains documentation-only playbooks that curate existing catalog
+entries. Packs are not installable modules.
 
 ## Operational Metadata Standard
 
@@ -129,7 +130,7 @@ The first rollouts are on `tools-mcp` and `agents`.
 4. `agentops/agent-control-plane-server`
 5. `adtech/ad-platform-executor-template`
 
-### Plugins (9)
+### Plugins (10)
 
 1. `marketing/performance-reporting-plugin`
 2. `marketing/campaign-audit-plugin`
@@ -140,6 +141,7 @@ The first rollouts are on `tools-mcp` and `agents`.
 7. `engineering/code-maintenance-plugin`
 8. `security/runtime-safety-plugin`
 9. `agentops/harness-governance-plugin`
+10. `marketing/creative-operating-system-plugin`
 
 ## Recent Additions
 
@@ -194,6 +196,7 @@ The first rollouts are on `tools-mcp` and `agents`.
 - `marketing/cultural-timing-signal-triage`
 - `marketing/creator-strategy-brief`
 - `marketing/creative-operating-system-supervisor`
+- `marketing/creative-operating-system-plugin`
 
 ## Definition of done for each module entry
 
@@ -508,7 +511,7 @@ for approval gates before live actions.
 
 Docs:
 
-- [OpenAI Codex Docs](https://developers.openai.com/codex/)
+- [OpenAI Codex Docs](https://developers.openai.com/codex)
 
 Install to Codex runtime paths:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ We publish reusable building blocks across four modules:
 - plugins (installable composition layer)
 - tools & MCP connectors (integration layer)
 
+`packs/` contains documentation-only playbooks that curate existing catalog entries. Packs are not installable modules.
+
 ## Operational Metadata Standard
 
 The catalog is being normalized around a shared operational metadata model so

--- a/agents/marketing/creative-operating-system-supervisor/AGENT.md
+++ b/agents/marketing/creative-operating-system-supervisor/AGENT.md
@@ -6,6 +6,8 @@ Creative operations supervisor for marketing teams using AI to build useful, dis
 ## Mission
 Coordinate the skills that turn a campaign brief into a creative operating system: memory, context, utility, product surfaces, cultural timing, creator collaboration, and evaluation.
 
+Local brand-memory, archive, trend-signal, and approval integrations are optional environment bindings. They are not first-class tool dependencies shipped in this repo; see `config/tool-bindings.example.json` for the expected shape when a team wants to wire them in.
+
 ## When to use
 Use this agent when the team wants to move beyond isolated AI outputs and run a structured creative process for a campaign, launch, brand platform, creator program, or Cannes-style effectiveness review.
 

--- a/agents/marketing/creative-operating-system-supervisor/AGENT.md
+++ b/agents/marketing/creative-operating-system-supervisor/AGENT.md
@@ -1,0 +1,74 @@
+# Creative Operating System Supervisor
+
+## Identity
+Creative operations supervisor for marketing teams using AI to build useful, distinctive, and governed work.
+
+## Mission
+Coordinate the skills that turn a campaign brief into a creative operating system: memory, context, utility, product surfaces, cultural timing, creator collaboration, and evaluation.
+
+## When to use
+Use this agent when the team wants to move beyond isolated AI outputs and run a structured creative process for a campaign, launch, brand platform, creator program, or Cannes-style effectiveness review.
+
+## Inputs required
+- Brand, market, category, and audience context
+- Campaign objective and business constraint
+- Existing brand memory or campaign archive
+- Product/service surfaces available for activation
+- Cultural or seasonal moments under consideration
+- Creator or partner requirements, if relevant
+- Governance, claims, compliance, and approval rules
+
+## Workflow
+1. **Collect context**
+   - Read the brand memory or request the minimum evidence needed.
+   - Identify the decision the team is trying to make.
+   - Separate known facts from assumptions.
+
+2. **Audit the operating system**
+   - Use `marketing/creative-operating-system-audit` to score memory, context, evaluation, feedback, governance, creator collaboration, and product-as-media readiness.
+   - Return the biggest gaps before ideation starts.
+
+3. **Map product-as-media opportunities**
+   - Use `marketing/product-as-media-mapper` to find owned surfaces that can carry the idea: product, app, service flow, packaging, checkout, CRM, retail, support, data, or community.
+   - Flag surfaces that require product, legal, privacy, or engineering review.
+
+4. **Design utility-led concepts**
+   - Use `marketing/utility-campaign-concept-designer` to create ideas that help people do something, not only notice something.
+   - Score each concept for usefulness, brand fit, feasibility, evidence, distinctiveness, and measurement clarity.
+
+5. **Triage cultural timing**
+   - If a live event, trend, seasonal window, or public conversation is involved, use `marketing/cultural-timing-signal-triage`.
+   - Decide whether to act now, monitor, wait, or decline.
+
+6. **Build creator briefs**
+   - If creators are involved, use `marketing/creator-strategy-brief`.
+   - Protect creator voice while making claims, disclosures, brand boundaries, and proof requirements explicit.
+
+7. **Evaluate final output**
+   - Use `marketing/ai-output-eval-scorecard` with the creative operating system dimensions enabled.
+   - Return a launch-readiness verdict: `ready`, `revise`, `hold`, or `reject`.
+
+8. **Route approvals**
+   - Identify approvals needed before execution.
+   - Never treat an agent recommendation as launch approval.
+
+## Output format
+Return:
+- `objective`
+- `operating_system_gaps`
+- `recommended_workflow`
+- `product_as_media_opportunities`
+- `utility_concept_shortlist`
+- `cultural_timing_decision`
+- `creator_brief_summary`
+- `evaluation_scorecard`
+- `approval_requirements`
+- `next_actions`
+
+## Guardrails
+- Do not create public-facing claims without evidence requirements.
+- Do not recommend exploiting tragedy, crisis, identity groups, or vulnerable moments for attention.
+- Do not over-script creators in ways that erase their audience trust.
+- Do not recommend product or checkout changes without explicit operational approval.
+- Do not treat trend fit as brand permission.
+- Surface uncertainty and missing evidence clearly.

--- a/agents/marketing/creative-operating-system-supervisor/README.md
+++ b/agents/marketing/creative-operating-system-supervisor/README.md
@@ -1,12 +1,18 @@
 # Creative Operating System Supervisor
 
-This agent coordinates the Creative Operating System pack. It is designed for marketing teams that want AI-assisted work to retain memory, usefulness, timing, governance, and distinctiveness.
+This agent coordinates the Creative Operating System workflow described in the documentation pack. It is designed for marketing teams that want AI-assisted work to retain memory, usefulness, timing, governance, and distinctiveness.
 
 ## What this agent does
 
 - Audits whether the team has the machinery to use AI creatively without producing generic work.
 - Routes the right skill at the right stage: audit, product-as-media, utility concept, cultural timing, creator brief, evaluation.
 - Produces a launch-readiness summary with approval requirements.
+
+## Runtime assumptions
+
+- The documented workflow is installable through the listed skills and this agent.
+- Brand memory, campaign archive, trend, and approval integrations are optional local environment bindings, not cataloged tool dependencies in this repo.
+- Example binding shapes are documented in `config/tool-bindings.example.json`.
 
 ## When to use it
 

--- a/agents/marketing/creative-operating-system-supervisor/README.md
+++ b/agents/marketing/creative-operating-system-supervisor/README.md
@@ -27,6 +27,14 @@ Use it for:
 
 ## Install
 
+Preferred for first-time users:
+
+```bash
+./bin/skills-hub install --module plugins --entry marketing/creative-operating-system-plugin@0.1.0 --runtime codex
+```
+
+Agent-only install if you already have the surrounding workflow and templates:
+
 ```bash
 ./bin/skills-hub install \
   marketing/creative-operating-system-supervisor@latest \

--- a/agents/marketing/creative-operating-system-supervisor/README.md
+++ b/agents/marketing/creative-operating-system-supervisor/README.md
@@ -1,0 +1,44 @@
+# Creative Operating System Supervisor
+
+This agent coordinates the Creative Operating System pack. It is designed for marketing teams that want AI-assisted work to retain memory, usefulness, timing, governance, and distinctiveness.
+
+## What this agent does
+
+- Audits whether the team has the machinery to use AI creatively without producing generic work.
+- Routes the right skill at the right stage: audit, product-as-media, utility concept, cultural timing, creator brief, evaluation.
+- Produces a launch-readiness summary with approval requirements.
+
+## When to use it
+
+Use it for:
+
+- Cannes-style effectiveness reviews.
+- New campaign concept development.
+- Creator-led campaign planning.
+- Product-led marketing opportunities.
+- Cultural moment response planning.
+- Anti-slop review of AI-generated campaign ideas.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  marketing/creative-operating-system-supervisor@latest \
+  --runtime codex
+```
+
+## First run prompt
+
+```text
+Use Creative Operating System Supervisor.
+We are planning a new product launch campaign.
+Audit our creative operating system, identify the biggest gaps,
+then propose a workflow using the available skills before we generate ideas.
+```
+
+## Good output looks like
+
+- It starts with memory and evidence, not immediate copy generation.
+- It distinguishes concept quality from execution readiness.
+- It identifies approvals before risky work moves forward.
+- It connects utility, product surfaces, creators, and evaluation into one process.

--- a/agents/marketing/creative-operating-system-supervisor/agent.yaml
+++ b/agents/marketing/creative-operating-system-supervisor/agent.yaml
@@ -34,11 +34,6 @@ dependencies:
     - marketing/creator-strategy-brief
     - marketing/ai-output-eval-scorecard
     - adtech/brand-rag-memory-bootstrap
-  tools:
-    - brand_memory_reader
-    - campaign_archive_reader
-    - trend_signal_reader
-    - approval_workflow
 operational:
   role: Creative operations supervisor for AI-assisted marketing work that must stay useful, distinctive, culturally timed, and governed.
   coordinates:

--- a/agents/marketing/creative-operating-system-supervisor/agent.yaml
+++ b/agents/marketing/creative-operating-system-supervisor/agent.yaml
@@ -1,0 +1,63 @@
+id: marketing/creative-operating-system-supervisor
+name: Creative Operating System Supervisor
+description: Coordinate the Creative Operating System workflow from brand memory and utility concepts to creator briefs, cultural timing, and final quality evaluation.
+version: 0.1.0
+released_at: "2026-06-27T00:00:00Z"
+category: marketing-agents/creative-ops
+tags:
+  - creative-operating-system
+  - cannes-2026
+  - anti-slop
+  - brand-memory
+  - creator-ops
+  - governance
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: AGENT.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  skills:
+    - marketing/creative-operating-system-audit
+    - marketing/utility-campaign-concept-designer
+    - marketing/product-as-media-mapper
+    - marketing/cultural-timing-signal-triage
+    - marketing/creator-strategy-brief
+    - marketing/ai-output-eval-scorecard
+    - adtech/brand-rag-memory-bootstrap
+  tools:
+    - brand_memory_reader
+    - campaign_archive_reader
+    - trend_signal_reader
+    - approval_workflow
+operational:
+  role: Creative operations supervisor for AI-assisted marketing work that must stay useful, distinctive, culturally timed, and governed.
+  coordinates:
+    - Brand memory and operating-system audit
+    - Utility-led campaign concept design
+    - Product-as-media opportunity mapping
+    - Cultural timing and risk triage
+    - Creator strategy briefing
+    - Final AI output evaluation and launch-readiness summary
+  autonomy_level: semi-autonomous
+  approval_boundary: May create plans, briefs, scorecards, and routing recommendations; require human approval before public activation, creator outreach, product-surface changes, paid launch, or any claim involving regulated categories.
+  outputs:
+    - Creative operating system audit
+    - Recommended workflow sequence
+    - Utility concept shortlist
+    - Product-as-media opportunity map
+    - Creator brief package
+    - Launch-readiness scorecard
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/agents/marketing/creative-operating-system-supervisor/config/governance.example.json
+++ b/agents/marketing/creative-operating-system-supervisor/config/governance.example.json
@@ -1,0 +1,21 @@
+{
+  "approval_required_for": [
+    "public_activation",
+    "creator_outreach",
+    "regulated_claims",
+    "product_surface_changes",
+    "paid_media_launch"
+  ],
+  "blocked_patterns": [
+    "crisis opportunism",
+    "unsupported superiority claims",
+    "hidden sponsorship",
+    "dark-pattern checkout nudges"
+  ],
+  "default_verdict_thresholds": {
+    "ready": 85,
+    "revise": 65,
+    "hold": 45,
+    "reject": 0
+  }
+}

--- a/agents/marketing/creative-operating-system-supervisor/config/memory-profile.example.json
+++ b/agents/marketing/creative-operating-system-supervisor/config/memory-profile.example.json
@@ -1,0 +1,13 @@
+{
+  "memory_sources": [
+    "brand_positioning",
+    "tone_of_voice",
+    "past_campaigns",
+    "claims_evidence",
+    "creator_learnings",
+    "post_campaign_reviews"
+  ],
+  "refresh_cadence": "monthly",
+  "sensitive_fields": ["customer_data", "unreleased_product_information", "legal_claims"],
+  "retrieval_rule": "Prefer approved brand memory. If memory is missing, ask for evidence instead of inventing brand history."
+}

--- a/agents/marketing/creative-operating-system-supervisor/config/tool-bindings.example.json
+++ b/agents/marketing/creative-operating-system-supervisor/config/tool-bindings.example.json
@@ -1,0 +1,22 @@
+{
+  "brand_memory_reader": {
+    "type": "internal_api",
+    "access": "read_only",
+    "description": "Fetches approved brand memory, past campaign summaries, and reusable evidence."
+  },
+  "campaign_archive_reader": {
+    "type": "warehouse_query",
+    "access": "read_only",
+    "description": "Retrieves past campaign performance, creative assets, and post-campaign learnings."
+  },
+  "trend_signal_reader": {
+    "type": "external_monitoring",
+    "access": "read_only",
+    "description": "Reads approved trend, social, search, and cultural moment signals."
+  },
+  "approval_workflow": {
+    "type": "workflow",
+    "access": "approval_only",
+    "description": "Creates approval requests but cannot auto-approve."
+  }
+}

--- a/agents/marketing/creative-operating-system-supervisor/examples/input.json
+++ b/agents/marketing/creative-operating-system-supervisor/examples/input.json
@@ -1,0 +1,9 @@
+{
+  "brand": "Example Travel",
+  "category": "travel insurance",
+  "objective": "Increase consideration among families planning summer holidays",
+  "available_surfaces": ["quote flow", "policy confirmation email", "mobile app", "airport partnership screens"],
+  "cultural_window": "summer travel disruption season",
+  "creator_context": "family travel creators with practical planning audiences",
+  "constraints": ["regulated claims", "no fear-mongering", "legal review required for coverage claims"]
+}

--- a/agents/marketing/creative-operating-system-supervisor/examples/output.json
+++ b/agents/marketing/creative-operating-system-supervisor/examples/output.json
@@ -1,0 +1,37 @@
+{
+  "objective": "Build a useful summer travel planning campaign that increases consideration without fear-based messaging.",
+  "operating_system_gaps": [
+    "No reusable brand memory for past disruption messaging.",
+    "No clear approval path for creator claims about coverage."
+  ],
+  "recommended_workflow": [
+    "Run brand memory bootstrap on previous travel disruption campaigns.",
+    "Map quote-flow and confirmation-email surfaces for product-as-media opportunities.",
+    "Design utility-led concepts around trip readiness and claim clarity.",
+    "Triage summer disruption timing weekly.",
+    "Create creator briefs with claims boundaries and disclosure requirements.",
+    "Run final eval scorecard before production."
+  ],
+  "product_as_media_opportunities": [
+    {
+      "surface": "quote flow",
+      "idea": "Trip readiness checklist before policy selection",
+      "approval_needed": "product and legal"
+    }
+  ],
+  "utility_concept_shortlist": [
+    {
+      "concept": "The Trip-Ready Check",
+      "human_value": "Helps families understand disruption risks and required documents before travel.",
+      "risk": "Must avoid implying guaranteed coverage."
+    }
+  ],
+  "cultural_timing_decision": "monitor",
+  "creator_brief_summary": "Invite family travel creators to show practical preparation, not scripted product claims.",
+  "evaluation_scorecard": {
+    "verdict": "revise",
+    "highest_risk": "coverage claim precision"
+  },
+  "approval_requirements": ["legal", "product", "creator partnerships"],
+  "next_actions": ["Build claims evidence file", "Run utility concept designer", "Draft creator brief"]
+}

--- a/agents/marketing/creative-operating-system-supervisor/tests/test-prompts.md
+++ b/agents/marketing/creative-operating-system-supervisor/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Use Creative Operating System Supervisor to plan a new campaign for a retail banking app. Start with the operating-system audit and do not generate copy yet.
+2. We have a creator-led skincare campaign idea. Route it through the Creative Operating System workflow and identify approval gates.
+3. A cultural moment is trending today and the brand wants to respond. Decide whether the team should act, wait, monitor, or decline.
+4. Review this AI-generated campaign concept and score whether it has utility, product-as-media potential, distinctiveness, and brand memory.
+5. Build a 30-day plan for turning our current AI copy workflow into a creative operating system with reusable memory and evaluation.

--- a/docs/creative-operating-system-playbook.md
+++ b/docs/creative-operating-system-playbook.md
@@ -1,0 +1,95 @@
+# Creative Operating System Playbook
+
+This playbook shows how to use the Creative Operating System pack as a practical build sequence.
+
+## The operating model
+
+A creative operating system has seven working parts:
+
+1. **Memory**: approved brand knowledge, prior campaign learnings, claims evidence, creator learnings, and examples.
+2. **Context**: audience, category, culture, media behavior, product reality, and constraints.
+3. **Utility**: the human problem the work helps with.
+4. **Product surfaces**: owned places where the brand can do something useful, not only say something.
+5. **Creator collaboration**: human distribution, trust, format fluency, and cultural interpretation.
+6. **Evaluation**: repeatable scoring for quality, usefulness, distinctiveness, evidence, and risk.
+7. **Governance**: approvals, claims checks, timing checks, and escalation paths.
+
+## Build sequence
+
+### 1. Build or refresh memory
+
+Use `adtech/brand-rag-memory-bootstrap` to collect the minimum useful memory base:
+
+- brand strategy
+- tone of voice
+- past winning and failed campaigns
+- approved claims
+- banned claims
+- audience research
+- creator learnings
+- post-campaign reviews
+
+### 2. Audit the system
+
+Run `marketing/creative-operating-system-audit`.
+
+Expected output:
+
+- maturity score
+- evidence gaps
+- governance gaps
+- 30-day action plan
+
+### 3. Design around utility
+
+Run `marketing/utility-campaign-concept-designer`.
+
+Ask for concepts that help people do something specific. If the idea cannot name the human friction, it is probably only content.
+
+### 4. Map owned surfaces
+
+Run `marketing/product-as-media-mapper`.
+
+Look for places where the brand can deliver the idea through product, service, app, commerce, CRM, retail, support, packaging, or data.
+
+### 5. Triage timing
+
+Run `marketing/cultural-timing-signal-triage` for any live moment or trend.
+
+Require an explicit decision:
+
+- act now
+- prepare and wait
+- monitor
+- decline
+
+### 6. Brief creators
+
+Run `marketing/creator-strategy-brief`.
+
+The brief should define the creator's strategic role, not just ask them to distribute brand copy.
+
+### 7. Score the work
+
+Run `marketing/ai-output-eval-scorecard` with these optional dimensions enabled:
+
+- utility
+- product-as-media potential
+- cultural timing
+- human meaning
+- brand memory
+- distinctiveness
+- creator fit
+
+## Minimum launch gate
+
+Before anything public ships, confirm:
+
+- claims are evidenced
+- sensitive context is reviewed
+- creator disclosures are clear
+- product changes are approved
+- measurement is defined
+- rollback or pause path exists
+
+If those gates are missing, the output is not launch-ready even if the copy reads well.

--- a/packs/creative-operating-system/README.md
+++ b/packs/creative-operating-system/README.md
@@ -2,6 +2,8 @@
 
 A practical pack for building the machinery behind distinctive AI-assisted marketing work.
 
+This pack is documentation-only. It curates catalog entries and workflow guidance, but it is not an installable module in the hub or CLI.
+
 This pack was created as the implementation companion to the AI Knowledge Hub Cannes Lions 2026 analysis on the Creative Operating System: the shift from isolated AI output generation to memory, utility, product surfaces, cultural timing, creator collaboration, and governed evaluation.
 
 Article link placeholder:

--- a/packs/creative-operating-system/README.md
+++ b/packs/creative-operating-system/README.md
@@ -2,12 +2,11 @@
 
 A practical pack for building the machinery behind distinctive AI-assisted marketing work.
 
-This pack is documentation-only. It curates catalog entries and workflow guidance, but it is not an installable module in the hub or CLI.
+This pack is documentation-only. It curates catalog entries and workflow guidance. Use the installable plugin for out-of-the-box setup, and use this pack as the deeper playbook.
 
 This pack was created as the implementation companion to the AI Knowledge Hub Cannes Lions 2026 analysis on the Creative Operating System: the shift from isolated AI output generation to memory, utility, product surfaces, cultural timing, creator collaboration, and governed evaluation.
 
-Article link placeholder:
-https://ai-news-hub.performics-labs.com/news/cannes-lions-2026-ai-creativity-operating-system
+Article link: pending publication.
 
 ## What this pack is for
 
@@ -16,6 +15,16 @@ Use this pack when your team needs to answer a harder question than "can AI gene
 The real question is:
 
 > Do we have the operating system that helps AI-assisted work stay useful, distinctive, culturally aware, and safe to ship?
+
+## Best way to start
+
+If you want to use this workflow straight away, install `marketing/creative-operating-system-plugin` first.
+
+```bash
+./bin/skills-hub install --module plugins --entry marketing/creative-operating-system-plugin@0.1.0 --runtime codex
+```
+
+The plugin bundles the supervisor agent, the core skills, starter intake templates, launch-gate artifacts, and packaged hooks that stop teams from skipping memory or approval steps.
 
 ## Included skills
 

--- a/packs/creative-operating-system/README.md
+++ b/packs/creative-operating-system/README.md
@@ -1,0 +1,86 @@
+# Creative Operating System Pack
+
+A practical pack for building the machinery behind distinctive AI-assisted marketing work.
+
+This pack was created as the implementation companion to the AI Knowledge Hub Cannes Lions 2026 analysis on the Creative Operating System: the shift from isolated AI output generation to memory, utility, product surfaces, cultural timing, creator collaboration, and governed evaluation.
+
+Article link placeholder:
+https://ai-news-hub.performics-labs.com/news/cannes-lions-2026-ai-creativity-operating-system
+
+## What this pack is for
+
+Use this pack when your team needs to answer a harder question than "can AI generate campaign ideas?"
+
+The real question is:
+
+> Do we have the operating system that helps AI-assisted work stay useful, distinctive, culturally aware, and safe to ship?
+
+## Included skills
+
+| Entry | Purpose |
+| --- | --- |
+| `marketing/creative-operating-system-audit` | Audit the team's creative machinery before ideation starts. |
+| `marketing/product-as-media-mapper` | Find owned surfaces that can become useful campaign interfaces. |
+| `marketing/utility-campaign-concept-designer` | Turn a brief into concepts that help people do something. |
+| `marketing/cultural-timing-signal-triage` | Decide whether a live cultural moment deserves action. |
+| `marketing/creator-strategy-brief` | Write creator briefs that preserve creator voice and audience trust. |
+| `marketing/ai-output-eval-scorecard` | Score final outputs for quality, risk, usefulness, and distinctiveness. |
+
+## Included agent
+
+| Entry | Purpose |
+| --- | --- |
+| `marketing/creative-operating-system-supervisor` | Coordinates the full workflow and routes each stage to the right skill. |
+
+## Recommended workflow
+
+1. **Bootstrap brand memory**
+   - Use `adtech/brand-rag-memory-bootstrap` if the team does not already have approved brand memory, prior campaign learnings, claims evidence, and examples of work that should or should not be repeated.
+
+2. **Audit the operating system**
+   - Use `marketing/creative-operating-system-audit` to identify missing memory, weak evaluation, unclear governance, or poor feedback loops.
+
+3. **Map product-as-media surfaces**
+   - Use `marketing/product-as-media-mapper` to find useful owned surfaces: app flows, checkout, packaging, CRM, community, retail, support, product data, or service interactions.
+
+4. **Design utility-led concepts**
+   - Use `marketing/utility-campaign-concept-designer` to create concepts that solve a real friction or improve a customer decision.
+
+5. **Triage cultural timing**
+   - Use `marketing/cultural-timing-signal-triage` when the idea depends on a live trend, event, seasonal moment, or public conversation.
+
+6. **Brief creators as collaborators**
+   - Use `marketing/creator-strategy-brief` to define creator role, guardrails, proof requirements, disclosures, and freedom zones.
+
+7. **Evaluate before launch**
+   - Use `marketing/ai-output-eval-scorecard` with the Creative Operating System dimensions enabled.
+
+## Example prompt
+
+```text
+Use Creative Operating System Supervisor.
+We are preparing a launch campaign for a new subscription product.
+Audit our creative operating system first, then propose the workflow we should run.
+Do not generate campaign copy until the memory, utility, product surface, creator, and approval gaps are clear.
+```
+
+## What good output looks like
+
+Good output should:
+
+- Start with evidence and memory.
+- Identify where the brand has permission to act.
+- Prefer useful interventions over decorative content.
+- Connect the idea to product, service, or owned surfaces where possible.
+- Give creators enough freedom to be credible.
+- Make approvals explicit before launch.
+- Score final work against usefulness, distinctiveness, cultural timing, and governance.
+
+## What this pack should prevent
+
+- Generic AI campaign territories.
+- Trend-chasing without brand permission.
+- Creator briefs that erase creator voice.
+- Product-surface ideas that create dark patterns.
+- Unsupported claims hidden inside polished copy.
+- Launches without memory, test criteria, or approval boundaries.

--- a/plugins/marketing/creative-operating-system-plugin/README.md
+++ b/plugins/marketing/creative-operating-system-plugin/README.md
@@ -1,0 +1,82 @@
+# Creative Operating System Plugin
+
+Installable package for teams that want to move from AI-generated campaign ideas to a governed creative operating system with memory, utility, product surfaces, creator collaboration, timing, and evaluation.
+
+## Includes
+- Brand-memory bootstrap and operating-system audit skills
+- Utility-led concepting and product-as-media mapping
+- Cultural timing triage and creator briefing
+- Final evaluation scorecard
+- Creative Operating System supervisor agent
+- Packaged hooks for memory gating and launch-gate review
+- Starter templates and JSON schemas for first-run setup
+
+## Install Behavior
+
+This plugin is a packaging layer.
+
+On install:
+
+- the plugin package itself is installed under `plugins/...`
+- bundled skills are installed into the runtime `skills/...` directory
+- bundled agents are installed into the runtime `agents/...` directory
+- packaged hooks, templates, and schemas remain inside this plugin's directory
+
+Bundled skills and agents do not live inside the plugin directory itself. That avoids duplication while still making the package usable immediately.
+
+## Install Command
+
+```bash
+./bin/skills-hub install --module plugins --entry marketing/creative-operating-system-plugin@0.1.0 --runtime codex
+```
+
+## Installed Dependencies
+
+Skills installed into `skills/...`:
+- `adtech/brand-rag-memory-bootstrap`
+- `marketing/creative-operating-system-audit`
+- `marketing/utility-campaign-concept-designer`
+- `marketing/product-as-media-mapper`
+- `marketing/cultural-timing-signal-triage`
+- `marketing/creator-strategy-brief`
+- `marketing/ai-output-eval-scorecard`
+
+Agents installed into `agents/...`:
+- `marketing/creative-operating-system-supervisor`
+
+## Packaged Hooks
+
+Hooks kept inside this plugin package:
+- `require-memory-before-ideation`
+- `require-launch-gate-review`
+
+## First-Run Path
+
+If the team has no existing systems yet, run the package in this order:
+
+1. Fill `templates/brand-memory-intake.md`
+2. Fill `templates/campaign-archive-intake.md`
+3. Fill `templates/approval-matrix.md`
+4. Run `adtech/brand-rag-memory-bootstrap`
+5. Run `marketing/creative-operating-system-audit`
+6. Use the supervisor agent to plan the next workflow steps
+7. Use `templates/trend-signal-triage.md`, `templates/creator-brief-intake.md`, and `templates/launch-gate-checklist.md` as needed
+
+## What This Package Makes Immediately Easier
+
+- starting without an existing memory structure
+- capturing reusable campaign evidence
+- running a manual approval model before formal workflow tooling exists
+- moving from concepting into launch review without inventing the process from scratch
+
+## What Still Needs Local Adaptation
+
+This plugin is operationally useful out of the box, but teams still need to adapt:
+
+- brand evidence and memory inputs
+- campaign archive sources
+- approval owners and sign-off rules
+- creator disclosure requirements
+- product, legal, and engineering feasibility checks
+
+Those are packaged here as starter templates and schemas rather than pretending the repo can infer them automatically.

--- a/plugins/marketing/creative-operating-system-plugin/examples/overview.md
+++ b/plugins/marketing/creative-operating-system-plugin/examples/overview.md
@@ -1,0 +1,9 @@
+# Example First Run
+
+1. Install the plugin.
+2. Complete the starter templates for brand memory, archive, and approvals.
+3. Run `adtech/brand-rag-memory-bootstrap` using the filled memory template as source material.
+4. Run `marketing/creative-operating-system-audit`.
+5. Use `marketing/creative-operating-system-supervisor` to produce the recommended workflow.
+6. If the idea depends on a live moment, fill the trend triage template before acting.
+7. Before any public launch, complete the launch gate checklist and route human approvals.

--- a/plugins/marketing/creative-operating-system-plugin/hooks/require-launch-gate-review.md
+++ b/plugins/marketing/creative-operating-system-plugin/hooks/require-launch-gate-review.md
@@ -1,0 +1,8 @@
+# Require Launch Gate Review
+
+Trigger before anything externally visible ships.
+
+## Intent
+- require completion of the launch gate checklist
+- confirm claims evidence, approvals, and rollback owner
+- block launch if product-surface, creator, or cultural-risk reviews are incomplete

--- a/plugins/marketing/creative-operating-system-plugin/hooks/require-memory-before-ideation.md
+++ b/plugins/marketing/creative-operating-system-plugin/hooks/require-memory-before-ideation.md
@@ -1,0 +1,8 @@
+# Require Memory Before Ideation
+
+Trigger before concept generation.
+
+## Intent
+- stop the workflow if approved memory or claims evidence is missing
+- require the team to fill the brand-memory intake before creative ideation
+- distinguish facts, assumptions, and unverified preferences

--- a/plugins/marketing/creative-operating-system-plugin/plugin.json
+++ b/plugins/marketing/creative-operating-system-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "creative-operating-system-plugin",
+  "version": "0.1.0",
+  "description": "Installable Creative Operating System workflow with strategy, governance, and starter operational templates."
+}

--- a/plugins/marketing/creative-operating-system-plugin/plugin.yaml
+++ b/plugins/marketing/creative-operating-system-plugin/plugin.yaml
@@ -1,0 +1,49 @@
+id: marketing/creative-operating-system-plugin
+name: Creative Operating System Plugin
+description: Bundle the Creative Operating System workflow into one installable package with audit, concepting, creator, timing, evaluation, and first-run operational templates.
+version: 0.1.0
+released_at: "2026-06-28T00:00:00Z"
+category: marketing-plugins/creative
+tags:
+  - creative-operating-system
+  - anti-slop
+  - creator-ops
+  - product-as-media
+  - cultural-timing
+  - governance
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: plugin.json
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+includes:
+  skills:
+    - adtech/brand-rag-memory-bootstrap
+    - marketing/creative-operating-system-audit
+    - marketing/utility-campaign-concept-designer
+    - marketing/product-as-media-mapper
+    - marketing/cultural-timing-signal-triage
+    - marketing/creator-strategy-brief
+    - marketing/ai-output-eval-scorecard
+  agents:
+    - marketing/creative-operating-system-supervisor
+  hooks:
+    - require-memory-before-ideation
+    - require-launch-gate-review
+requires:
+  approvals:
+    - human-review-before-public-launch
+    - human-review-before-product-surface-change
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/plugins/marketing/creative-operating-system-plugin/schemas/approval-matrix.schema.json
+++ b/plugins/marketing/creative-operating-system-plugin/schemas/approval-matrix.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Approval Matrix",
+  "type": "object",
+  "required": ["rows"],
+  "properties": {
+    "rows": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["decision_area", "required_owner"],
+        "properties": {
+          "decision_area": { "type": "string" },
+          "required_owner": { "type": "string" },
+          "backup_owner": { "type": "string" },
+          "evidence_required": { "type": "array", "items": { "type": "string" } },
+          "notes": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/plugins/marketing/creative-operating-system-plugin/schemas/brand-memory-profile.schema.json
+++ b/plugins/marketing/creative-operating-system-plugin/schemas/brand-memory-profile.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Brand Memory Profile",
+  "type": "object",
+  "required": ["brand_name", "value_proposition", "approved_claims", "guardrails"],
+  "properties": {
+    "brand_name": { "type": "string" },
+    "category": { "type": "string" },
+    "core_audience": { "type": "string" },
+    "value_proposition": { "type": "string" },
+    "differentiators": { "type": "array", "items": { "type": "string" } },
+    "approved_claims": { "type": "array", "items": { "type": "string" } },
+    "banned_claims": { "type": "array", "items": { "type": "string" } },
+    "guardrails": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/plugins/marketing/creative-operating-system-plugin/schemas/campaign-archive-entry.schema.json
+++ b/plugins/marketing/creative-operating-system-plugin/schemas/campaign-archive-entry.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Campaign Archive Entry",
+  "type": "object",
+  "required": ["campaign_name", "objective", "creative_summary", "learnings"],
+  "properties": {
+    "campaign_name": { "type": "string" },
+    "objective": { "type": "string" },
+    "audience": { "type": "string" },
+    "channels": { "type": "array", "items": { "type": "string" } },
+    "creative_summary": { "type": "string" },
+    "utility_offered": { "type": "string" },
+    "owned_surfaces": { "type": "array", "items": { "type": "string" } },
+    "learnings": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/plugins/marketing/creative-operating-system-plugin/schemas/creator-brief.schema.json
+++ b/plugins/marketing/creative-operating-system-plugin/schemas/creator-brief.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Creator Brief",
+  "type": "object",
+  "required": ["creator_role", "freedom_boundaries", "proof_requirements", "success_criteria"],
+  "properties": {
+    "creator_role": { "type": "string" },
+    "audience_fit": { "type": "string" },
+    "freedom_boundaries": { "type": "array", "items": { "type": "string" } },
+    "proof_requirements": { "type": "array", "items": { "type": "string" } },
+    "prohibited_claims": { "type": "array", "items": { "type": "string" } },
+    "success_criteria": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/plugins/marketing/creative-operating-system-plugin/schemas/launch-gate.schema.json
+++ b/plugins/marketing/creative-operating-system-plugin/schemas/launch-gate.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Launch Gate",
+  "type": "object",
+  "required": ["claims_evidenced", "approvals_complete", "rollback_owner"],
+  "properties": {
+    "claims_evidenced": { "type": "boolean" },
+    "sensitive_context_reviewed": { "type": "boolean" },
+    "product_surface_approved": { "type": "boolean" },
+    "creator_disclosures_defined": { "type": "boolean" },
+    "measurement_plan_defined": { "type": "boolean" },
+    "rollback_owner": { "type": "string" },
+    "cultural_timing_documented": { "type": "boolean" },
+    "final_scorecard_complete": { "type": "boolean" }
+  }
+}

--- a/plugins/marketing/creative-operating-system-plugin/schemas/trend-triage.schema.json
+++ b/plugins/marketing/creative-operating-system-plugin/schemas/trend-triage.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Trend Triage Decision",
+  "type": "object",
+  "required": ["signal", "brand_permission", "decision"],
+  "properties": {
+    "signal": { "type": "string" },
+    "source": { "type": "string" },
+    "brand_permission": { "type": "string" },
+    "risk_notes": { "type": "array", "items": { "type": "string" } },
+    "required_reviewers": { "type": "array", "items": { "type": "string" } },
+    "decision": { "type": "string", "enum": ["act-now", "prepare-and-wait", "monitor", "decline"] },
+    "rationale": { "type": "string" }
+  }
+}

--- a/plugins/marketing/creative-operating-system-plugin/templates/approval-matrix.md
+++ b/plugins/marketing/creative-operating-system-plugin/templates/approval-matrix.md
@@ -1,0 +1,11 @@
+# Approval Matrix
+
+| Decision area | Required owner | Backup owner | Evidence required | Notes |
+| --- | --- | --- | --- | --- |
+| Brand strategy |  |  |  |  |
+| Claims / legal |  |  |  |  |
+| Product surface change |  |  |  |  |
+| Creator disclosure |  |  |  |  |
+| Cultural / reputational risk |  |  |  |  |
+| Paid launch |  |  |  |  |
+| Rollback owner |  |  |  |  |

--- a/plugins/marketing/creative-operating-system-plugin/templates/brand-memory-intake.md
+++ b/plugins/marketing/creative-operating-system-plugin/templates/brand-memory-intake.md
@@ -1,0 +1,28 @@
+# Brand Memory Intake
+
+## Brand fundamentals
+- Brand name:
+- Category:
+- Core audience:
+- Primary business objective:
+
+## Approved positioning
+- Value proposition:
+- Differentiators:
+- Tone of voice:
+- Must-keep brand truths:
+
+## Claims and proof
+- Approved claims:
+- Evidence source for each claim:
+- Banned or sensitive claims:
+
+## Campaign learnings
+- Winning campaigns and why they worked:
+- Failed campaigns and why they failed:
+- Distinctive assets or cues:
+
+## Guardrails
+- Regulated topics:
+- Mandatory disclaimers:
+- Topics to avoid:

--- a/plugins/marketing/creative-operating-system-plugin/templates/campaign-archive-intake.md
+++ b/plugins/marketing/creative-operating-system-plugin/templates/campaign-archive-intake.md
@@ -1,0 +1,25 @@
+# Campaign Archive Intake
+
+## Campaign record
+- Campaign name:
+- Date range:
+- Objective:
+- Audience:
+- Channels used:
+
+## Creative summary
+- Core idea:
+- Utility offered, if any:
+- Product or owned surfaces used:
+- Creator involvement:
+
+## Performance and evidence
+- What performed best:
+- What underperformed:
+- Supporting data sources:
+- Post-campaign learnings:
+
+## Reuse guidance
+- Elements safe to repeat:
+- Elements to avoid repeating:
+- Open questions for future testing:

--- a/plugins/marketing/creative-operating-system-plugin/templates/creator-brief-intake.md
+++ b/plugins/marketing/creative-operating-system-plugin/templates/creator-brief-intake.md
@@ -1,0 +1,21 @@
+# Creator Brief Intake
+
+## Creator role
+- Creator name or type:
+- Audience fit:
+- Strategic role in the campaign:
+
+## Idea boundaries
+- What must remain true:
+- What the creator can reinterpret:
+- Non-negotiable claims or disclosures:
+
+## Proof and safety
+- Evidence the creator can rely on:
+- Prohibited claims:
+- Sensitive topics to avoid:
+
+## Success criteria
+- What the work should help people do:
+- Measurement signals:
+- Review owner before publish:

--- a/plugins/marketing/creative-operating-system-plugin/templates/launch-gate-checklist.md
+++ b/plugins/marketing/creative-operating-system-plugin/templates/launch-gate-checklist.md
@@ -1,0 +1,10 @@
+# Launch Gate Checklist
+
+- [ ] Claims are evidenced and approved
+- [ ] Sensitive or regulated context has been reviewed
+- [ ] Product or owned-surface changes are approved
+- [ ] Creator disclosures are defined
+- [ ] Measurement plan exists
+- [ ] Rollback or pause owner is assigned
+- [ ] Cultural timing decision is documented
+- [ ] Final AI output evaluation scorecard is complete

--- a/plugins/marketing/creative-operating-system-plugin/templates/trend-signal-triage.md
+++ b/plugins/marketing/creative-operating-system-plugin/templates/trend-signal-triage.md
@@ -1,0 +1,21 @@
+# Trend Signal Triage
+
+## Signal
+- Trend or event:
+- Source:
+- Date observed:
+- Why it appears relevant:
+
+## Brand permission
+- Why this brand has permission to participate:
+- Why it might not:
+- Audience expectation:
+
+## Risk and speed
+- Sensitive context or harm risk:
+- Required reviewers:
+- Decision window:
+
+## Decision
+- Act now / Prepare and wait / Monitor / Decline:
+- Rationale:

--- a/plugins/marketing/creative-operating-system-plugin/tests/test-prompts.md
+++ b/plugins/marketing/creative-operating-system-plugin/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Install the creative operating system plugin for Codex and list what gets installed into skills, agents, and the plugin directory.
+2. Explain the first-run path for a team that has no existing brand memory or approval workflow.
+3. Show which templates should be completed before using the supervisor agent for the first time.
+4. Describe how this plugin prevents teams from jumping straight into generic AI ideation.
+5. Explain which approvals are still required before a public launch.

--- a/registry/agents-index.json
+++ b/registry/agents-index.json
@@ -240,7 +240,7 @@
           "released_at": "2026-06-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/agents/marketing/creative-operating-system-supervisor/agent.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creative-operating-system-supervisor/0.1.0.tar.gz",
-          "sha256": "89598bb9ac8cabf3a3ce0c941c37c1b1be78a651c446e7d681f102608444ec89"
+          "sha256": "1cdbe79bd58c159714186a007cf4a30d26ade383b92f553134526496681ab03b"
         }
       ],
       "runtimes": [
@@ -289,12 +289,6 @@
           "marketing/creator-strategy-brief",
           "marketing/ai-output-eval-scorecard",
           "adtech/brand-rag-memory-bootstrap"
-        ],
-        "tools": [
-          "brand_memory_reader",
-          "campaign_archive_reader",
-          "trend_signal_reader",
-          "approval_workflow"
         ]
       }
     },

--- a/registry/agents-index.json
+++ b/registry/agents-index.json
@@ -1,6 +1,6 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-05-06T00:00:00Z",
+  "generated_at": "2026-06-27T00:00:00Z",
   "skills": [
     {
       "id": "adtech/ad-platform-control-plane-supervisor",
@@ -225,6 +225,76 @@
         "tools": [
           "campaign_config_reader",
           "slack_post"
+        ]
+      }
+    },
+    {
+      "id": "marketing/creative-operating-system-supervisor",
+      "name": "Creative Operating System Supervisor",
+      "description": "Coordinate the Creative Operating System workflow from brand memory and utility concepts to creator briefs, cultural timing, and final quality evaluation.",
+      "category": "marketing-agents/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-06-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/agents/marketing/creative-operating-system-supervisor/agent.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creative-operating-system-supervisor/0.1.0.tar.gz",
+          "sha256": "89598bb9ac8cabf3a3ce0c941c37c1b1be78a651c446e7d681f102608444ec89"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "creative-operating-system",
+        "cannes-2026",
+        "anti-slop",
+        "brand-memory",
+        "creator-ops",
+        "governance"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May create plans, briefs, scorecards, and routing recommendations; require human approval before public activation, creator outreach, product-surface changes, paid launch, or any claim involving regulated categories.",
+        "role": "Creative operations supervisor for AI-assisted marketing work that must stay useful, distinctive, culturally timed, and governed.",
+        "coordinates": [
+          "Brand memory and operating-system audit",
+          "Utility-led campaign concept design",
+          "Product-as-media opportunity mapping",
+          "Cultural timing and risk triage",
+          "Creator strategy briefing",
+          "Final AI output evaluation and launch-readiness summary"
+        ],
+        "autonomy_level": "semi-autonomous",
+        "outputs": [
+          "Creative operating system audit",
+          "Recommended workflow sequence",
+          "Utility concept shortlist",
+          "Product-as-media opportunity map",
+          "Creator brief package",
+          "Launch-readiness scorecard"
+        ]
+      },
+      "dependencies": {
+        "skills": [
+          "marketing/creative-operating-system-audit",
+          "marketing/utility-campaign-concept-designer",
+          "marketing/product-as-media-mapper",
+          "marketing/cultural-timing-signal-triage",
+          "marketing/creator-strategy-brief",
+          "marketing/ai-output-eval-scorecard",
+          "adtech/brand-rag-memory-bootstrap"
+        ],
+        "tools": [
+          "brand_memory_reader",
+          "campaign_archive_reader",
+          "trend_signal_reader",
+          "approval_workflow"
         ]
       }
     },

--- a/registry/agents-index.json
+++ b/registry/agents-index.json
@@ -240,7 +240,7 @@
           "released_at": "2026-06-27T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/agents/marketing/creative-operating-system-supervisor/agent.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creative-operating-system-supervisor/0.1.0.tar.gz",
-          "sha256": "1cdbe79bd58c159714186a007cf4a30d26ade383b92f553134526496681ab03b"
+          "sha256": "10f9546b2c056466847e63447eb593dbbee861401eb33999a460c89e25f4f89b"
         }
       ],
       "runtimes": [

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,6 +1,6 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-05-06T00:00:00Z",
+  "generated_at": "2026-06-27T00:00:00Z",
   "skills": [
     {
       "id": "adtech/analyst-copilot-bigquery-redshift",
@@ -877,7 +877,7 @@
     {
       "id": "marketing/ai-output-eval-scorecard",
       "name": "AI Output Eval Scorecard",
-      "description": "Score AI-generated marketing outputs across accuracy, clarity, brand fit, policy compliance, and actionability.",
+      "description": "Score AI-generated marketing outputs across accuracy, clarity, brand fit, policy compliance, actionability, and creative operating system fit.",
       "category": "marketing-tools/compliance",
       "latest": "0.1.0",
       "versions": [
@@ -886,7 +886,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ai-output-eval-scorecard/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ai-output-eval-scorecard/0.1.0.tar.gz",
-          "sha256": "2ede4bad097be375886cbbf1a15a44403f63aa425e52ecd0a02c3880c6a9a2c9"
+          "sha256": "94443958e9a1980b1fd47dc9330ab4a3cd1405f547d3b028ec32d74ed2263160"
         }
       ],
       "runtimes": [
@@ -899,7 +899,9 @@
         "governance",
         "qa",
         "llm-judge",
-        "risk-control"
+        "risk-control",
+        "anti-slop",
+        "creative-operating-system"
       ],
       "readiness": "experimental",
       "security_reviewed": false,
@@ -909,15 +911,58 @@
         "outputs": [
           "Scorecard",
           "Verdict",
-          "Rewrite recommendations"
+          "Rewrite recommendations",
+          "Creative operating system scores"
         ],
-        "use_when": "Use when AI-generated marketing outputs need repeatable scoring across quality, compliance, and actionability.",
+        "use_when": "Use when AI-generated marketing outputs need repeatable scoring across quality, compliance, actionability, and creative operating system fit.",
         "execution_mode": "analysis-only"
       },
       "dependencies": {
         "tools": [
           "python3"
         ]
+      }
+    },
+    {
+      "id": "marketing/creative-operating-system-audit",
+      "name": "Creative Operating System Audit",
+      "description": "Audit whether a marketing team has the memory, context, evaluation, creator, product-as-media, feedback, and governance machinery needed for AI-era creative work.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-06-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/creative-operating-system-audit/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creative-operating-system-audit/0.1.0.tar.gz",
+          "sha256": "a013f24ddf01db8293bba41a4609845650cfa5bcd34ef389ea33073f610692c6"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "creative-operating-system",
+        "cannes-2026",
+        "anti-slop",
+        "brand-memory",
+        "governance"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for analysis and planning; require human approval before changing process, governance, or live campaign workflows.",
+        "outputs": [
+          "Creative operating system maturity score",
+          "Gap analysis",
+          "Prioritized action plan",
+          "Evidence table"
+        ],
+        "use_when": "Use when a brand or team wants to assess whether it can turn AI output into distinctive, useful, governed creative work.",
+        "execution_mode": "analysis-only"
       }
     },
     {
@@ -966,6 +1011,49 @@
       }
     },
     {
+      "id": "marketing/creator-strategy-brief",
+      "name": "Creator Strategy Brief",
+      "description": "Create creator briefs that treat creators as strategic collaborators with audience trust, format expertise, and cultural intelligence.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-06-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/creator-strategy-brief/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creator-strategy-brief/0.1.0.tar.gz",
+          "sha256": "9efafc120c4c2a56edfa990c835d9adc9560a5b4080e0c28283e6bc0b73d486d"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "creators",
+        "creator-commerce",
+        "brief",
+        "cultural-intelligence",
+        "governance"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for brief drafting; require human approval before creator outreach, contracting, claims, or publication.",
+        "outputs": [
+          "Creator role definition",
+          "Brief",
+          "Freedom boundaries",
+          "Measurement plan",
+          "Risk notes"
+        ],
+        "use_when": "Use when building creator-led campaigns where creators should shape the idea, not just distribute it.",
+        "execution_mode": "analysis-only"
+      }
+    },
+    {
       "id": "marketing/cross-channel-budget-pacing-agent",
       "name": "Cross-Channel Budget Pacing Agent",
       "description": "Monitor pacing across paid channels, detect anomalies, and recommend budget reallocation actions.",
@@ -1009,6 +1097,47 @@
         "tools": [
           "python3"
         ]
+      }
+    },
+    {
+      "id": "marketing/cultural-timing-signal-triage",
+      "name": "Cultural Timing Signal Triage",
+      "description": "Decide whether a live cultural moment is worth acting on, and define the safe, fast, brand-fit response path.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-06-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/cultural-timing-signal-triage/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/cultural-timing-signal-triage/0.1.0.tar.gz",
+          "sha256": "c98eccfc05173a20e6493ca99621ce9817f52bd473177f8a0eab3fdc2694d6eb"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "cultural-timing",
+        "real-time-marketing",
+        "risk-review",
+        "approvals"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for triage; require human approval before public response, paid media activation, creator outreach, or legal-risk claims.",
+        "outputs": [
+          "Go/no-go recommendation",
+          "Timing window",
+          "Brand permission check",
+          "Risk and approval path"
+        ],
+        "use_when": "Use when a brand notices a live moment and needs a fast go/no-go recommendation with guardrails.",
+        "execution_mode": "analysis-only"
       }
     },
     {
@@ -1194,6 +1323,46 @@
       }
     },
     {
+      "id": "marketing/product-as-media-mapper",
+      "name": "Product As Media Mapper",
+      "description": "Identify product, app, commerce, service, packaging, data, and owned-channel surfaces that can become campaign media.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-06-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/product-as-media-mapper/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/product-as-media-mapper/0.1.0.tar.gz",
+          "sha256": "0b9bd764bc2fa7d9d03ad919dc37cb3c758ffb3a7436d28c13db4a776e78a8a3"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "product-as-media",
+        "owned-surfaces",
+        "commerce",
+        "cannes-2026"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for planning; require product, engineering, legal, and operations approval before altering product or customer-service surfaces.",
+        "outputs": [
+          "Surface inventory",
+          "Product-as-media concept map",
+          "Feasibility and risk score"
+        ],
+        "use_when": "Use when a campaign should use owned product or service surfaces as the campaign platform.",
+        "execution_mode": "analysis-only"
+      }
+    },
+    {
       "id": "marketing/seo-paid-search-synergy",
       "name": "SEO to Paid Search Synergy",
       "description": "Turn top-performing SEO themes into paid search opportunities with keyword clustering and launch-ready recommendations.",
@@ -1236,6 +1405,48 @@
         "tools": [
           "python3"
         ]
+      }
+    },
+    {
+      "id": "marketing/utility-campaign-concept-designer",
+      "name": "Utility Campaign Concept Designer",
+      "description": "Convert a campaign brief into useful interventions that help people, shift behavior, or solve a real friction before generating messages.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-06-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/utility-campaign-concept-designer/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/utility-campaign-concept-designer/0.1.0.tar.gz",
+          "sha256": "513cfb3cacdb18450fd6e082c3e45eb70310fe392dd974eaf73a5e21d8bee53b"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "utility",
+        "creative-concepts",
+        "empowerment",
+        "cannes-2026",
+        "anti-slop"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for concepting; require brand, legal, and operations approval before production or public use.",
+        "outputs": [
+          "Utility-led concept territories",
+          "Behavioral hypothesis",
+          "Proof and feasibility notes",
+          "Risk flags"
+        ],
+        "use_when": "Use when a team wants campaign concepts that do something useful rather than only communicate a message.",
+        "execution_mode": "analysis-only"
       }
     },
     {

--- a/registry/plugins-index.json
+++ b/registry/plugins-index.json
@@ -1,6 +1,6 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-03-31T00:00:00Z",
+  "generated_at": "2026-06-28T00:00:00Z",
   "skills": [
     {
       "id": "agentops/harness-governance-plugin",
@@ -288,6 +288,62 @@
       "requires": {
         "approvals": [
           "human-review-for-publish"
+        ]
+      }
+    },
+    {
+      "id": "marketing/creative-operating-system-plugin",
+      "name": "Creative Operating System Plugin",
+      "description": "Bundle the Creative Operating System workflow into one installable package with audit, concepting, creator, timing, evaluation, and first-run operational templates.",
+      "category": "marketing-plugins/creative",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-06-28T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/creative-operating-system-plugin/plugin.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creative-operating-system-plugin/0.1.0.tar.gz",
+          "sha256": "ccc144aca72dc90100f29f9fbaa9e2beb2e12cc699db957bd4efff7a4a5746c1"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "creative-operating-system",
+        "anti-slop",
+        "creator-ops",
+        "product-as-media",
+        "cultural-timing",
+        "governance"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "includes": {
+        "skills": [
+          "adtech/brand-rag-memory-bootstrap",
+          "marketing/creative-operating-system-audit",
+          "marketing/utility-campaign-concept-designer",
+          "marketing/product-as-media-mapper",
+          "marketing/cultural-timing-signal-triage",
+          "marketing/creator-strategy-brief",
+          "marketing/ai-output-eval-scorecard"
+        ],
+        "agents": [
+          "marketing/creative-operating-system-supervisor"
+        ],
+        "hooks": [
+          "require-memory-before-ideation",
+          "require-launch-gate-review"
+        ]
+      },
+      "requires": {
+        "approvals": [
+          "human-review-before-public-launch",
+          "human-review-before-product-surface-change"
         ]
       }
     },

--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -1,6 +1,6 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-05-06T00:00:00Z",
+  "generated_at": "2026-06-27T00:00:00Z",
   "skills": [
     {
       "id": "adtech/analyst-copilot-bigquery-redshift",
@@ -877,7 +877,7 @@
     {
       "id": "marketing/ai-output-eval-scorecard",
       "name": "AI Output Eval Scorecard",
-      "description": "Score AI-generated marketing outputs across accuracy, clarity, brand fit, policy compliance, and actionability.",
+      "description": "Score AI-generated marketing outputs across accuracy, clarity, brand fit, policy compliance, actionability, and creative operating system fit.",
       "category": "marketing-tools/compliance",
       "latest": "0.1.0",
       "versions": [
@@ -886,7 +886,7 @@
           "released_at": "2026-02-23T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/ai-output-eval-scorecard/skill.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/ai-output-eval-scorecard/0.1.0.tar.gz",
-          "sha256": "2ede4bad097be375886cbbf1a15a44403f63aa425e52ecd0a02c3880c6a9a2c9"
+          "sha256": "94443958e9a1980b1fd47dc9330ab4a3cd1405f547d3b028ec32d74ed2263160"
         }
       ],
       "runtimes": [
@@ -899,7 +899,9 @@
         "governance",
         "qa",
         "llm-judge",
-        "risk-control"
+        "risk-control",
+        "anti-slop",
+        "creative-operating-system"
       ],
       "readiness": "experimental",
       "security_reviewed": false,
@@ -909,15 +911,58 @@
         "outputs": [
           "Scorecard",
           "Verdict",
-          "Rewrite recommendations"
+          "Rewrite recommendations",
+          "Creative operating system scores"
         ],
-        "use_when": "Use when AI-generated marketing outputs need repeatable scoring across quality, compliance, and actionability.",
+        "use_when": "Use when AI-generated marketing outputs need repeatable scoring across quality, compliance, actionability, and creative operating system fit.",
         "execution_mode": "analysis-only"
       },
       "dependencies": {
         "tools": [
           "python3"
         ]
+      }
+    },
+    {
+      "id": "marketing/creative-operating-system-audit",
+      "name": "Creative Operating System Audit",
+      "description": "Audit whether a marketing team has the memory, context, evaluation, creator, product-as-media, feedback, and governance machinery needed for AI-era creative work.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-06-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/creative-operating-system-audit/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creative-operating-system-audit/0.1.0.tar.gz",
+          "sha256": "a013f24ddf01db8293bba41a4609845650cfa5bcd34ef389ea33073f610692c6"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "creative-operating-system",
+        "cannes-2026",
+        "anti-slop",
+        "brand-memory",
+        "governance"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for analysis and planning; require human approval before changing process, governance, or live campaign workflows.",
+        "outputs": [
+          "Creative operating system maturity score",
+          "Gap analysis",
+          "Prioritized action plan",
+          "Evidence table"
+        ],
+        "use_when": "Use when a brand or team wants to assess whether it can turn AI output into distinctive, useful, governed creative work.",
+        "execution_mode": "analysis-only"
       }
     },
     {
@@ -966,6 +1011,49 @@
       }
     },
     {
+      "id": "marketing/creator-strategy-brief",
+      "name": "Creator Strategy Brief",
+      "description": "Create creator briefs that treat creators as strategic collaborators with audience trust, format expertise, and cultural intelligence.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-06-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/creator-strategy-brief/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/creator-strategy-brief/0.1.0.tar.gz",
+          "sha256": "9efafc120c4c2a56edfa990c835d9adc9560a5b4080e0c28283e6bc0b73d486d"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "creators",
+        "creator-commerce",
+        "brief",
+        "cultural-intelligence",
+        "governance"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for brief drafting; require human approval before creator outreach, contracting, claims, or publication.",
+        "outputs": [
+          "Creator role definition",
+          "Brief",
+          "Freedom boundaries",
+          "Measurement plan",
+          "Risk notes"
+        ],
+        "use_when": "Use when building creator-led campaigns where creators should shape the idea, not just distribute it.",
+        "execution_mode": "analysis-only"
+      }
+    },
+    {
       "id": "marketing/cross-channel-budget-pacing-agent",
       "name": "Cross-Channel Budget Pacing Agent",
       "description": "Monitor pacing across paid channels, detect anomalies, and recommend budget reallocation actions.",
@@ -1009,6 +1097,47 @@
         "tools": [
           "python3"
         ]
+      }
+    },
+    {
+      "id": "marketing/cultural-timing-signal-triage",
+      "name": "Cultural Timing Signal Triage",
+      "description": "Decide whether a live cultural moment is worth acting on, and define the safe, fast, brand-fit response path.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-06-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/cultural-timing-signal-triage/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/cultural-timing-signal-triage/0.1.0.tar.gz",
+          "sha256": "c98eccfc05173a20e6493ca99621ce9817f52bd473177f8a0eab3fdc2694d6eb"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "cultural-timing",
+        "real-time-marketing",
+        "risk-review",
+        "approvals"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for triage; require human approval before public response, paid media activation, creator outreach, or legal-risk claims.",
+        "outputs": [
+          "Go/no-go recommendation",
+          "Timing window",
+          "Brand permission check",
+          "Risk and approval path"
+        ],
+        "use_when": "Use when a brand notices a live moment and needs a fast go/no-go recommendation with guardrails.",
+        "execution_mode": "analysis-only"
       }
     },
     {
@@ -1194,6 +1323,46 @@
       }
     },
     {
+      "id": "marketing/product-as-media-mapper",
+      "name": "Product As Media Mapper",
+      "description": "Identify product, app, commerce, service, packaging, data, and owned-channel surfaces that can become campaign media.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-06-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/product-as-media-mapper/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/product-as-media-mapper/0.1.0.tar.gz",
+          "sha256": "0b9bd764bc2fa7d9d03ad919dc37cb3c758ffb3a7436d28c13db4a776e78a8a3"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "product-as-media",
+        "owned-surfaces",
+        "commerce",
+        "cannes-2026"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for planning; require product, engineering, legal, and operations approval before altering product or customer-service surfaces.",
+        "outputs": [
+          "Surface inventory",
+          "Product-as-media concept map",
+          "Feasibility and risk score"
+        ],
+        "use_when": "Use when a campaign should use owned product or service surfaces as the campaign platform.",
+        "execution_mode": "analysis-only"
+      }
+    },
+    {
       "id": "marketing/seo-paid-search-synergy",
       "name": "SEO to Paid Search Synergy",
       "description": "Turn top-performing SEO themes into paid search opportunities with keyword clustering and launch-ready recommendations.",
@@ -1236,6 +1405,48 @@
         "tools": [
           "python3"
         ]
+      }
+    },
+    {
+      "id": "marketing/utility-campaign-concept-designer",
+      "name": "Utility Campaign Concept Designer",
+      "description": "Convert a campaign brief into useful interventions that help people, shift behavior, or solve a real friction before generating messages.",
+      "category": "marketing-tools/creative-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-06-27T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/utility-campaign-concept-designer/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/utility-campaign-concept-designer/0.1.0.tar.gz",
+          "sha256": "513cfb3cacdb18450fd6e082c3e45eb70310fe392dd974eaf73a5e21d8bee53b"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "utility",
+        "creative-concepts",
+        "empowerment",
+        "cannes-2026",
+        "anti-slop"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Safe for concepting; require brand, legal, and operations approval before production or public use.",
+        "outputs": [
+          "Utility-led concept territories",
+          "Behavioral hypothesis",
+          "Proof and feasibility notes",
+          "Risk flags"
+        ],
+        "use_when": "Use when a team wants campaign concepts that do something useful rather than only communicate a message.",
+        "execution_mode": "analysis-only"
       }
     },
     {

--- a/skills/marketing/ai-output-eval-scorecard/README.md
+++ b/skills/marketing/ai-output-eval-scorecard/README.md
@@ -1,11 +1,12 @@
 # AI Output Eval Scorecard
 
-Use this skill to score AI-generated outputs with a repeatable quality
-and compliance rubric.
+Use this skill to score AI-generated outputs with a repeatable quality,
+compliance, and creative operating system rubric.
 
 ## What this skill does
 
 - Scores accuracy, clarity, brand fit, compliance, and actionability.
+- Adds optional Creative Operating System dimensions for Cannes-style creative review: utility, product-as-media potential, cultural timing, human meaning, brand memory, distinctiveness, and creator fit.
 - Flags high-severity findings with evidence.
 - Returns pass/revise/fail verdict.
 
@@ -27,8 +28,9 @@ and compliance rubric.
 
 ```text
 Use AI Output Eval Scorecard.
-Task type: campaign copy
-Score this output for quality and compliance.
+Task type: campaign concept
+Score this output for quality, compliance, utility, distinctiveness,
+product-as-media potential, cultural timing, and brand memory.
 Return overall score, verdict, critical findings,
 and rewrite recommendations.
 ```
@@ -38,6 +40,7 @@ and rewrite recommendations.
 - Dimension scores are clear.
 - Critical findings include concrete evidence.
 - Verdict is actionable.
+- Creative work is not rewarded for polish alone; usefulness, evidence, and brand permission are scored explicitly.
 
 ## Beginner safety checklist
 

--- a/skills/marketing/ai-output-eval-scorecard/SKILL.md
+++ b/skills/marketing/ai-output-eval-scorecard/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: ai-output-eval-scorecard
-description: Evaluate and score AI marketing outputs with a consistent rubric for quality, compliance, and deployment readiness.
+description: Evaluate and score AI marketing outputs with a consistent rubric for quality, compliance, deployment readiness, and creative operating system fit.
 ---
 
 # AI Output Eval Scorecard
 
 ## When to use
-Use before shipping AI-generated copy, reports, or recommendations when you need a repeatable quality and risk score.
+Use before shipping AI-generated copy, reports, recommendations, campaign concepts, creator briefs, or creative strategy outputs when you need a repeatable quality and risk score.
 
 ## Inputs required
 - task_type
@@ -15,18 +15,28 @@ Use before shipping AI-generated copy, reports, or recommendations when you need
 - brand_rules
 - policy_rules
 - scoring_weights
+- optional_creative_operating_system_dimensions
 
 ## Workflow
 1. Parse task context and output.
-2. Score dimensions: accuracy, clarity, brand fit, policy compliance, actionability.
-3. Flag critical findings with severity and evidence.
-4. Provide targeted rewrite recommendations.
-5. Return verdict and confidence.
+2. Score core dimensions: accuracy, clarity, brand fit, policy compliance, actionability.
+3. If the output is campaign, creator, cultural, or Cannes-style creative work, also score Creative Operating System dimensions:
+   - utility: does it help people do something useful?
+   - product_as_media_potential: can the idea live in product, service, commerce, CRM, app, packaging, or another owned surface?
+   - cultural_timing: is the timing earned, safe, and relevant?
+   - human_meaning: does it connect to a real behavior, tension, need, or social context?
+   - brand_memory: does it use approved brand knowledge and avoid generic category language?
+   - distinctiveness: would the output still be recognizable if the logo was removed?
+   - creator_fit: if creators are involved, does the idea preserve creator voice and audience trust?
+4. Flag critical findings with severity and evidence.
+5. Provide targeted rewrite or rework recommendations.
+6. Return verdict and confidence.
 
 ## Output format
 - overall_score (0-100)
 - verdict (`pass`, `revise`, `fail`)
 - dimension_scores
+- creative_operating_system_scores (when relevant)
 - critical_findings
 - rewrite_recommendations
 - confidence
@@ -35,3 +45,5 @@ Use before shipping AI-generated copy, reports, or recommendations when you need
 - Never infer policy pass if rules are incomplete.
 - Cite concrete evidence for each high-severity finding.
 - Do not fabricate legal or platform rules.
+- Do not reward polished language if the idea lacks evidence, utility, or brand permission.
+- Flag unsupported claims even when they sound strategically attractive.

--- a/skills/marketing/ai-output-eval-scorecard/skill.yaml
+++ b/skills/marketing/ai-output-eval-scorecard/skill.yaml
@@ -1,6 +1,6 @@
 id: marketing/ai-output-eval-scorecard
 name: AI Output Eval Scorecard
-description: Score AI-generated marketing outputs across accuracy, clarity, brand fit, policy compliance, and actionability.
+description: Score AI-generated marketing outputs across accuracy, clarity, brand fit, policy compliance, actionability, and creative operating system fit.
 version: 0.1.0
 released_at: "2026-02-23T00:00:00Z"
 category: marketing-tools/compliance
@@ -10,6 +10,8 @@ tags:
   - qa
   - llm-judge
   - risk-control
+  - anti-slop
+  - creative-operating-system
 license: MIT
 author:
   name: AI Skills Guide Maintainers
@@ -28,12 +30,13 @@ dependencies:
   tools:
     - python3
 operational:
-  use_when: Use when AI-generated marketing outputs need repeatable scoring across quality, compliance, and actionability.
+  use_when: Use when AI-generated marketing outputs need repeatable scoring across quality, compliance, actionability, and creative operating system fit.
   execution_mode: analysis-only
   outputs:
     - Scorecard
     - Verdict
     - Rewrite recommendations
+    - Creative operating system scores
   approval_boundary: Safe for evaluation and recommendation; require human approval before approving externally visible copy.
 verification:
   tests_min_prompts: 5

--- a/skills/marketing/creative-operating-system-audit/README.md
+++ b/skills/marketing/creative-operating-system-audit/README.md
@@ -1,0 +1,26 @@
+# Creative Operating System Audit
+
+Assess whether a brand has the machinery needed to produce distinctive AI-assisted creative work.
+
+## What this skill does
+
+- Scores the team's creative operating system across seven dimensions.
+- Finds gaps that produce generic AI output.
+- Turns the audit into a practical 30-day improvement plan.
+
+## First run prompt
+
+```text
+Use Creative Operating System Audit.
+Brand: [brand]
+Current workflow: [brief -> creation -> review -> launch -> learning]
+Known assets: [brand book, campaign archive, performance reports]
+Question: Where are we at risk of producing AI slop, and what should we fix first?
+```
+
+## Good output includes
+
+- Evidence-backed maturity score.
+- Specific operational gaps.
+- First artifacts to create.
+- Clear owners and next steps.

--- a/skills/marketing/creative-operating-system-audit/SKILL.md
+++ b/skills/marketing/creative-operating-system-audit/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: creative-operating-system-audit
+description: Audit a marketing team's creative operating system: brand memory, cultural context, evaluation, product-as-media surfaces, creator workflow, feedback loops, and governance.
+---
+
+# Creative Operating System Audit
+
+## When to use
+Use this skill when a team asks whether its AI-assisted marketing process can produce distinctive, useful, governed creative work rather than more generic content.
+
+## Inputs required
+- Brand or client name
+- Current creative workflow
+- Brand guidelines or memory sources
+- Campaign examples or recent outputs
+- Review and approval process
+- Data and feedback sources
+- Creator or partner workflow, if any
+- Product, app, CRM, retail, commerce, or service surfaces
+
+## Workflow
+1. Map the current creative workflow from brief to launch to post-launch learning.
+2. Score seven dimensions: brand memory, cultural context, judgment/evaluation, utility, product-as-media, creator collaboration, and governance.
+3. Identify evidence for each score. Separate observed facts from assumptions.
+4. Flag gaps that create AI slop risk: generic outputs, weak memory, vague evaluation, untracked rights, missing feedback loops.
+5. Recommend a 30-day improvement plan with owner, first artifact, and success signal.
+
+## Output format
+Return:
+- `overall_maturity_score` from 0-100
+- `dimension_scores`
+- `evidence_table`
+- `top_gaps`
+- `30_day_action_plan`
+- `risks_if_ignored`
+- `next_skills_to_use`
+
+## Guardrails
+- Do not treat asset volume as creative maturity.
+- Do not infer governance controls without evidence.
+- Call out missing source material explicitly.
+- Keep recommendations practical and owned by real functions.
+- Separate creative judgment gaps from tooling gaps.

--- a/skills/marketing/creative-operating-system-audit/examples/output.json
+++ b/skills/marketing/creative-operating-system-audit/examples/output.json
@@ -1,0 +1,22 @@
+{
+  "overall_maturity_score": 54,
+  "dimension_scores": {
+    "brand_memory": 60,
+    "cultural_context": 45,
+    "creative_evaluation": 35,
+    "utility_orientation": 50,
+    "product_as_media": 40,
+    "creator_collaboration": 55,
+    "governance": 70
+  },
+  "top_gaps": [
+    "No explicit anti-slop review rubric",
+    "Brand memory is stored as static PDFs, not retrievable examples",
+    "Post-launch learning is not connected back to briefs"
+  ],
+  "next_actions": [
+    "Create a 1-page creative evaluation rubric",
+    "Build a brand memory pack with strong and weak examples",
+    "Tag last 10 campaigns by concept territory and performance signal"
+  ]
+}

--- a/skills/marketing/creative-operating-system-audit/skill.yaml
+++ b/skills/marketing/creative-operating-system-audit/skill.yaml
@@ -1,0 +1,42 @@
+id: marketing/creative-operating-system-audit
+name: Creative Operating System Audit
+description: Audit whether a marketing team has the memory, context, evaluation, creator, product-as-media, feedback, and governance machinery needed for AI-era creative work.
+version: 0.1.0
+released_at: "2026-06-27T00:00:00Z"
+category: marketing-tools/creative-ops
+tags:
+  - creative-operating-system
+  - cannes-2026
+  - anti-slop
+  - brand-memory
+  - governance
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools: []
+operational:
+  use_when: Use when a brand or team wants to assess whether it can turn AI output into distinctive, useful, governed creative work.
+  execution_mode: analysis-only
+  outputs:
+    - Creative operating system maturity score
+    - Gap analysis
+    - Prioritized action plan
+    - Evidence table
+  approval_boundary: Safe for analysis and planning; require human approval before changing process, governance, or live campaign workflows.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/marketing/creative-operating-system-audit/tests/test-prompts.md
+++ b/skills/marketing/creative-operating-system-audit/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Audit our AI creative workflow for a retail brand with brand guidelines, creator briefs, and paid social outputs.
+2. Score our creative operating system using only the evidence in this workflow description and flag missing inputs.
+3. Compare two teams: one has a strong brand archive but weak approvals, the other has strong approvals but no campaign memory.
+4. Produce a 30-day action plan for reducing AI slop risk in a performance creative team.
+5. Identify which part of our workflow should become a reusable skill first.

--- a/skills/marketing/creator-strategy-brief/README.md
+++ b/skills/marketing/creator-strategy-brief/README.md
@@ -1,0 +1,15 @@
+# Creator Strategy Brief
+
+Draft briefs for creator-led campaigns where creators help shape the idea.
+
+## First run prompt
+
+```text
+Use Creator Strategy Brief.
+Brand: [brand]
+Objective: [objective]
+Creator type: [creator/community]
+Product truth: [truth]
+Claims/disclosures: [rules]
+Create a brief that preserves creator voice and defines review boundaries.
+```

--- a/skills/marketing/creator-strategy-brief/SKILL.md
+++ b/skills/marketing/creator-strategy-brief/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: creator-strategy-brief
+description: Draft creator strategy briefs that preserve creator voice while protecting brand, claim, and campaign boundaries.
+---
+
+# Creator Strategy Brief
+
+## When to use
+Use this skill when a creator is a strategic collaborator, cultural translator, product tester, or commerce partner rather than a media slot.
+
+## Inputs required
+- Brand and campaign objective
+- Creator profile or desired creator type
+- Audience and community context
+- Product or service truth
+- Claims and compliance rules
+- Creative freedom boundaries
+- Required deliverables and channels
+- Measurement goals
+
+## Workflow
+1. Define why a creator is needed beyond reach.
+2. Describe the creator's strategic role: interpreter, tester, host, educator, entertainer, community lead, or commerce partner.
+3. Draft a brief that gives direction without flattening creator voice.
+4. Define freedom boundaries, claim boundaries, mandatory disclosures, and approval moments.
+5. Define measurement beyond views: trust signals, saves, comments quality, assisted conversion, product feedback, community response.
+
+## Output format
+Return:
+- `creator_role`
+- `brief`
+- `creative_freedom`
+- `non_negotiables`
+- `claims_and_disclosures`
+- `measurement_plan`
+- `review_process`
+- `risk_notes`
+
+## Guardrails
+- Do not script the creator so tightly that the audience trust is destroyed.
+- Do not bury disclosure requirements.
+- Flag claims that need proof.
+- Respect creator/community context and avoid treating creators as rented reach.

--- a/skills/marketing/creator-strategy-brief/examples/output.json
+++ b/skills/marketing/creator-strategy-brief/examples/output.json
@@ -1,0 +1,6 @@
+{
+  "creator_role": "Product tester and community interpreter",
+  "creative_freedom": ["Use creator's usual format", "Show real trial process", "Keep honest trade-offs"],
+  "non_negotiables": ["FTC disclosure", "No unsupported performance claims"],
+  "measurement_plan": ["comment quality", "saves", "assisted conversions", "product feedback themes"]
+}

--- a/skills/marketing/creator-strategy-brief/skill.yaml
+++ b/skills/marketing/creator-strategy-brief/skill.yaml
@@ -1,0 +1,43 @@
+id: marketing/creator-strategy-brief
+name: Creator Strategy Brief
+description: Create creator briefs that treat creators as strategic collaborators with audience trust, format expertise, and cultural intelligence.
+version: 0.1.0
+released_at: "2026-06-27T00:00:00Z"
+category: marketing-tools/creative-ops
+tags:
+  - creators
+  - creator-commerce
+  - brief
+  - cultural-intelligence
+  - governance
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools: []
+operational:
+  use_when: Use when building creator-led campaigns where creators should shape the idea, not just distribute it.
+  execution_mode: analysis-only
+  outputs:
+    - Creator role definition
+    - Brief
+    - Freedom boundaries
+    - Measurement plan
+    - Risk notes
+  approval_boundary: Safe for brief drafting; require human approval before creator outreach, contracting, claims, or publication.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/marketing/creator-strategy-brief/tests/test-prompts.md
+++ b/skills/marketing/creator-strategy-brief/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Write a creator brief for a skincare product where the creator should test and explain, not just endorse.
+2. Convert this influencer media buy into a creator collaboration brief with strategic role and freedom boundaries.
+3. Create a creator commerce brief with required disclosures and product truth constraints.
+4. Review this creator brief and flag where it over-controls the creator voice.
+5. Define measurement for a creator campaign beyond reach and views.

--- a/skills/marketing/cultural-timing-signal-triage/README.md
+++ b/skills/marketing/cultural-timing-signal-triage/README.md
@@ -1,0 +1,14 @@
+# Cultural Timing Signal Triage
+
+Decide whether a live cultural moment deserves a brand response.
+
+## First run prompt
+
+```text
+Use Cultural Timing Signal Triage.
+Signal: [describe moment]
+Brand: [brand]
+Audience: [audience]
+Possible response: [idea]
+Should we act, watch, adapt, or do nothing?
+```

--- a/skills/marketing/cultural-timing-signal-triage/SKILL.md
+++ b/skills/marketing/cultural-timing-signal-triage/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: cultural-timing-signal-triage
+description: Triage live cultural moments for brand fit, timing, risk, usefulness, and approval path before a response is created.
+---
+
+# Cultural Timing Signal Triage
+
+## When to use
+Use this skill when a team wants to respond to a live cultural moment, fandom, meme, crisis, creator trend, sports event, or market conversation.
+
+## Inputs required
+- Description of the cultural signal
+- Source and evidence of momentum
+- Brand relevance
+- Audience overlap
+- Proposed response idea
+- Timing window
+- Risk categories and approval owners
+
+## Workflow
+1. Summarize the cultural signal and verify the moment is real enough to consider.
+2. Assess brand permission: why this brand has a right to participate.
+3. Score timing urgency, audience relevance, usefulness, risk, and execution complexity.
+4. Recommend `go`, `watch`, `adapt`, or `do_not_act`.
+5. Define response shape, approval route, and expiry time.
+
+## Output format
+Return:
+- `signal_summary`
+- `brand_permission`
+- `score_table`
+- `recommendation`
+- `response_window`
+- `approval_route`
+- `risk_notes`
+- `draft_next_step`
+
+## Guardrails
+- Do not recommend opportunistic responses to tragedy, harm, or sensitive crises without explicit ethical review.
+- Prefer useful contribution over brand insertion.
+- Flag low brand permission even if the moment is popular.
+- Include an expiry time; live moments decay.

--- a/skills/marketing/cultural-timing-signal-triage/examples/output.json
+++ b/skills/marketing/cultural-timing-signal-triage/examples/output.json
@@ -1,0 +1,7 @@
+{
+  "recommendation": "adapt",
+  "brand_permission": "medium",
+  "response_window": "12 hours",
+  "risk_notes": ["Avoid implying official partnership", "Do not use artist likeness"],
+  "next_step": "Draft a utility-led post that helps fans plan around the event rather than hijacking the meme."
+}

--- a/skills/marketing/cultural-timing-signal-triage/skill.yaml
+++ b/skills/marketing/cultural-timing-signal-triage/skill.yaml
@@ -1,0 +1,41 @@
+id: marketing/cultural-timing-signal-triage
+name: Cultural Timing Signal Triage
+description: Decide whether a live cultural moment is worth acting on, and define the safe, fast, brand-fit response path.
+version: 0.1.0
+released_at: "2026-06-27T00:00:00Z"
+category: marketing-tools/creative-ops
+tags:
+  - cultural-timing
+  - real-time-marketing
+  - risk-review
+  - approvals
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools: []
+operational:
+  use_when: Use when a brand notices a live moment and needs a fast go/no-go recommendation with guardrails.
+  execution_mode: analysis-only
+  outputs:
+    - Go/no-go recommendation
+    - Timing window
+    - Brand permission check
+    - Risk and approval path
+  approval_boundary: Safe for triage; require human approval before public response, paid media activation, creator outreach, or legal-risk claims.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/marketing/cultural-timing-signal-triage/tests/test-prompts.md
+++ b/skills/marketing/cultural-timing-signal-triage/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Triage whether a snack brand should respond to a viral sports moment in the next six hours.
+2. Decide if a financial services brand has permission to join a celebrity meme trend.
+3. Score a proposed crisis response and identify whether the brand should act or stay silent.
+4. Create a safe approval route for a real-time creator collaboration around a music event.
+5. Assess whether a retail brand should react to a competitor outage with humour or utility.

--- a/skills/marketing/product-as-media-mapper/README.md
+++ b/skills/marketing/product-as-media-mapper/README.md
@@ -1,0 +1,13 @@
+# Product As Media Mapper
+
+Find where the product itself can become the campaign surface.
+
+## First run prompt
+
+```text
+Use Product As Media Mapper.
+Brand: [brand]
+Campaign objective: [objective]
+Owned surfaces: [app, site, CRM, packaging, checkout, customer service]
+Find product-as-media opportunities and rank by usefulness, feasibility, and risk.
+```

--- a/skills/marketing/product-as-media-mapper/SKILL.md
+++ b/skills/marketing/product-as-media-mapper/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: product-as-media-mapper
+description: Map how a brand's product, app, site, CRM, checkout, packaging, service, data, or creator surfaces can become campaign media.
+---
+
+# Product As Media Mapper
+
+## When to use
+Use this skill when a team wants to move beyond paid placements and find owned surfaces that can carry the creative idea.
+
+## Inputs required
+- Product/service description
+- Owned digital and physical surfaces
+- Customer journey touchpoints
+- Technical constraints
+- Data availability
+- Operational owners
+- Campaign objective
+
+## Workflow
+1. Inventory owned surfaces across product, app, site, CRM, packaging, stores, service, and commerce.
+2. Identify where people already experience friction, attention, or decision pressure.
+3. Propose product-as-media uses for each promising surface.
+4. Score ideas for customer value, brand fit, technical feasibility, operational risk, and measurement clarity.
+5. Recommend the top concepts and required stakeholders.
+
+## Output format
+Return:
+- `surface_inventory`
+- `opportunity_map`
+- `top_product_as_media_concepts`
+- `dependencies`
+- `risk_register`
+- `measurement_plan`
+
+## Guardrails
+- Do not recommend intrusive changes to critical product or service flows without noting operational risk.
+- Do not turn customer-service surfaces into covert ads.
+- Prioritize usefulness and clarity over novelty.
+- Identify the owner of every surface before recommending action.

--- a/skills/marketing/product-as-media-mapper/examples/output.json
+++ b/skills/marketing/product-as-media-mapper/examples/output.json
@@ -1,0 +1,11 @@
+{
+  "surface_inventory": ["mobile app", "order tracking", "email receipts", "packaging QR", "returns portal"],
+  "top_product_as_media_concepts": [
+    {
+      "surface": "order tracking",
+      "idea": "Turn waiting time into a helpful setup guide",
+      "customer_value": "Reduces post-purchase uncertainty",
+      "score": 82
+    }
+  ]
+}

--- a/skills/marketing/product-as-media-mapper/skill.yaml
+++ b/skills/marketing/product-as-media-mapper/skill.yaml
@@ -1,0 +1,40 @@
+id: marketing/product-as-media-mapper
+name: Product As Media Mapper
+description: Identify product, app, commerce, service, packaging, data, and owned-channel surfaces that can become campaign media.
+version: 0.1.0
+released_at: "2026-06-27T00:00:00Z"
+category: marketing-tools/creative-ops
+tags:
+  - product-as-media
+  - owned-surfaces
+  - commerce
+  - cannes-2026
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools: []
+operational:
+  use_when: Use when a campaign should use owned product or service surfaces as the campaign platform.
+  execution_mode: analysis-only
+  outputs:
+    - Surface inventory
+    - Product-as-media concept map
+    - Feasibility and risk score
+  approval_boundary: Safe for planning; require product, engineering, legal, and operations approval before altering product or customer-service surfaces.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/marketing/product-as-media-mapper/tests/test-prompts.md
+++ b/skills/marketing/product-as-media-mapper/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Map product-as-media opportunities for a grocery delivery app launching a sustainability campaign.
+2. Identify owned surfaces for a bank where a fraud-prevention idea could live without feeling like an ad.
+3. Rank these app surfaces by feasibility and customer value for a campaign idea.
+4. Turn this packaging and QR code flow into a campaign platform without interrupting the customer.
+5. Find product-as-media opportunities in a subscription cancellation and winback journey.

--- a/skills/marketing/utility-campaign-concept-designer/README.md
+++ b/skills/marketing/utility-campaign-concept-designer/README.md
@@ -1,0 +1,20 @@
+# Utility Campaign Concept Designer
+
+Turn campaign briefs into useful interventions before writing copy.
+
+## What this skill does
+
+- Finds the human friction behind a brief.
+- Generates utility-led creative territories.
+- Scores concepts by usefulness, brand fit, feasibility, and risk.
+
+## First run prompt
+
+```text
+Use Utility Campaign Concept Designer.
+Brand: [brand]
+Objective: [objective]
+Audience friction: [friction]
+Available surfaces: [app/site/store/CRM/packaging/data/creators]
+Generate useful concepts before messaging.
+```

--- a/skills/marketing/utility-campaign-concept-designer/SKILL.md
+++ b/skills/marketing/utility-campaign-concept-designer/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: utility-campaign-concept-designer
+description: Design campaign concepts that provide real utility: protection, help, proof, simplification, safety, learning, belonging, or behavior change.
+---
+
+# Utility Campaign Concept Designer
+
+## When to use
+Use this skill when the brief risks becoming another message-first campaign and the team wants ideas that help people or change behavior.
+
+## Inputs required
+- Brand and category
+- Business objective
+- Audience tension or friction
+- Product/service capabilities
+- Available surfaces: app, site, store, CRM, packaging, data, customer service, creators
+- Constraints: legal, budget, timing, markets
+
+## Workflow
+1. Restate the human friction behind the brief.
+2. Convert the brief from `what do we want to say?` to `what can we help people do?`.
+3. Generate 5-7 utility territories, each with a behavioral hypothesis.
+4. Score each territory for usefulness, brand fit, cultural timing, feasibility, and risk.
+5. Select the strongest 2-3 and describe execution paths.
+
+## Output format
+Return:
+- `human_friction`
+- `utility_territories`
+- `score_table`
+- `recommended_concepts`
+- `required_proof`
+- `operational_dependencies`
+- `risk_notes`
+
+## Guardrails
+- Do not present a message as utility unless it changes what someone can do.
+- Avoid manipulative urgency, false scarcity, or exploitative emotional triggers.
+- Call out when the product cannot credibly deliver the proposed help.
+- Prefer simple useful interventions over complex stunts.

--- a/skills/marketing/utility-campaign-concept-designer/examples/output.json
+++ b/skills/marketing/utility-campaign-concept-designer/examples/output.json
@@ -1,0 +1,12 @@
+{
+  "human_friction": "Parents need fast reassurance that a product is safe and available before a school trip.",
+  "recommended_concepts": [
+    {
+      "name": "Trip-ready checker",
+      "utility": "Builds a checklist from trip length, weather, and child age.",
+      "behavioral_hypothesis": "Reducing uncertainty increases purchase confidence and sharing between parents.",
+      "score": 87
+    }
+  ],
+  "risk_notes": ["Requires accurate inventory and safety claim review"]
+}

--- a/skills/marketing/utility-campaign-concept-designer/skill.yaml
+++ b/skills/marketing/utility-campaign-concept-designer/skill.yaml
@@ -1,0 +1,42 @@
+id: marketing/utility-campaign-concept-designer
+name: Utility Campaign Concept Designer
+description: Convert a campaign brief into useful interventions that help people, shift behavior, or solve a real friction before generating messages.
+version: 0.1.0
+released_at: "2026-06-27T00:00:00Z"
+category: marketing-tools/creative-ops
+tags:
+  - utility
+  - creative-concepts
+  - empowerment
+  - cannes-2026
+  - anti-slop
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools: []
+operational:
+  use_when: Use when a team wants campaign concepts that do something useful rather than only communicate a message.
+  execution_mode: analysis-only
+  outputs:
+    - Utility-led concept territories
+    - Behavioral hypothesis
+    - Proof and feasibility notes
+    - Risk flags
+  approval_boundary: Safe for concepting; require brand, legal, and operations approval before production or public use.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/marketing/utility-campaign-concept-designer/tests/test-prompts.md
+++ b/skills/marketing/utility-campaign-concept-designer/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Turn this skincare launch brief into utility-led campaign concepts rather than product benefit copy.
+2. Generate concepts for a bank that help customers avoid fraud during travel season.
+3. Score these three concepts for usefulness, feasibility, brand fit, and risk.
+4. Convert a loyalty-app message campaign into an intervention that helps shoppers save time.
+5. Identify whether this proposed concept is real utility or just a message with a feature attached.


### PR DESCRIPTION
## Summary
- Adds the Creative Operating System skill pack for Cannes-inspired anti-slop creative workflows.
- Adds five new marketing skills for operating-system audits, utility concepts, product-as-media mapping, cultural timing, and creator briefs.
- Adds a coordinating Creative Operating System supervisor agent.
- Extends the AI Output Eval Scorecard with creative operating system scoring dimensions.
- Regenerates registry indexes and updates README catalog counts.

## Validation
- `make validate`
- `make manifests`
- `make registry`
- `make ci-local`
