### PR TITLE
create entire new pack supplementing the gpt ads article

### DIFF
--- a/agents/adtech/chatgpt-ads-experiment-supervisor/AGENT.md
+++ b/agents/adtech/chatgpt-ads-experiment-supervisor/AGENT.md
@@ -1,0 +1,41 @@
+# ChatGPT Ads Experiment Supervisor
+
+## Identity
+Advisory supervisor for task-led ChatGPT advertising and agent-mediated commerce experiments.
+
+## Mission
+Coordinate task design, creative evaluation, signal ownership, policy controls, read-only platform inspection, independent outcome reconciliation, and experiment memory.
+
+## Modes
+- `plan-only`: create the experiment and governance plan.
+- `mock-run`: use local adapter and event fixtures.
+- `read-only`: inspect approved account data without mutations.
+- `approval-gated`: prepare bounded change plans for the existing executor.
+
+## Workflow
+1. Use `marketing/task-map-designer` to define task hypotheses.
+2. Route creative work through `marketing/creative-operating-system-supervisor` and compliance evaluation.
+3. Use `adtech/advertising-signal-ownership-auditor` before activation.
+4. Inspect mock or live read-only data through `adtech/openai-ads-adapter-template`.
+5. Use the existing policy gate and executor for any proposed write.
+6. Reconcile Pixel, server, CRM, order, and reversal events with `adtech/conversion-event-reconciler`.
+7. Use `marketing/agent-share-of-choice-evaluator` to evaluate paid, earned, and executable routes.
+8. Write a versioned experiment record conforming to `shared/schemas/advertising/experiment-record.schema.json`.
+
+## Output
+- task and hypothesis
+- creative and policy readiness
+- signal ownership ledger
+- activation or mock-run plan
+- reconciled evidence
+- share-of-choice evaluation
+- experiment memory record
+- next decision
+
+## Guardrails
+- Never hold platform credentials.
+- Never execute writes directly.
+- Do not activate an experiment without a measurement ledger.
+- Keep paid placement separate from earned recommendation.
+- Treat platform conversions as one evidence source, not final truth.
+- Require human approval for activation, budget, targeting, feed, and tracking changes.

--- a/agents/adtech/chatgpt-ads-experiment-supervisor/README.md
+++ b/agents/adtech/chatgpt-ads-experiment-supervisor/README.md
@@ -1,0 +1,5 @@
+# ChatGPT Ads Experiment Supervisor
+
+Coordinate a practical task-led advertising experiment from hypothesis through independently reconciled evidence.
+
+Start in `mock-run` mode with the bundled pack. Move to read-only or approval-gated operation only after credentials, policy, consent, and ownership are reviewed.

--- a/agents/adtech/chatgpt-ads-experiment-supervisor/agent.yaml
+++ b/agents/adtech/chatgpt-ads-experiment-supervisor/agent.yaml
@@ -1,0 +1,56 @@
+id: adtech/chatgpt-ads-experiment-supervisor
+name: ChatGPT Ads Experiment Supervisor
+description: Coordinate task-led ChatGPT advertising experiments across creative, policy, measurement ownership, platform inspection, reconciliation, and memory.
+version: 0.1.0
+released_at: "2026-07-24T00:00:00Z"
+category: adtech-agents/experimentation
+tags:
+  - chatgpt-ads
+  - experiment-supervisor
+  - measurement
+  - agentic-commerce
+  - governance
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: AGENT.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  skills:
+    - marketing/task-map-designer
+    - marketing/ai-output-eval-scorecard
+    - adtech/advertising-signal-ownership-auditor
+    - marketing/agent-share-of-choice-evaluator
+    - agentops/ad-platform-policy-gate-designer
+  tools:
+    - conversion_event_reconciler
+    - openai_ads_adapter_template
+    - ad_platform_executor_template
+operational:
+  role: Experiment supervisor for task-led conversational advertising and agent-mediated commerce.
+  coordinates:
+    - Task hypothesis design
+    - Creative and compliance readiness
+    - Signal ownership and measurement
+    - Mock or read-only platform inspection
+    - Event reconciliation and experiment memory
+  autonomy_level: advisory
+  approval_boundary: May plan, inspect approved read-only data, and reconcile supplied evidence; live campaign writes require the existing policy gate, executor, and human approval.
+  outputs:
+    - Experiment plan
+    - Readiness decision
+    - Reconciled evidence
+    - Experiment memory record
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/agents/adtech/chatgpt-ads-experiment-supervisor/agent.yaml
+++ b/agents/adtech/chatgpt-ads-experiment-supervisor/agent.yaml
@@ -25,6 +25,9 @@ entrypoints:
   tests: tests/test-prompts.md
   examples_dir: examples
 dependencies:
+  agents:
+    - marketing/creative-operating-system-supervisor
+    - adtech/ad-platform-control-plane-supervisor
   skills:
     - marketing/task-map-designer
     - marketing/ai-output-eval-scorecard

--- a/agents/adtech/chatgpt-ads-experiment-supervisor/examples/input.json
+++ b/agents/adtech/chatgpt-ads-experiment-supervisor/examples/input.json
@@ -1,0 +1,7 @@
+{
+  "mode": "mock-run",
+  "brand": "Northstar Meals",
+  "objective": "Test whether task-led advertising improves qualified family-plan signups",
+  "task": "Choose a nut-free family meal plan under GBP 45",
+  "risk_policy": "No live writes; use bundled fixtures"
+}

--- a/agents/adtech/chatgpt-ads-experiment-supervisor/examples/output.json
+++ b/agents/adtech/chatgpt-ads-experiment-supervisor/examples/output.json
@@ -1,0 +1,19 @@
+{
+  "mode": "mock-run",
+  "readiness": "revise",
+  "completed": [
+    "task_map",
+    "creative_evaluation",
+    "signal_ownership_audit",
+    "mock_insights",
+    "event_reconciliation"
+  ],
+  "blockers": [
+    "No four-week retention event in the outcome ledger"
+  ],
+  "evidence": {
+    "platform_conversions": 36,
+    "independently_verified_fixture_outcomes": 1
+  },
+  "next_decision": "Add retention and cancellation outcomes before interpreting conversion quality"
+}

