### PR TITLE
Codex/release automation

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,159 @@
+name: Cut Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Version bump to cut from the latest tag
+        required: true
+        type: choice
+        default: minor-alpha
+        options:
+          - patch
+          - minor
+          - major
+          - patch-alpha
+          - minor-alpha
+          - major-alpha
+      dry_run:
+        description: Compute and validate without pushing the tag
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  cut-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install check-jsonschema
+        run: python3 -m pip install --upgrade pip check-jsonschema
+
+      - name: Compute next tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          latest_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+          if [[ -z "$latest_tag" ]]; then
+            latest_tag="v0.0.0"
+          fi
+
+          version="${latest_tag#v}"
+          base="${version%%-*}"
+          prerelease=""
+          if [[ "$version" == *-* ]]; then
+            prerelease="${version#*-}"
+          fi
+
+          IFS=. read -r major minor patch <<< "$base"
+          release_type="${{ inputs.release_type }}"
+
+          case "$release_type" in
+            major|major-alpha)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            minor|minor-alpha)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            patch|patch-alpha)
+              patch=$((patch + 1))
+              ;;
+            *)
+              echo "Unsupported release type: $release_type" >&2
+              exit 1
+              ;;
+          esac
+
+          next_tag="v${major}.${minor}.${patch}"
+          if [[ "$release_type" == *-alpha ]]; then
+            next_tag="${next_tag}-alpha.1"
+          elif [[ "$prerelease" == alpha.* ]]; then
+            next_tag="v${major}.${minor}.${patch}"
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$next_tag" >/dev/null; then
+            echo "Tag already exists: $next_tag" >&2
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$next_tag" >/dev/null 2>&1; then
+            echo "Tag already exists on origin: $next_tag" >&2
+            exit 1
+          fi
+
+          {
+            echo "latest_tag=$latest_tag"
+            echo "next_tag=$next_tag"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Latest tag: $latest_tag"
+          echo "Next tag: $next_tag"
+
+      - name: Validate skills
+        run: bash scripts/validate-skills.sh
+
+      - name: Rebuild registry
+        run: make registry
+
+      - name: Validate manifests and registry schemas
+        run: bash scripts/validate-manifests.sh
+
+      - name: Ensure generated registry is committed
+        run: |
+          git diff --exit-code \
+            registry/index.json \
+            registry/skills-index.json \
+            registry/agents-index.json \
+            registry/tools-index.json \
+            registry/plugins-index.json
+
+      - name: Install web dependencies
+        working-directory: apps/web
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint web app
+        working-directory: apps/web
+        run: pnpm lint
+
+      - name: Build web app
+        working-directory: apps/web
+        run: pnpm build
+
+      - name: Push release tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git tag "${{ steps.version.outputs.next_tag }}"
+          git push origin "${{ steps.version.outputs.next_tag }}"
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Dry run complete. Tag not pushed."
+          echo "Latest tag: ${{ steps.version.outputs.latest_tag }}"
+          echo "Next tag: ${{ steps.version.outputs.next_tag }}"

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 20
           cache: pnpm
           cache-dependency-path: apps/web/pnpm-lock.yaml
 

--- a/README.md
+++ b/README.md
@@ -275,11 +275,15 @@ Useful sections include skills for:
 ## Quickstart
 
 1. Pick a module entry under `skills/`, `agents/`, `plugins/`, or `tools-mcp/`.
-2. Read `README.md` and the module spec file (`SKILL.md`/`AGENT.md`/`plugin.json`/`TOOL.md`).
+2. Read `README.md` and the module spec file
+   (`SKILL.md`/`AGENT.md`/`plugin.json`/`TOOL.md`).
 3. Run prompts in `tests/test-prompts.md`.
 4. Verify structure with `bash scripts/validate-skills.sh`.
 5. Validate manifests with `bash scripts/validate-manifests.sh`.
 6. Submit improvements via PR.
+
+Release workflow and version bump definitions are documented in
+[docs/versioning-and-release.md](docs/versioning-and-release.md).
 
 ## Install New Skill Packs
 

--- a/docs/versioning-and-release.md
+++ b/docs/versioning-and-release.md
@@ -28,25 +28,85 @@ git tag v0.2.0-alpha.1
 git push origin v0.2.0-alpha.1
 ```
 
-## Automated release cut (recommended)
+## GitHub release cut (recommended)
 
-From a clean `main` branch, run:
+Use the `Cut Release` workflow from the GitHub Actions tab. It is a manual
+workflow so maintainers can decide which merged changes deserve a public
+release.
+
+Inputs:
+
+- `release_type`: the version bump to cut from the latest `v*` tag.
+- `dry_run`: validates and computes the next tag without pushing it.
+
+Recommended flow:
+
+1. Merge `dev` into `main`.
+2. Open GitHub Actions.
+3. Run `Cut Release` with `dry_run: true`.
+4. Confirm the computed tag and checks.
+5. Re-run with `dry_run: false`.
+
+The workflow runs validation, rebuilds the registry, checks generated files,
+installs the web app, lints it, builds it, and then pushes the computed tag.
+The tag push triggers `.github/workflows/release-on-tag.yml`.
+
+## Release type definitions
+
+Use semantic versioning: `vMAJOR.MINOR.PATCH`.
+
+`patch`:
+
+- Small stable fixes.
+- Example: `v0.2.0-alpha.1` -> `v0.2.1`.
+- Use for bug fixes, docs fixes, CI fixes, and no new capability.
+
+`minor`:
+
+- New stable backward-compatible capability.
+- Example: `v0.2.0-alpha.1` -> `v0.3.0`.
+- Use for new plugins, skills, agents, catalog features, or install behavior
+  that does not break existing users.
+
+`major`:
+
+- Stable breaking release.
+- Example: `v0.2.0-alpha.1` -> `v1.0.0`.
+- Use when schemas, registry contracts, CLI behavior, or install layout break
+  existing consumers.
+
+`patch-alpha`:
+
+- Prerelease patch.
+- Example: `v0.2.0-alpha.1` -> `v0.2.1-alpha.1`.
+- Use for small fixes that should remain marked experimental.
+
+`minor-alpha`:
+
+- Prerelease minor.
+- Example: `v0.2.0-alpha.1` -> `v0.3.0-alpha.1`.
+- Use for new capabilities that are still alpha. This is the usual choice for
+  catalog/plugin waves.
+
+`major-alpha`:
+
+- Prerelease major.
+- Example: `v0.2.0-alpha.1` -> `v1.0.0-alpha.1`.
+- Use when preparing breaking changes that are not ready to call stable.
+
+## Local release cut fallback
+
+If GitHub Actions is unavailable, a maintainer can still cut a release from a
+clean `main` branch:
 
 ```bash
-make release-cut VERSION=v0.2.0-alpha.2
+make release-cut VERSION=v0.3.0-alpha.1
 ```
-
-What this does:
-- verifies clean working tree and `main` branch
-- fast-forwards `main` from `origin/main`
-- runs skill validation and registry generation checks
-- runs web install, lint, and build checks
-- creates and pushes the tag
 
 Optional:
 
 ```bash
-RUN_E2E=1 make release-cut VERSION=v0.2.0-alpha.2
+RUN_E2E=1 make release-cut VERSION=v0.3.0-alpha.1
 ```
 
 to include local Playwright smoke tests before tagging.


### PR DESCRIPTION
## Summary

This PR adds a manual release automation workflow and documents the release type options.

The goal is to remove the need for maintainers to create release tags locally while keeping release timing intentional.

## What changed

- Added `.github/workflows/cut-release.yml`
- Added a manual `Cut Release` GitHub Actions workflow
- Workflow computes the next tag from the latest `v*` tag
- Workflow supports:
  - `patch`
  - `minor`
  - `major`
  - `patch-alpha`
  - `minor-alpha`
  - `major-alpha`
- Workflow defaults to `dry_run: true`
- Workflow validates before pushing a tag:
  - skill structure
  - registry generation
  - manifest schemas
  - generated registry drift
  - web install
  - web lint
  - web build
- Updated `docs/versioning-and-release.md`
- Added a README pointer to the release docs

## Release behavior

When `dry_run` is true:
- computes the next tag
- runs validation
- does not push a tag

When `dry_run` is false:
- computes the next tag
- runs validation
- pushes the tag

The existing `release-on-tag.yml` workflow remains responsible for publishing the GitHub Release after the tag is pushed.

## Validation

Passed locally:

- YAML parse check for `.github/workflows/cut-release.yml`
- `bash scripts/validate-manifests.sh`
- `go test ./internal/registry ./cmd/registry-builder ./cmd/skills-hub ./internal/installer ./internal/plugins`

Also verified version computation:

- `v0.2.0-alpha.1` + `minor-alpha` -> `v0.3.0-alpha.1`

## Notes

The workflow intentionally runs from `main`, even when introduced via `dev`, because releases should be cut only from merged production state.