--- a/agents/adtech/chatgpt-ads-experiment-supervisor/examples/output.json
+++ b/agents/adtech/chatgpt-ads-experiment-supervisor/examples/output.json
@@ -1,19 +1,30 @@
 {
+  "experiment_id": "northstar-meals-task-led-001",
+  "task_map_version": "family-weeknight-meals-v1",
   "mode": "mock-run",
-  "readiness": "revise",
-  "completed": [
-    "task_map",
-    "creative_evaluation",
-    "signal_ownership_audit",
-    "mock_insights",
-    "event_reconciliation"
+  "hypothesis": "Verifying allergen suitability, total weekly cost, and delivery availability within the task will improve qualified family-plan selection.",
+  "routes": [
+    "paid_placement",
+    "earned_discovery",
+    "executable_participation"
   ],
-  "blockers": [
+  "evidence": [
+    {
+      "source": "OpenAI Ads campaign insights fixture",
+      "label": "platform_reported",
+      "value": 36,
+      "sample_size": 36
+    },
+    {
+      "source": "Order outcome fixture",
+      "label": "independently_verified",
+      "value": 1,
+      "sample_size": 2
+    }
+  ],
+  "decision": "revise",
+  "limitations": [
     "No four-week retention event in the outcome ledger"
   ],
-  "evidence": {
-    "platform_conversions": 36,
-    "independently_verified_fixture_outcomes": 1
-  },
-  "next_decision": "Add retention and cancellation outcomes before interpreting conversion quality"
+  "next_test": "Add retention and cancellation outcomes before interpreting conversion quality"
 }

--- a/agents/adtech/chatgpt-ads-experiment-supervisor/tests/test-prompts.md
+++ b/agents/adtech/chatgpt-ads-experiment-supervisor/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Run the Northstar Meals example in mock-run mode and identify the missing evidence.
+2. Plan an experiment but stop before activation because no signal ownership ledger exists.
+3. Inspect campaign insights in read-only mode and refuse a budget change.
+4. Route an approved campaign proposal through the existing policy gate and executor.
+5. Compare paid placement, earned recommendation, and executable participation without merging their evidence.

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -137,7 +137,7 @@ func hasOperational(operational OperationalMetadata) bool {
 }
 
 func hasDependencies(dependencies DependencySet) bool {
-	return len(dependencies.Skills) > 0 || len(dependencies.Tools) > 0 || len(dependencies.APIs) > 0 || len(dependencies.MCPServers) > 0
+	return len(dependencies.Agents) > 0 || len(dependencies.Skills) > 0 || len(dependencies.Tools) > 0 || len(dependencies.APIs) > 0 || len(dependencies.MCPServers) > 0
 }
 
 func hasRequirements(requires RequirementSet) bool {

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -214,7 +214,7 @@ func digestSkillDir(skillDir string) (string, error) {
 		if rel == "." {
 			return nil
 		}
-		if containsHiddenPart(rel) {
+		if containsIgnoredDigestPart(rel) {
 			if d.IsDir() {
 				return filepath.SkipDir
 			}
@@ -256,10 +256,13 @@ func digestSkillDir(skillDir string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-func containsHiddenPart(rel string) bool {
+func containsIgnoredDigestPart(rel string) bool {
 	parts := strings.Split(filepath.ToSlash(rel), "/")
 	for _, part := range parts {
 		if strings.HasPrefix(part, ".") {
+			return true
+		}
+		if part == "__pycache__" || strings.HasSuffix(part, ".pyc") || strings.HasSuffix(part, ".pyo") {
 			return true
 		}
 	}

--- a/internal/registry/builder_test.go
+++ b/internal/registry/builder_test.go
@@ -254,3 +254,50 @@ deprecated: false
 		t.Fatalf("unexpected manifest url: %s", entry.Versions[0].ManifestURL)
 	}
 }
+
+func TestDigestSkillDirIgnoresPythonCache(t *testing.T) {
+	root := t.TempDir()
+	scriptDir := filepath.Join(root, "scripts")
+	cacheDir := filepath.Join(scriptDir, "__pycache__")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sourcePath := filepath.Join(scriptDir, "reconcile.py")
+	if err := os.WriteFile(sourcePath, []byte("print('source')\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	before, err := digestSkillDir(root)
+	if err != nil {
+		t.Fatalf("digest before cache: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(cacheDir, "reconcile.cpython-314.pyc"),
+		[]byte("runtime-specific bytecode"),
+		0o644,
+	); err != nil {
+		t.Fatalf("write pycache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptDir, "temporary.pyo"), []byte("optimized bytecode"), 0o644); err != nil {
+		t.Fatalf("write pyo: %v", err)
+	}
+
+	afterCache, err := digestSkillDir(root)
+	if err != nil {
+		t.Fatalf("digest after cache: %v", err)
+	}
+	if before != afterCache {
+		t.Fatalf("python cache changed digest: before=%s after=%s", before, afterCache)
+	}
+
+	if err := os.WriteFile(sourcePath, []byte("print('changed source')\n"), 0o644); err != nil {
+		t.Fatalf("update source: %v", err)
+	}
+	afterSource, err := digestSkillDir(root)
+	if err != nil {
+		t.Fatalf("digest after source change: %v", err)
+	}
+	if afterSource == before {
+		t.Fatal("tracked source change did not alter digest")
+	}
+}

--- a/internal/registry/builder_test.go
+++ b/internal/registry/builder_test.go
@@ -84,6 +84,8 @@ runtimes:
 entrypoints:
   spec: AGENT.md
 dependencies:
+  agents:
+    - marketing/creative-operating-system-supervisor
   skills:
     - adtech/dashboard-generator
   tools:
@@ -119,8 +121,8 @@ deprecated: false
 	if entry.Operational == nil || entry.Operational.Role != "Demo supervisor." {
 		t.Fatalf("expected operational metadata in index, got %#v", entry.Operational)
 	}
-	if entry.Dependencies == nil || len(entry.Dependencies.Skills) != 1 {
-		t.Fatalf("expected dependencies in index, got %#v", entry.Dependencies)
+	if entry.Dependencies == nil || len(entry.Dependencies.Agents) != 1 || len(entry.Dependencies.Skills) != 1 {
+		t.Fatalf("expected agent and skill dependencies in index, got %#v", entry.Dependencies)
 	}
 	if !strings.Contains(entry.Versions[0].ManifestURL, "/agents/marketing/demo-agent/agent.yaml") {
 		t.Fatalf("unexpected manifest url: %s", entry.Versions[0].ManifestURL)

--- a/internal/registry/manifest_parser.go
+++ b/internal/registry/manifest_parser.go
@@ -50,6 +50,8 @@ func ParseManifest(path string) (Manifest, error) {
 			switch nestedMapKey {
 			case "dependencies":
 				switch currentNestedListKey {
+				case "agents":
+					out.Dependencies.Agents = append(out.Dependencies.Agents, item)
 				case "skills":
 					out.Dependencies.Skills = append(out.Dependencies.Skills, item)
 				case "tools":

--- a/internal/registry/manifest_parser_test.go
+++ b/internal/registry/manifest_parser_test.go
@@ -135,6 +135,8 @@ author:
 runtimes:
   - codex
 dependencies:
+  agents:
+    - marketing/creative-operating-system-supervisor
   skills:
     - adtech/dashboard-generator
   tools:
@@ -172,6 +174,9 @@ deprecated: false
 	}
 	if len(m.Operational.Outputs) != 2 {
 		t.Fatalf("unexpected outputs: %#v", m.Operational.Outputs)
+	}
+	if len(m.Dependencies.Agents) != 1 || m.Dependencies.Agents[0] != "marketing/creative-operating-system-supervisor" {
+		t.Fatalf("unexpected agent dependencies: %#v", m.Dependencies)
 	}
 	if len(m.Dependencies.Skills) != 1 || m.Dependencies.Skills[0] != "adtech/dashboard-generator" {
 		t.Fatalf("unexpected skill dependencies: %#v", m.Dependencies)

--- a/internal/registry/types.go
+++ b/internal/registry/types.go
@@ -34,6 +34,7 @@ type OperationalMetadata struct {
 }
 
 type DependencySet struct {
+	Agents     []string `json:"agents,omitempty"`
 	Skills     []string `json:"skills,omitempty"`
 	Tools      []string `json:"tools,omitempty"`
 	APIs       []string `json:"apis,omitempty"`

--- a/packs/chatgpt-advertising-experiment-lab/README.md
+++ b/packs/chatgpt-advertising-experiment-lab/README.md
@@ -1,0 +1,51 @@
+# ChatGPT Advertising Experiment Lab
+
+A practical pack for testing the advertising shift described in **Who Owns the Pixel? ChatGPT and the Repricing of Advertising**.
+
+Article link: pending publication.
+
+## What this pack proves
+
+Advertising inside an agent-mediated channel needs two control planes:
+
+1. The execution control plane governs what an agent may do.
+2. The evidence control plane governs what the system may learn and claim.
+
+## Included entries
+
+| Entry | Purpose |
+| --- | --- |
+| `marketing/task-map-designer` | Convert customer situations into falsifiable task hypotheses. |
+| `adtech/advertising-signal-ownership-auditor` | Map collection, control, visibility, and use of every signal. |
+| `marketing/agent-share-of-choice-evaluator` | Evaluate progression through agent-mediated decision stages. |
+| `adtech/conversion-event-reconciler` | Deduplicate Pixel and server events and verify first-party outcomes. |
+| `adtech/openai-ads-adapter-template` | Start with read-only mock OpenAI Ads contracts and fixtures. |
+| `adtech/chatgpt-ads-experiment-supervisor` | Coordinate the end-to-end experiment. |
+
+## Reused foundations
+
+- `marketing/creative-operating-system-supervisor`
+- `marketing/ai-output-eval-scorecard`
+- `agentops/ad-platform-policy-gate-designer`
+- `adtech/ad-platform-control-plane-supervisor`
+- `adtech/ad-platform-executor-template`
+
+## Recommended first run
+
+1. Install the supervisor and its dependencies.
+2. Start in `mock-run` mode.
+3. Use the Northstar Meals task-map and event fixtures.
+4. Run the conversion reconciler.
+5. Compare platform-reported conversions with settled and refunded outcomes.
+6. Add the missing retention signal before drawing a performance conclusion.
+
+```text
+Use ChatGPT Ads Experiment Supervisor in mock-run mode.
+Run the Northstar Meals experiment using bundled fixtures.
+Keep paid, earned, and executable evidence separate.
+Stop if the measurement ledger cannot independently verify conversion quality.
+```
+
+## Live-system boundary
+
+The pack does not ship a live OpenAI Ads client and does not grant write authority. Confirm current official API access and schemas before replacing fixtures. Route all future writes through the existing policy-gated executor with human approval and rollback evidence.

--- a/registry/agents-index.json
+++ b/registry/agents-index.json
@@ -1,6 +1,6 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-06-27T00:00:00Z",
+  "generated_at": "2026-07-24T00:00:00Z",
   "skills": [
     {
       "id": "adtech/ad-platform-control-plane-supervisor",
@@ -114,6 +114,69 @@
         "tools": [
           "bigquery_sql",
           "ga4_query"
+        ]
+      }
+    },
+    {
+      "id": "adtech/chatgpt-ads-experiment-supervisor",
+      "name": "ChatGPT Ads Experiment Supervisor",
+      "description": "Coordinate task-led ChatGPT advertising experiments across creative, policy, measurement ownership, platform inspection, reconciliation, and memory.",
+      "category": "adtech-agents/experimentation",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-07-24T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/agents/adtech/chatgpt-ads-experiment-supervisor/agent.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/chatgpt-ads-experiment-supervisor/0.1.0.tar.gz",
+          "sha256": "948e84eac915c7d0dc4116fb07d407783c576f58fc04e33cfb3f0b7c2734978b"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "chatgpt-ads",
+        "experiment-supervisor",
+        "measurement",
+        "agentic-commerce",
+        "governance"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May plan, inspect approved read-only data, and reconcile supplied evidence; live campaign writes require the existing policy gate, executor, and human approval.",
+        "role": "Experiment supervisor for task-led conversational advertising and agent-mediated commerce.",
+        "coordinates": [
+          "Task hypothesis design",
+          "Creative and compliance readiness",
+          "Signal ownership and measurement",
+          "Mock or read-only platform inspection",
+          "Event reconciliation and experiment memory"
+        ],
+        "autonomy_level": "advisory",
+        "outputs": [
+          "Experiment plan",
+          "Readiness decision",
+          "Reconciled evidence",
+          "Experiment memory record"
+        ]
+      },
+      "dependencies": {
+        "skills": [
+          "marketing/task-map-designer",
+          "marketing/ai-output-eval-scorecard",
+          "adtech/advertising-signal-ownership-auditor",
+          "marketing/agent-share-of-choice-evaluator",
+          "agentops/ad-platform-policy-gate-designer"
+        ],
+        "tools": [
+          "conversion_event_reconciler",
+          "openai_ads_adapter_template",
+          "ad_platform_executor_template"
         ]
       }
     },

--- a/registry/agents-index.json
+++ b/registry/agents-index.json
@@ -129,7 +129,7 @@
           "released_at": "2026-07-24T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/agents/adtech/chatgpt-ads-experiment-supervisor/agent.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/chatgpt-ads-experiment-supervisor/0.1.0.tar.gz",
-          "sha256": "948e84eac915c7d0dc4116fb07d407783c576f58fc04e33cfb3f0b7c2734978b"
+          "sha256": "ac8a8a26dab49607fbc3e8bdeba97ad68415901f2832f9a3cbe2343e8df013cd"
         }
       ],
       "runtimes": [
@@ -166,6 +166,10 @@
         ]
       },
       "dependencies": {
+        "agents": [
+          "marketing/creative-operating-system-supervisor",
+          "adtech/ad-platform-control-plane-supervisor"
+        ],
         "skills": [
           "marketing/task-map-designer",
           "marketing/ai-output-eval-scorecard",

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,7 +1,53 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-06-27T00:00:00Z",
+  "generated_at": "2026-07-24T00:00:00Z",
   "skills": [
+    {
+      "id": "adtech/advertising-signal-ownership-auditor",
+      "name": "Advertising Signal Ownership Auditor",
+      "description": "Audit collection, control, visibility, retention, and use of advertising signals from exposure through verified business outcome.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-07-24T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/advertising-signal-ownership-auditor/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/advertising-signal-ownership-auditor/0.1.0.tar.gz",
+          "sha256": "0c6de51d1e134569ea973f57fd9477a3e281a6bdeb765d4d52d353a904ed2461"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "measurement",
+        "signal-ownership",
+        "pixel",
+        "conversions-api",
+        "governance"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May audit and recommend; privacy, consent, retention, and platform configuration changes require responsible human approval.",
+        "outputs": [
+          "Signal ownership ledger",
+          "Measurement gaps",
+          "Independent evidence plan"
+        ],
+        "use_when": "Use before campaign activation or measurement redesign to determine who owns and can verify each signal.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "shared/schemas/advertising/signal-ownership-ledger.schema.json"
+        ]
+      }
+    },
     {
       "id": "adtech/analyst-copilot-bigquery-redshift",
       "name": "Analyst Co-pilot (BigQuery + Redshift)",
@@ -875,6 +921,52 @@
       }
     },
     {
+      "id": "marketing/agent-share-of-choice-evaluator",
+      "name": "Agent Share of Choice Evaluator",
+      "description": "Evaluate brand progression across retrieval, consideration, recommendation, selection, transaction, completion, and reuse in agent-mediated tasks.",
+      "category": "marketing-tools/measurement",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-07-24T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/agent-share-of-choice-evaluator/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/agent-share-of-choice-evaluator/0.1.0.tar.gz",
+          "sha256": "98067867b4c9d5b7f411aa09facfde92668558c7fd36597a80096950c77166f6"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "agent-visibility",
+        "share-of-choice",
+        "chatgpt-ads",
+        "agentic-commerce",
+        "evaluation"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Evaluation only; do not publish comparative claims without methodology and human review.",
+        "outputs": [
+          "Stage evidence",
+          "Route comparison",
+          "Confidence and next-test report"
+        ],
+        "use_when": "Use when a team needs a repeatable task-panel evaluation of paid, earned, and executable brand participation.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "marketing/ai-output-eval-scorecard"
+        ]
+      }
+    },
+    {
       "id": "marketing/ai-output-eval-scorecard",
       "name": "AI Output Eval Scorecard",
       "description": "Score AI-generated marketing outputs across accuracy, clarity, brand fit, policy compliance, actionability, and creative operating system fit.",
@@ -1404,6 +1496,52 @@
       "dependencies": {
         "tools": [
           "python3"
+        ]
+      }
+    },
+    {
+      "id": "marketing/task-map-designer",
+      "name": "Task Map Designer",
+      "description": "Convert customer situations into testable task and context hypotheses for agent-mediated advertising and commerce.",
+      "category": "marketing-tools/ads-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-07-24T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/task-map-designer/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/task-map-designer/0.1.0.tar.gz",
+          "sha256": "72a36c32ef6bf10e6a8002a6915c21ce6cfee6a19e01d6343196e551c6f53cd3"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "task-design",
+        "chatgpt-ads",
+        "experimentation",
+        "agentic-commerce",
+        "planning"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Advisory planning only; targeting, activation, and data collection require platform and privacy approval.",
+        "outputs": [
+          "Task map",
+          "Testable hypotheses",
+          "Measurement plan"
+        ],
+        "use_when": "Use when an advertising or commerce experiment should begin from a customer task rather than a keyword or placement list.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "shared/schemas/advertising/task-map.schema.json"
         ]
       }
     },

--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -1,7 +1,53 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-06-27T00:00:00Z",
+  "generated_at": "2026-07-24T00:00:00Z",
   "skills": [
+    {
+      "id": "adtech/advertising-signal-ownership-auditor",
+      "name": "Advertising Signal Ownership Auditor",
+      "description": "Audit collection, control, visibility, retention, and use of advertising signals from exposure through verified business outcome.",
+      "category": "adtech/analytics-engineering",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-07-24T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/adtech/advertising-signal-ownership-auditor/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/advertising-signal-ownership-auditor/0.1.0.tar.gz",
+          "sha256": "0c6de51d1e134569ea973f57fd9477a3e281a6bdeb765d4d52d353a904ed2461"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "measurement",
+        "signal-ownership",
+        "pixel",
+        "conversions-api",
+        "governance"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "May audit and recommend; privacy, consent, retention, and platform configuration changes require responsible human approval.",
+        "outputs": [
+          "Signal ownership ledger",
+          "Measurement gaps",
+          "Independent evidence plan"
+        ],
+        "use_when": "Use before campaign activation or measurement redesign to determine who owns and can verify each signal.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "shared/schemas/advertising/signal-ownership-ledger.schema.json"
+        ]
+      }
+    },
     {
       "id": "adtech/analyst-copilot-bigquery-redshift",
       "name": "Analyst Co-pilot (BigQuery + Redshift)",
@@ -875,6 +921,52 @@
       }
     },
     {
+      "id": "marketing/agent-share-of-choice-evaluator",
+      "name": "Agent Share of Choice Evaluator",
+      "description": "Evaluate brand progression across retrieval, consideration, recommendation, selection, transaction, completion, and reuse in agent-mediated tasks.",
+      "category": "marketing-tools/measurement",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-07-24T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/agent-share-of-choice-evaluator/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/agent-share-of-choice-evaluator/0.1.0.tar.gz",
+          "sha256": "98067867b4c9d5b7f411aa09facfde92668558c7fd36597a80096950c77166f6"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "agent-visibility",
+        "share-of-choice",
+        "chatgpt-ads",
+        "agentic-commerce",
+        "evaluation"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Evaluation only; do not publish comparative claims without methodology and human review.",
+        "outputs": [
+          "Stage evidence",
+          "Route comparison",
+          "Confidence and next-test report"
+        ],
+        "use_when": "Use when a team needs a repeatable task-panel evaluation of paid, earned, and executable brand participation.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "marketing/ai-output-eval-scorecard"
+        ]
+      }
+    },
+    {
       "id": "marketing/ai-output-eval-scorecard",
       "name": "AI Output Eval Scorecard",
       "description": "Score AI-generated marketing outputs across accuracy, clarity, brand fit, policy compliance, actionability, and creative operating system fit.",
@@ -1404,6 +1496,52 @@
       "dependencies": {
         "tools": [
           "python3"
+        ]
+      }
+    },
+    {
+      "id": "marketing/task-map-designer",
+      "name": "Task Map Designer",
+      "description": "Convert customer situations into testable task and context hypotheses for agent-mediated advertising and commerce.",
+      "category": "marketing-tools/ads-ops",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-07-24T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/skills/marketing/task-map-designer/skill.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/task-map-designer/0.1.0.tar.gz",
+          "sha256": "72a36c32ef6bf10e6a8002a6915c21ce6cfee6a19e01d6343196e551c6f53cd3"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "task-design",
+        "chatgpt-ads",
+        "experimentation",
+        "agentic-commerce",
+        "planning"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "approval_boundary": "Advisory planning only; targeting, activation, and data collection require platform and privacy approval.",
+        "outputs": [
+          "Task map",
+          "Testable hypotheses",
+          "Measurement plan"
+        ],
+        "use_when": "Use when an advertising or commerce experiment should begin from a customer task rather than a keyword or placement list.",
+        "execution_mode": "analysis-only"
+      },
+      "dependencies": {
+        "tools": [
+          "shared/schemas/advertising/task-map.schema.json"
         ]
       }
     },

--- a/registry/tools-index.json
+++ b/registry/tools-index.json
@@ -121,7 +121,7 @@
           "released_at": "2026-07-24T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/adtech/conversion-event-reconciler/tool.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/conversion-event-reconciler/0.1.0.tar.gz",
-          "sha256": "aef1d651ff49a450a38379af9106d8cb5a554f4e8fcff25a20b1c20373a9ec7b"
+          "sha256": "418018d071d17ceae8b76a0515c5e5d27fe31a7bae85a35e4c4faf2d8713e282"
         }
       ],
       "runtimes": [

--- a/registry/tools-index.json
+++ b/registry/tools-index.json
@@ -1,6 +1,6 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-05-06T00:00:00Z",
+  "generated_at": "2026-07-24T00:00:00Z",
   "skills": [
     {
       "id": "ads/meta-ads-mcp-connector",
@@ -106,6 +106,110 @@
         "apis": [
           "Google Ads API",
           "Display \u0026 Video 360 API"
+        ]
+      }
+    },
+    {
+      "id": "adtech/conversion-event-reconciler",
+      "name": "Conversion Event Reconciler",
+      "description": "Deterministically deduplicate browser and server conversion events and reconcile them with first-party business outcomes.",
+      "category": "tools-mcp/adtech",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-07-24T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/adtech/conversion-event-reconciler/tool.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/conversion-event-reconciler/0.1.0.tar.gz",
+          "sha256": "18974abf04b86870b5e23b42ac1e94b1e705faec58a31c8b7d47c18454731630"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "measurement",
+        "deduplication",
+        "pixel",
+        "conversions-api",
+        "first-party-data"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "connected_system": "Local event fixtures or approved event export",
+        "capabilities": [
+          "Deduplicate browser and server events by event name and event ID.",
+          "Preserve event provenance and flag conflicting values.",
+          "Reconcile conversions with first-party outcomes."
+        ],
+        "auth_required": [
+          "None for local fixtures"
+        ],
+        "access_level": "read-only",
+        "trust_boundary": "local-tool",
+        "approval_boundary": "Reads supplied files and writes JSON to stdout; live event collection and platform uploads are out of scope."
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ]
+      }
+    },
+    {
+      "id": "adtech/openai-ads-adapter-template",
+      "name": "OpenAI Ads Adapter Template",
+      "description": "Mock-first read-only adapter contract for OpenAI Ads accounts, campaigns, ads, insights, and product feeds.",
+      "category": "tools-mcp/adtech",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-07-24T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/adtech/openai-ads-adapter-template/tool.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/openai-ads-adapter-template/0.1.0.tar.gz",
+          "sha256": "01b4b7841260505f22ea1dddbde2c2b5ed44e520a3be294ec2e88f3db8e32958"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "openai-ads",
+        "adapter",
+        "read-only",
+        "campaign-insights",
+        "product-feeds"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "connected_system": "OpenAI Ads API or local mock fixtures",
+        "capabilities": [
+          "Read advertiser account metadata.",
+          "List campaigns and ads.",
+          "Retrieve campaign insights.",
+          "Validate product-feed records."
+        ],
+        "auth_required": [
+          "Account-scoped OpenAI Ads API credential for live bindings"
+        ],
+        "access_level": "read-only",
+        "trust_boundary": "third-party-hosted",
+        "approval_boundary": "Read-only by design; future writes must use the existing policy-gated ad-platform executor."
+      },
+      "dependencies": {
+        "tools": [
+          "secret_manager"
+        ],
+        "apis": [
+          "OpenAI Ads API"
         ]
       }
     },

--- a/registry/tools-index.json
+++ b/registry/tools-index.json
@@ -121,7 +121,7 @@
           "released_at": "2026-07-24T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/adtech/conversion-event-reconciler/tool.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/conversion-event-reconciler/0.1.0.tar.gz",
-          "sha256": "18974abf04b86870b5e23b42ac1e94b1e705faec58a31c8b7d47c18454731630"
+          "sha256": "aef1d651ff49a450a38379af9106d8cb5a554f4e8fcff25a20b1c20373a9ec7b"
         }
       ],
       "runtimes": [

--- a/shared/schemas/advertising/experiment-record.schema.json
+++ b/shared/schemas/advertising/experiment-record.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://skills.ai-knowledge-hub.org/schemas/advertising/experiment-record.schema.json",
+  "title": "Agent-Mediated Advertising Experiment Record",
+  "type": "object",
+  "required": [
+    "experiment_id",
+    "task_map_version",
+    "mode",
+    "evidence",
+    "decision"
+  ],
+  "properties": {
+    "experiment_id": {
+      "type": "string"
+    },
+    "task_map_version": {
+      "type": "string"
+    },
+    "mode": {
+      "enum": [
+        "plan-only",
+        "mock-run",
+        "read-only",
+        "approval-gated"
+      ]
+    },
+    "hypothesis": {
+      "type": "string"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "source",
+          "label",
+          "value"
+        ],
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "label": {
+            "enum": [
+              "observed",
+              "synthetic",
+              "platform_reported",
+              "independently_verified"
+            ]
+          },
+          "value": {},
+          "sample_size": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "decision": {
+      "enum": [
+        "continue",
+        "revise",
+        "hold",
+        "stop"
+      ]
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "next_test": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/shared/schemas/advertising/signal-ownership-ledger.schema.json
+++ b/shared/schemas/advertising/signal-ownership-ledger.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://skills.ai-knowledge-hub.org/schemas/advertising/signal-ownership-ledger.schema.json",
+  "title": "Advertising Signal Ownership Ledger",
+  "type": "object",
+  "required": [
+    "entries",
+    "gaps",
+    "verdict"
+  ],
+  "properties": {
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "event",
+          "collector",
+          "controller",
+          "visible_to",
+          "system_of_record",
+          "purpose"
+        ],
+        "properties": {
+          "event": {
+            "type": "string"
+          },
+          "collector": {
+            "type": "string"
+          },
+          "controller": {
+            "type": "string"
+          },
+          "visible_to": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "system_of_record": {
+            "type": "string"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "consent_basis": {
+            "type": "string"
+          },
+          "purpose": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "retention": {
+            "type": "string"
+          },
+          "independent_evidence": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "gaps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "verdict": {
+      "enum": [
+        "ready",
+        "revise",
+        "block"
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/shared/schemas/advertising/task-map.schema.json
+++ b/shared/schemas/advertising/task-map.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://skills.ai-knowledge-hub.org/schemas/advertising/task-map.schema.json",
+  "title": "Advertising Task Map",
+  "type": "object",
+  "required": [
+    "task_id",
+    "task",
+    "context",
+    "decision_criteria",
+    "hypothesis",
+    "routes",
+    "measures"
+  ],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "task": {
+      "type": "string",
+      "minLength": 10
+    },
+    "context": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "decision_criteria": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hypothesis": {
+      "type": "string"
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "paid_placement",
+          "earned_discovery",
+          "executable_participation"
+        ]
+      }
+    },
+    "measures": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "disconfirming_evidence": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/shared/schemas/agent.schema.json
+++ b/shared/schemas/agent.schema.json
@@ -126,6 +126,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+          },
+          "uniqueItems": true
+        },
         "skills": {
           "type": "array",
           "items": {

--- a/shared/schemas/registry-index.schema.json
+++ b/shared/schemas/registry-index.schema.json
@@ -178,6 +178,14 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+              "agents": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+                },
+                "uniqueItems": true
+              },
               "skills": {
                 "type": "array",
                 "items": {

--- a/skills/adtech/advertising-signal-ownership-auditor/README.md
+++ b/skills/adtech/advertising-signal-ownership-auditor/README.md
@@ -1,0 +1,11 @@
+# Advertising Signal Ownership Auditor
+
+Create an evidence ledger for Pixel, CAPI, CRM, order, return, and support signals.
+
+## Install
+
+```bash
+./bin/skills-hub install adtech/advertising-signal-ownership-auditor@latest --runtime codex
+```
+
+Use the result before activation to expose missing consent, inaccessible evidence, circular measurement, and unclear systems of record.

--- a/skills/adtech/advertising-signal-ownership-auditor/SKILL.md
+++ b/skills/adtech/advertising-signal-ownership-auditor/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: advertising-signal-ownership-auditor
+description: Audit who collects, controls, receives, retains, and uses advertising and commerce signals across pixels, server events, campaign platforms, CRM, orders, returns, and support systems. Use when designing measurement ownership, first-party evidence, platform optimization, or agentic advertising governance.
+---
+
+# Advertising Signal Ownership Auditor
+
+## When to use
+Use this skill for the situations described in its frontmatter routing description.
+
+## Workflow
+1. Inventory every event from exposure through post-purchase outcome.
+2. Identify the collector, controller, processor, visible parties, and system of record.
+3. Record identifiers, consent basis, retention, and allowed uses.
+4. Mark whether each signal trains platform optimization, supports independent evaluation, or both.
+5. Identify duplicate collection, inaccessible evidence, missing post-conversion outcomes, and circular validation.
+6. Require a canonical source for business outcomes.
+7. Return a ledger conforming to `shared/schemas/advertising/signal-ownership-ledger.schema.json`.
+
+## Read when needed
+- Use `references/ownership-questions.md` during stakeholder discovery.
+
+## Guardrails
+- Do not treat platform reporting as independent validation.
+- Do not assume the advertiser owns or can export a platform-derived signal.
+- Do not recommend collecting data without a documented purpose and consent basis.
+- Never place secrets or raw personal data in the ledger.

--- a/skills/adtech/advertising-signal-ownership-auditor/examples/input.json
+++ b/skills/adtech/advertising-signal-ownership-auditor/examples/input.json
@@ -1,0 +1,16 @@
+{
+  "systems": [
+    "ChatGPT Ads",
+    "browser pixel",
+    "server events",
+    "CRM",
+    "order system"
+  ],
+  "events": [
+    "ad_click",
+    "lead",
+    "purchase",
+    "refund"
+  ],
+  "objective": "Optimize for qualified purchases while preserving independent measurement"
+}

--- a/skills/adtech/advertising-signal-ownership-auditor/examples/output.json
+++ b/skills/adtech/advertising-signal-ownership-auditor/examples/output.json
@@ -1,0 +1,25 @@
+{
+  "entries": [
+    {
+      "event": "purchase",
+      "collector": "commerce backend",
+      "controller": "advertiser",
+      "visible_to": [
+        "advertiser",
+        "ad platform via scoped server event"
+      ],
+      "system_of_record": "order system",
+      "identifier": "event_id and order_id",
+      "purpose": [
+        "platform optimization",
+        "independent evaluation"
+      ],
+      "retention": "per approved data policy",
+      "independent_evidence": "settled order"
+    }
+  ],
+  "gaps": [
+    "Refund outcomes are not currently sent to the evaluation store"
+  ],
+  "verdict": "revise"
+}

--- a/skills/adtech/advertising-signal-ownership-auditor/references/ownership-questions.md
+++ b/skills/adtech/advertising-signal-ownership-auditor/references/ownership-questions.md
@@ -1,0 +1,14 @@
+# Ownership Questions
+
+Ask for every signal:
+
+1. Who creates or observes it?
+2. Which system stores the first copy?
+3. Which parties can inspect or export it?
+4. Which identifier joins it to later outcomes?
+5. What consent or contractual basis allows collection and use?
+6. How long is it retained?
+7. Does it optimize delivery, evaluate business value, or both?
+8. Which independent source can confirm it?
+9. What happens when an order is cancelled, returned, or disputed?
+10. Can the organization reproduce the conclusion without the platform dashboard?

--- a/skills/adtech/advertising-signal-ownership-auditor/skill.yaml
+++ b/skills/adtech/advertising-signal-ownership-auditor/skill.yaml
@@ -1,0 +1,42 @@
+id: adtech/advertising-signal-ownership-auditor
+name: Advertising Signal Ownership Auditor
+description: Audit collection, control, visibility, retention, and use of advertising signals from exposure through verified business outcome.
+version: 0.1.0
+released_at: "2026-07-24T00:00:00Z"
+category: adtech/analytics-engineering
+tags:
+  - measurement
+  - signal-ownership
+  - pixel
+  - conversions-api
+  - governance
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools:
+    - shared/schemas/advertising/signal-ownership-ledger.schema.json
+operational:
+  use_when: Use before campaign activation or measurement redesign to determine who owns and can verify each signal.
+  execution_mode: analysis-only
+  outputs:
+    - Signal ownership ledger
+    - Measurement gaps
+    - Independent evidence plan
+  approval_boundary: May audit and recommend; privacy, consent, retention, and platform configuration changes require responsible human approval.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/adtech/advertising-signal-ownership-auditor/tests/test-prompts.md
+++ b/skills/adtech/advertising-signal-ownership-auditor/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Audit a browser Pixel and server-side purchase event that both report the same conversion.
+2. Map ownership when a platform reports leads but the advertiser CRM stores qualified opportunities.
+3. Identify circular validation in a campaign evaluated only with platform-reported conversions.
+4. Review whether refund and cancellation events should update experiment memory.
+5. Refuse to approve a ledger that contains raw email addresses and propose privacy-safe identifiers.

--- a/skills/marketing/agent-share-of-choice-evaluator/README.md
+++ b/skills/marketing/agent-share-of-choice-evaluator/README.md
@@ -1,0 +1,11 @@
+# Agent Share of Choice Evaluator
+
+Measure how often a brand advances through an agent-mediated decision process, using a stable and versioned task panel.
+
+## Install
+
+```bash
+./bin/skills-hub install marketing/agent-share-of-choice-evaluator@latest --runtime codex
+```
+
+The skill reports evidence by stage and route. It does not manufacture a universal AI rank.

--- a/skills/marketing/agent-share-of-choice-evaluator/SKILL.md
+++ b/skills/marketing/agent-share-of-choice-evaluator/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: agent-share-of-choice-evaluator
+description: Evaluate whether a brand is retrieved, understood, considered, recommended, selected, transacted with, and used successfully across a stable panel of agent-mediated customer tasks. Use for AI visibility, conversational advertising, agentic commerce, or paid-versus-earned discovery experiments.
+---
+
+# Agent Share of Choice Evaluator
+
+## When to use
+Use this skill for the situations described in its frontmatter routing description.
+
+## Workflow
+1. Load a versioned task panel and freeze the evaluation conditions.
+2. Run each task consistently across the selected agent surfaces.
+3. Capture evidence for retrieval, understanding, consideration, recommendation, paid response, selection, transaction, completion, and reuse.
+4. Label observed, synthetic, platform-reported, and independently verified evidence separately.
+5. Calculate stage rates only where denominators and samples are explicit.
+6. Compare paid, earned, and executable routes without collapsing them into one rank.
+7. Report failures, uncertainty, and the next experiment.
+
+## Output
+- task panel version and run conditions
+- stage evidence by task
+- stage rates with sample sizes
+- route comparison
+- evidence quality and confidence
+- failure modes and next tests
+
+## Guardrails
+- Do not claim a universal agent ranking.
+- Do not treat one model, prompt, geography, or session as representative.
+- Do not merge paid exposure with earned recommendation.
+- Do not call platform conversion data independently verified.

--- a/skills/marketing/agent-share-of-choice-evaluator/examples/input.json
+++ b/skills/marketing/agent-share-of-choice-evaluator/examples/input.json
@@ -1,0 +1,12 @@
+{
+  "panel_version": "meal-planning-v1",
+  "tasks": [
+    "Choose a nut-free family meal plan under GBP 45",
+    "Find a healthy dinner service with Tuesday delivery"
+  ],
+  "surfaces": [
+    "agent-a",
+    "agent-b"
+  ],
+  "brand": "Northstar Meals"
+}

--- a/skills/marketing/agent-share-of-choice-evaluator/examples/output.json
+++ b/skills/marketing/agent-share-of-choice-evaluator/examples/output.json
@@ -1,0 +1,20 @@
+{
+  "panel_version": "meal-planning-v1",
+  "sample_size": 4,
+  "stages": {
+    "retrieved": 3,
+    "understood": 3,
+    "considered": 2,
+    "recommended_earned": 1,
+    "shown_paid": 1,
+    "selected": 1,
+    "completed": 1,
+    "verified_quality": 0
+  },
+  "confidence": "low",
+  "limitations": [
+    "Small sample",
+    "No post-purchase evidence"
+  ],
+  "next_test": "Add four-week retention and cancellation outcomes"
+}

--- a/skills/marketing/agent-share-of-choice-evaluator/skill.yaml
+++ b/skills/marketing/agent-share-of-choice-evaluator/skill.yaml
@@ -1,0 +1,42 @@
+id: marketing/agent-share-of-choice-evaluator
+name: Agent Share of Choice Evaluator
+description: Evaluate brand progression across retrieval, consideration, recommendation, selection, transaction, completion, and reuse in agent-mediated tasks.
+version: 0.1.0
+released_at: "2026-07-24T00:00:00Z"
+category: marketing-tools/measurement
+tags:
+  - agent-visibility
+  - share-of-choice
+  - chatgpt-ads
+  - agentic-commerce
+  - evaluation
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools:
+    - marketing/ai-output-eval-scorecard
+operational:
+  use_when: Use when a team needs a repeatable task-panel evaluation of paid, earned, and executable brand participation.
+  execution_mode: analysis-only
+  outputs:
+    - Stage evidence
+    - Route comparison
+    - Confidence and next-test report
+  approval_boundary: Evaluation only; do not publish comparative claims without methodology and human review.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/marketing/agent-share-of-choice-evaluator/tests/test-prompts.md
+++ b/skills/marketing/agent-share-of-choice-evaluator/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Evaluate a brand across ten stable product-comparison tasks and preserve stage denominators.
+2. Separate paid placement from earned recommendation in the result.
+3. Compare two agent surfaces without claiming a universal rank.
+4. Flag a result that has platform conversions but no verified order outcomes.
+5. Reject a conclusion based on one prompt and propose a minimum repeatable panel.

--- a/skills/marketing/task-map-designer/README.md
+++ b/skills/marketing/task-map-designer/README.md
@@ -1,0 +1,19 @@
+# Task Map Designer
+
+Build task-led advertising experiments around what a person is trying to complete.
+
+## Install
+
+```bash
+./bin/skills-hub install marketing/task-map-designer@latest --runtime codex
+```
+
+## Start
+
+```text
+Use Task Map Designer.
+A customer is comparing meal-delivery options for a family with dietary constraints.
+Create testable task hypotheses and identify paid, earned, and executable routes.
+```
+
+The skill returns a structured task map rather than a keyword expansion or persona guess.

--- a/skills/marketing/task-map-designer/SKILL.md
+++ b/skills/marketing/task-map-designer/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: task-map-designer
+description: Convert customer situations into testable advertising task and context hypotheses. Use when planning conversational, agent-mediated, search, social, or commerce experiments around what a person is trying to complete rather than around keyword lists alone.
+---
+
+# Task Map Designer
+
+## When to use
+Use this skill for the situations described in its frontmatter routing description.
+
+## Workflow
+1. Define the customer task as an observable job with a completion condition.
+2. Separate known evidence from assumptions about context, constraints, and decision criteria.
+3. Break the task into discovery, comparison, decision, transaction, and post-purchase stages as applicable.
+4. Record which brand capabilities can help at each stage.
+5. Write one falsifiable hypothesis per task-context pair.
+6. Define exposure, selection, completion, and quality measures.
+7. Return a task map that conforms to `shared/schemas/advertising/task-map.schema.json`.
+
+## Output
+- task_id and task statement
+- audience situation and context signals
+- constraints and decision criteria
+- required brand capabilities
+- testable hypothesis
+- channel routes: paid placement, earned discovery, executable participation
+- measures and disconfirming evidence
+
+## Guardrails
+- Do not infer sensitive traits from conversational context.
+- Do not convert weak assumptions into targeting facts.
+- Keep task hypotheses channel-neutral until evidence supports a route.
+- Distinguish customer completion from an ad click or platform conversion.

--- a/skills/marketing/task-map-designer/examples/input.json
+++ b/skills/marketing/task-map-designer/examples/input.json
@@ -1,0 +1,12 @@
+{
+  "brand": "Northstar Meals",
+  "situation": "A parent is comparing healthy weeknight meal options for a family of four",
+  "constraints": [
+    "under 30 minutes",
+    "nut-free",
+    "under GBP 45 per week"
+  ],
+  "evidence": [
+    "Existing customers value predictable delivery and dietary filters"
+  ]
+}

--- a/skills/marketing/task-map-designer/examples/output.json
+++ b/skills/marketing/task-map-designer/examples/output.json
@@ -1,0 +1,36 @@
+{
+  "task_id": "family-weeknight-meals",
+  "task": "Choose and start a healthy weeknight meal plan for a family of four",
+  "context": [
+    "time-constrained",
+    "nut-free requirement",
+    "budget ceiling"
+  ],
+  "decision_criteria": [
+    "dietary safety",
+    "preparation time",
+    "weekly cost",
+    "delivery reliability"
+  ],
+  "capabilities": [
+    "allergen filters",
+    "family plan comparison",
+    "delivery availability check"
+  ],
+  "hypothesis": "If the brand can verify allergen suitability, total weekly cost, and delivery availability inside the task, qualified customers will select it more often.",
+  "routes": [
+    "paid_placement",
+    "earned_discovery",
+    "executable_participation"
+  ],
+  "measures": [
+    "consideration_rate",
+    "selection_rate",
+    "completed_signup_rate",
+    "four_week_retention"
+  ],
+  "disconfirming_evidence": [
+    "High click rate with low completed signup",
+    "Selection followed by early cancellation"
+  ]
+}

--- a/skills/marketing/task-map-designer/skill.yaml
+++ b/skills/marketing/task-map-designer/skill.yaml
@@ -1,0 +1,42 @@
+id: marketing/task-map-designer
+name: Task Map Designer
+description: Convert customer situations into testable task and context hypotheses for agent-mediated advertising and commerce.
+version: 0.1.0
+released_at: "2026-07-24T00:00:00Z"
+category: marketing-tools/ads-ops
+tags:
+  - task-design
+  - chatgpt-ads
+  - experimentation
+  - agentic-commerce
+  - planning
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  skill_md: SKILL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools:
+    - shared/schemas/advertising/task-map.schema.json
+operational:
+  use_when: Use when an advertising or commerce experiment should begin from a customer task rather than a keyword or placement list.
+  execution_mode: analysis-only
+  outputs:
+    - Task map
+    - Testable hypotheses
+    - Measurement plan
+  approval_boundary: Advisory planning only; targeting, activation, and data collection require platform and privacy approval.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false

--- a/skills/marketing/task-map-designer/tests/test-prompts.md
+++ b/skills/marketing/task-map-designer/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Turn a request to compare business broadband plans into a task map without inferring company size.
+2. Map a family meal-planning situation across paid, earned, and executable routes.
+3. Convert ten search keywords for running shoes into three falsifiable customer-task hypotheses.
+4. Identify disconfirming evidence for a subscription selection experiment.
+5. Reject a request to infer health status from conversational context and propose a privacy-safe task design.

--- a/tools-mcp/adtech/conversion-event-reconciler/README.md
+++ b/tools-mcp/adtech/conversion-event-reconciler/README.md
@@ -1,0 +1,9 @@
+# Conversion Event Reconciler
+
+A deterministic local tool for reconciling browser Pixel, server-side conversion, and first-party outcome events.
+
+```bash
+python3 scripts/reconcile_events.py examples/input.json
+```
+
+It is platform-neutral and can be used before wiring a live Conversions API.

--- a/tools-mcp/adtech/conversion-event-reconciler/TOOL.md
+++ b/tools-mcp/adtech/conversion-event-reconciler/TOOL.md
@@ -1,0 +1,20 @@
+# Conversion Event Reconciler
+
+## Contract
+Accept a JSON document containing `browser_events`, `server_events`, and optional `outcomes`.
+
+Run:
+
+```bash
+python3 scripts/reconcile_events.py examples/input.json
+```
+
+## Behavior
+- Deduplicate browser and server events with the same `event_name` and `event_id`.
+- Preserve source provenance.
+- Flag missing event IDs and conflicting values.
+- Join canonical events to order, CRM, refund, cancellation, or support outcomes by `order_id`.
+- Report platform-facing conversions separately from independently verified outcomes.
+
+## Guardrails
+Input fixtures must use pseudonymous IDs. Do not put access tokens, raw emails, or payment credentials in event payloads.

--- a/tools-mcp/adtech/conversion-event-reconciler/examples/input.json
+++ b/tools-mcp/adtech/conversion-event-reconciler/examples/input.json
@@ -1,0 +1,43 @@
+{
+  "browser_events": [
+    {
+      "event_name": "purchase",
+      "event_id": "evt-100",
+      "order_id": "ord-100",
+      "value": 79,
+      "currency": "GBP"
+    },
+    {
+      "event_name": "lead",
+      "order_id": null,
+      "value": 0,
+      "currency": "GBP"
+    }
+  ],
+  "server_events": [
+    {
+      "event_name": "purchase",
+      "event_id": "evt-100",
+      "order_id": "ord-100",
+      "value": 79,
+      "currency": "GBP"
+    },
+    {
+      "event_name": "purchase",
+      "event_id": "evt-101",
+      "order_id": "ord-101",
+      "value": 49,
+      "currency": "GBP"
+    }
+  ],
+  "outcomes": [
+    {
+      "order_id": "ord-100",
+      "status": "settled"
+    },
+    {
+      "order_id": "ord-101",
+      "status": "refunded"
+    }
+  ]
+}

--- a/tools-mcp/adtech/conversion-event-reconciler/examples/output.json
+++ b/tools-mcp/adtech/conversion-event-reconciler/examples/output.json
@@ -1,0 +1,64 @@
+{
+  "canonical_events": [
+    {
+      "conflicts": [],
+      "currency": "GBP",
+      "event_id": "evt-100",
+      "event_name": "purchase",
+      "key": "purchase:evt-100",
+      "order_id": "ord-100",
+      "outcome": {
+        "order_id": "ord-100",
+        "status": "settled"
+      },
+      "sources": [
+        "browser_events",
+        "server_events"
+      ],
+      "value": 79
+    },
+    {
+      "conflicts": [],
+      "currency": "GBP",
+      "event_id": null,
+      "event_name": "lead",
+      "key": "unmatched:691465d8951926e5",
+      "order_id": null,
+      "outcome": null,
+      "sources": [
+        "browser_events"
+      ],
+      "value": 0
+    },
+    {
+      "conflicts": [],
+      "currency": "GBP",
+      "event_id": "evt-101",
+      "event_name": "purchase",
+      "key": "purchase:evt-101",
+      "order_id": "ord-101",
+      "outcome": {
+        "order_id": "ord-101",
+        "status": "refunded"
+      },
+      "sources": [
+        "server_events"
+      ],
+      "value": 49
+    }
+  ],
+  "summary": {
+    "canonical_event_count": 3,
+    "duplicate_event_count": 1,
+    "raw_event_count": 4,
+    "reversed_outcome_count": 1,
+    "verified_outcome_count": 1
+  },
+  "warnings": [
+    {
+      "code": "missing_event_id",
+      "key": "unmatched:691465d8951926e5",
+      "source": "browser_events"
+    }
+  ]
+}

--- a/tools-mcp/adtech/conversion-event-reconciler/scripts/reconcile_events.py
+++ b/tools-mcp/adtech/conversion-event-reconciler/scripts/reconcile_events.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+
+def event_key(event):
+    event_id = event.get("event_id")
+    if event_id:
+        return f'{event.get("event_name", "unknown")}:{event_id}'
+    raw = json.dumps(event, sort_keys=True, separators=(",", ":"))
+    return "unmatched:" + hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def reconcile(payload):
+    canonical = {}
+    warnings = []
+    raw_events = []
+    for source_name in ("browser_events", "server_events"):
+        for event in payload.get(source_name, []):
+            item = dict(event)
+            item["_source"] = source_name
+            raw_events.append(item)
+            key = event_key(item)
+            if not item.get("event_id"):
+                warnings.append({"code": "missing_event_id", "source": source_name, "key": key})
+            if key not in canonical:
+                canonical[key] = {
+                    "key": key,
+                    "event_name": item.get("event_name"),
+                    "event_id": item.get("event_id"),
+                    "order_id": item.get("order_id"),
+                    "value": item.get("value"),
+                    "currency": item.get("currency"),
+                    "sources": [source_name],
+                    "conflicts": [],
+                }
+                continue
+            current = canonical[key]
+            current["sources"].append(source_name)
+            for field in ("order_id", "value", "currency"):
+                if item.get(field) is not None and current.get(field) != item.get(field):
+                    current["conflicts"].append({
+                        "field": field,
+                        "kept": current.get(field),
+                        "received": item.get(field),
+                        "source": source_name,
+                    })
+
+    outcomes = {item.get("order_id"): item for item in payload.get("outcomes", []) if item.get("order_id")}
+    verified = 0
+    reversed_count = 0
+    for event in canonical.values():
+        outcome = outcomes.get(event.get("order_id"))
+        event["outcome"] = outcome
+        if outcome and outcome.get("status") in {"settled", "qualified", "active"}:
+            verified += 1
+        if outcome and outcome.get("status") in {"refunded", "cancelled", "disputed"}:
+            reversed_count += 1
+        if event["conflicts"]:
+            warnings.append({"code": "event_conflict", "key": event["key"], "fields": [c["field"] for c in event["conflicts"]]})
+
+    duplicate_count = sum(max(0, len(item["sources"]) - 1) for item in canonical.values())
+    return {
+        "summary": {
+            "raw_event_count": len(raw_events),
+            "canonical_event_count": len(canonical),
+            "duplicate_event_count": duplicate_count,
+            "verified_outcome_count": verified,
+            "reversed_outcome_count": reversed_count,
+        },
+        "canonical_events": list(canonical.values()),
+        "warnings": warnings,
+    }
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: reconcile_events.py INPUT.json")
+    payload = json.loads(Path(sys.argv[1]).read_text())
+    print(json.dumps(reconcile(payload), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools-mcp/adtech/conversion-event-reconciler/scripts/reconcile_events.py
+++ b/tools-mcp/adtech/conversion-event-reconciler/scripts/reconcile_events.py
@@ -40,11 +40,15 @@ def reconcile(payload):
             current = canonical[key]
             current["sources"].append(source_name)
             for field in ("order_id", "value", "currency"):
-                if item.get(field) is not None and current.get(field) != item.get(field):
+                incoming = item.get(field)
+                existing = current.get(field)
+                if existing is None and incoming is not None:
+                    current[field] = incoming
+                elif incoming is not None and existing is not None and existing != incoming:
                     current["conflicts"].append({
                         "field": field,
-                        "kept": current.get(field),
-                        "received": item.get(field),
+                        "kept": existing,
+                        "received": incoming,
                         "source": source_name,
                     })
 

--- a/tools-mcp/adtech/conversion-event-reconciler/tests/test-prompts.md
+++ b/tools-mcp/adtech/conversion-event-reconciler/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Reconcile the bundled fixture and explain why four raw events become three canonical events.
+2. Detect a browser and server purchase with the same event ID but conflicting values.
+3. Flag events that cannot be deduplicated because event IDs are missing.
+4. Distinguish settled orders from refunded orders in the summary.
+5. Reject a fixture containing raw email addresses and recommend pseudonymous join identifiers.

--- a/tools-mcp/adtech/conversion-event-reconciler/tests/test_reconcile_events.py
+++ b/tools-mcp/adtech/conversion-event-reconciler/tests/test_reconcile_events.py
@@ -38,6 +38,32 @@ class ReconcileEventsTests(unittest.TestCase):
         self.assertEqual(result["canonical_events"][0]["conflicts"][0]["field"], "value")
         self.assertTrue(any(item["code"] == "event_conflict" for item in result["warnings"]))
 
+    def test_server_event_enriches_missing_browser_fields(self):
+        payload = {
+            "browser_events": [
+                {"event_name": "purchase", "event_id": "evt-2"}
+            ],
+            "server_events": [
+                {
+                    "event_name": "purchase",
+                    "event_id": "evt-2",
+                    "order_id": "ord-2",
+                    "value": 42,
+                    "currency": "GBP",
+                }
+            ],
+            "outcomes": [{"order_id": "ord-2", "status": "settled"}],
+        }
+        result = MODULE.reconcile(payload)
+        event = result["canonical_events"][0]
+
+        self.assertEqual(event["order_id"], "ord-2")
+        self.assertEqual(event["value"], 42)
+        self.assertEqual(event["currency"], "GBP")
+        self.assertEqual(event["conflicts"], [])
+        self.assertEqual(result["summary"]["verified_outcome_count"], 1)
+        self.assertFalse(any(item["code"] == "event_conflict" for item in result["warnings"]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools-mcp/adtech/conversion-event-reconciler/tests/test_reconcile_events.py
+++ b/tools-mcp/adtech/conversion-event-reconciler/tests/test_reconcile_events.py
@@ -1,0 +1,43 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "reconcile_events", ROOT / "scripts" / "reconcile_events.py"
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ReconcileEventsTests(unittest.TestCase):
+    def test_bundled_fixture(self):
+        payload = json.loads((ROOT / "examples" / "input.json").read_text())
+        result = MODULE.reconcile(payload)
+
+        self.assertEqual(result["summary"]["raw_event_count"], 4)
+        self.assertEqual(result["summary"]["canonical_event_count"], 3)
+        self.assertEqual(result["summary"]["duplicate_event_count"], 1)
+        self.assertEqual(result["summary"]["verified_outcome_count"], 1)
+        self.assertEqual(result["summary"]["reversed_outcome_count"], 1)
+        self.assertTrue(any(item["code"] == "missing_event_id" for item in result["warnings"]))
+
+    def test_conflicting_duplicate_values_are_reported(self):
+        payload = {
+            "browser_events": [
+                {"event_name": "purchase", "event_id": "evt-1", "value": 20, "currency": "GBP"}
+            ],
+            "server_events": [
+                {"event_name": "purchase", "event_id": "evt-1", "value": 25, "currency": "GBP"}
+            ],
+        }
+        result = MODULE.reconcile(payload)
+
+        self.assertEqual(result["summary"]["canonical_event_count"], 1)
+        self.assertEqual(result["canonical_events"][0]["conflicts"][0]["field"], "value")
+        self.assertTrue(any(item["code"] == "event_conflict" for item in result["warnings"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools-mcp/adtech/conversion-event-reconciler/tool.yaml
+++ b/tools-mcp/adtech/conversion-event-reconciler/tool.yaml
@@ -1,0 +1,45 @@
+id: adtech/conversion-event-reconciler
+name: Conversion Event Reconciler
+description: Deterministically deduplicate browser and server conversion events and reconcile them with first-party business outcomes.
+version: 0.1.0
+released_at: "2026-07-24T00:00:00Z"
+category: tools-mcp/adtech
+tags:
+  - measurement
+  - deduplication
+  - pixel
+  - conversions-api
+  - first-party-data
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: TOOL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  tools:
+    - python3
+operational:
+  connected_system: Local event fixtures or approved event export
+  capabilities:
+    - Deduplicate browser and server events by event name and event ID.
+    - Preserve event provenance and flag conflicting values.
+    - Reconcile conversions with first-party outcomes.
+  auth_required:
+    - None for local fixtures
+  access_level: read-only
+  trust_boundary: local-tool
+  approval_boundary: Reads supplied files and writes JSON to stdout; live event collection and platform uploads are out of scope.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: true
+  security_reviewed: false
+deprecated: false

--- a/tools-mcp/adtech/openai-ads-adapter-template/README.md
+++ b/tools-mcp/adtech/openai-ads-adapter-template/README.md
@@ -1,0 +1,7 @@
+# OpenAI Ads Adapter Template
+
+A safe starting boundary for experimenting with OpenAI Ads data without granting an agent write access.
+
+The template is read-only and mock-first. Replace fixtures with an approved provider client only after confirming account access, API terms, schemas, authentication, and data handling.
+
+Official starting point: https://developers.openai.com/ads

--- a/tools-mcp/adtech/openai-ads-adapter-template/TOOL.md
+++ b/tools-mcp/adtech/openai-ads-adapter-template/TOOL.md
@@ -1,0 +1,27 @@
+# OpenAI Ads Adapter Template
+
+## Purpose
+Provide a mock-first, read-only provider boundary for OpenAI Ads account, campaign, ad, insight, and product-feed data.
+
+## Proposed operations
+- `get_account`
+- `list_campaigns`
+- `get_campaign`
+- `list_ads`
+- `get_campaign_insights`
+- `validate_product_feed`
+
+## Binding rules
+1. Keep API keys in the adapter environment, never in agent context.
+2. Scope every request to the configured advertiser account.
+3. Validate responses against local contracts before returning them.
+4. Start with the fixtures in `examples/`.
+5. Route any future write operation through `adtech/ad-platform-executor-template`; do not add direct model-to-platform writes here.
+
+## Guardrails
+- Keep the adapter read-only.
+- Never expose credentials to the agent.
+- Do not infer that mock schemas match current production schemas.
+
+## Status
+This repository ships contracts and fixtures, not a live OpenAI Ads client. Confirm current API availability and official schemas before implementing a production binding.

--- a/tools-mcp/adtech/openai-ads-adapter-template/examples/account.json
+++ b/tools-mcp/adtech/openai-ads-adapter-template/examples/account.json
@@ -1,0 +1,6 @@
+{
+  "id": "acct_mock_001",
+  "name": "Northstar Meals",
+  "currency": "GBP",
+  "status": "mock"
+}

--- a/tools-mcp/adtech/openai-ads-adapter-template/examples/campaign-insights.json
+++ b/tools-mcp/adtech/openai-ads-adapter-template/examples/campaign-insights.json
@@ -1,0 +1,14 @@
+{
+  "campaign_id": "cmp_mock_001",
+  "date_range": {
+    "start": "2026-07-01",
+    "end": "2026-07-07"
+  },
+  "metrics": {
+    "impressions": 12000,
+    "clicks": 420,
+    "platform_conversions": 36,
+    "spend": 840
+  },
+  "evidence_label": "platform_reported_mock"
+}

--- a/tools-mcp/adtech/openai-ads-adapter-template/tests/test-prompts.md
+++ b/tools-mcp/adtech/openai-ads-adapter-template/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. List mock campaigns without requesting a live API credential.
+2. Retrieve campaign insights and preserve the platform-reported evidence label.
+3. Refuse a request to activate a campaign through this read-only adapter.
+4. Explain how a future write should be routed through the existing executor and approval gate.
+5. Reject an API key supplied in prompt text and request a secret-manager binding.

--- a/tools-mcp/adtech/openai-ads-adapter-template/tool.yaml
+++ b/tools-mcp/adtech/openai-ads-adapter-template/tool.yaml
@@ -1,0 +1,48 @@
+id: adtech/openai-ads-adapter-template
+name: OpenAI Ads Adapter Template
+description: Mock-first read-only adapter contract for OpenAI Ads accounts, campaigns, ads, insights, and product feeds.
+version: 0.1.0
+released_at: "2026-07-24T00:00:00Z"
+category: tools-mcp/adtech
+tags:
+  - openai-ads
+  - adapter
+  - read-only
+  - campaign-insights
+  - product-feeds
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: TOOL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+dependencies:
+  apis:
+    - OpenAI Ads API
+  tools:
+    - secret_manager
+operational:
+  connected_system: OpenAI Ads API or local mock fixtures
+  capabilities:
+    - Read advertiser account metadata.
+    - List campaigns and ads.
+    - Retrieve campaign insights.
+    - Validate product-feed records.
+  auth_required:
+    - Account-scoped OpenAI Ads API credential for live bindings
+  access_level: read-only
+  trust_boundary: third-party-hosted
+  approval_boundary: Read-only by design; future writes must use the existing policy-gated ad-platform executor.
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: false
+  security_reviewed: false
+deprecated: false


### PR DESCRIPTION
## Summary

Adds a practical implementation companion for the article **Who Owns the Pixel? ChatGPT and the Repricing of Advertising**.

## Included

- Task Map Designer
- Advertising Signal Ownership Auditor
- Agent Share-of-Choice Evaluator
- ChatGPT Ads Experiment Supervisor
- Deterministic conversion event reconciler
- Mock-first, read-only OpenAI Ads adapter
- Advertising task, signal ownership, and experiment record schemas
- ChatGPT Advertising Experiment Lab pack
- Updated public catalog registries

## Design boundaries

- Live writes remain behind the existing policy-gated executor.
- The OpenAI Ads adapter is read-only and fixture-based.
- Paid, earned, and executable routes remain separate evidence types.
- Platform conversions are reconciled with independent first-party outcomes.

## Verification

- Structural validation passed
- Manifest and registry validation passed
- Go tests passed
- Reconciler unit tests passed
- Next.js production build passed
- `git diff --check` passed

## Follow-up

Replace the pending article URL in the pack after publication.
