### PR TITLE
feat: clarify usability and add OpenAI Ads lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ venv/
 # Python
 __pycache__/
 *.pyc
+plugins/**/output/
 
 # Go build artifacts
 bin/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ tools/MCP definitions, a hub UI, and QA automation flows.
 
 ## What this repo is
 
-This repository is the practical companion to our written guide. It contains a mix of directly usable instructions, local executables, configured integrations, orchestration templates, installable plugins, and documentation-only packs. Every registry entry now declares or receives an explicit usability classification.
+This repository is the practical companion to our written guide. It contains
+directly usable instructions, local executables, configured integrations,
+orchestration templates, installable plugins, and documentation-only packs.
+Every registry entry declares or receives an explicit usability classification.
 
 ## Positioning
 
@@ -28,19 +31,27 @@ entries. Packs are not installable modules.
 Review maturity and operational usability answer different questions:
 
 - `readiness` says whether an entry is experimental, reviewed, or deprecated.
-- `usability.availability` says whether it can be used now, needs setup, is a template, or is documentation only.
-- `usability.execution` says whether it behaves as instructions, a local tool, remote integration, orchestrator, bundle, or documentation.
+- `usability.availability` says whether it can be used now, needs setup, is a
+  template, or is documentation only.
+- `usability.execution` says whether it behaves as instructions, a local tool,
+  remote integration, orchestrator, bundle, or documentation.
 
-| Availability | Meaning |
-| --- | --- |
-| `usable-now` | Install and use the instructions or local executable immediately. |
-| `setup-required` | The package works after credentials, bindings, dependencies, or policy are configured. |
-| `template-only` | The package is a contract or scaffold to implement, not an executable integration. |
-| `documentation-only` | The package is a learning or architecture guide and is not installed as runtime capability. |
+- `usable-now`: Install and use the instructions or local executable
+  immediately.
+- `setup-required`: Configure credentials, bindings, dependencies, or policy
+  before use.
+- `template-only`: Implement the supplied contract or scaffold before treating
+  it as an executable integration.
+- `documentation-only`: Use the package as a learning or architecture guide;
+  it is not installed as a runtime capability.
 
-Older entries receive conservative inferred labels during registry generation. New or updated entries should declare `usability` in their manifest. The website and `skills-hub info` show whether a classification is declared or inferred.
+Older entries receive conservative inferred labels during registry generation.
+New or updated entries should declare `usability` in their manifest. The
+website and `skills-hub info` show whether a classification is declared or
+inferred.
 
-See [docs/using-the-catalog.md](docs/using-the-catalog.md) for module behavior, install effects, and first-run guidance.
+See [docs/using-the-catalog.md](docs/using-the-catalog.md) for module behavior,
+install effects, and first-run guidance.
 
 ## Catalog scope
 
@@ -51,7 +62,9 @@ Generated registry files are the source of truth for current catalog contents:
 - `registry/tools-index.json`
 - `registry/plugins-index.json`
 
-Use `./bin/skills-hub list --module <skills|agents|tools|plugins>` for the current inventory. `packs/` remains documentation-only and is intentionally outside the install registry.
+Use `./bin/skills-hub list --module <skills|agents|tools|plugins>` for the
+current inventory. `packs/` remains documentation-only and is intentionally
+outside the install registry.
 
 ## Definition of done for each module entry
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ tools/MCP definitions, a hub UI, and QA automation flows.
 
 ## What this repo is
 
-This repository is the executable companion to our written guide.
-It contains production-oriented `SKILL.md` packages, deterministic
-scripts, test prompts, and contribution standards.
+This repository is the practical companion to our written guide. It contains a mix of directly usable instructions, local executables, configured integrations, orchestration templates, installable plugins, and documentation-only packs. Every registry entry now declares or receives an explicit usability classification.
 
 ## Positioning
 
@@ -25,178 +23,35 @@ We publish reusable building blocks across four modules:
 `packs/` contains documentation-only playbooks that curate existing catalog
 entries. Packs are not installable modules.
 
-## Operational Metadata Standard
+## Know what you are installing
 
-The catalog is being normalized around a shared operational metadata model so
-users can answer the same practical questions across modules:
+Review maturity and operational usability answer different questions:
 
-- what this entry does
-- what systems it touches
-- what it needs to authenticate
-- what permissions it can exercise
-- what approval boundary applies
+- `readiness` says whether an entry is experimental, reviewed, or deprecated.
+- `usability.availability` says whether it can be used now, needs setup, is a template, or is documentation only.
+- `usability.execution` says whether it behaves as instructions, a local tool, remote integration, orchestrator, bundle, or documentation.
 
-The first rollouts are on `tools-mcp` and `agents`.
+| Availability | Meaning |
+| --- | --- |
+| `usable-now` | Install and use the instructions or local executable immediately. |
+| `setup-required` | The package works after credentials, bindings, dependencies, or policy are configured. |
+| `template-only` | The package is a contract or scaffold to implement, not an executable integration. |
+| `documentation-only` | The package is a learning or architecture guide and is not installed as runtime capability. |
 
-`tools-mcp` now exposes:
+Older entries receive conservative inferred labels during registry generation. New or updated entries should declare `usability` in their manifest. The website and `skills-hub info` show whether a classification is declared or inferred.
 
-- connected system
-- capabilities
-- auth required
-- access level
-- trust boundary
-- approval boundary
+See [docs/using-the-catalog.md](docs/using-the-catalog.md) for module behavior, install effects, and first-run guidance.
 
-`agents` now exposes:
+## Catalog scope
 
-- role
-- coordinates
-- autonomy level
-- approval boundary
-- outputs
+Generated registry files are the source of truth for current catalog contents:
 
-`skills` now exposes:
+- `registry/skills-index.json`
+- `registry/agents-index.json`
+- `registry/tools-index.json`
+- `registry/plugins-index.json`
 
-- use when
-- execution mode
-- outputs
-- approval boundary
-
-- Guide article site:
-  [ai-news-hub.performics-labs.com](https://ai-news-hub.performics-labs.com)
-  (article title: The Agent Architect’s Playbook: Building AI Skills
-  for Marketing & Ad Tech)
-- Community references:
-  [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)
-
-## Current Scope
-
-### Skills (39)
-
-1. `meta-google-weekly-performance-review` (Beginner)
-2. `creative-workshop-pmax-reels` (Intermediate)
-3. `lifecycle-experiment-planner` (Intermediate)
-4. `policy-brand-compliance-checker` (Intermediate)
-5. `seo-paid-search-synergy` (Advanced)
-6. `analyst-copilot-bigquery-redshift` (Advanced)
-7. `playwright-agentic-e2e` (QA / Infrastructure)
-8. `playwright-vscode-loop-codex` (QA / VS Code Loop)
-9. `ai-output-eval-scorecard` (Governance / Evaluation)
-10. `cross-channel-budget-pacing-agent` (Ads Ops)
-11. `ab-test-planner-analyzer` (Measurement / Experimentation)
-12. `lifecycle-journey-trigger-designer` (Lifecycle CRM)
-13. `dynamic-creative-rules-engine` (Creative Ops / Personalization)
-14. `brand-rag-memory-bootstrap` (Analytics Engineering / RAG)
-15. `weekly-performance-review-bi` (BI Reporting)
-16. `dashboard-generator` (BI Dashboard Build)
-17. `dashboard-qa-checker` (BI QA)
-18. `executive-narrative-writer` (BI Insights Communication)
-19. `engineering/implementation-strategy` (Code Maintenance)
-20. `engineering/code-change-verification` (Code Maintenance)
-21. `engineering/test-gap-analyzer` (Testing Quality)
-22. `engineering/coverage-gap-reporter` (Testing Quality)
-23. `engineering/pr-review-and-draft` (PR Review)
-24. `security/handle-untrusted-content` (Prompt Safety)
-25. `security/dependency-supply-chain-audit` (Supply Chain)
-26. `security/secrets-and-credential-hygiene` (Runtime Hardening)
-27. `security/environment-risk-assessment` (Runtime Hardening)
-28. `agentops/harness-run-reflection` (Harness Evolution)
-29. `agentops/harness-skill-proposal` (Harness Governance)
-30. `agentops/harness-regression-evaluator` (Harness Evaluation)
-31. `agentops/agent-control-plane-review` (Harness Governance)
-32. `security/marketing-agent-risk-review` (Runtime Hardening)
-33. `security/ad-platform-agent-auth-review` (Runtime Hardening)
-34. `agentops/ad-platform-policy-gate-designer` (Harness Governance)
-35. `marketing/creative-operating-system-audit` (Creative Ops / Anti-Slop)
-36. `marketing/utility-campaign-concept-designer` (Creative Ops / Utility)
-37. `marketing/product-as-media-mapper` (Creative Ops / Owned Surfaces)
-38. `marketing/cultural-timing-signal-triage` (Creative Ops / Cultural Timing)
-39. `marketing/creator-strategy-brief` (Creator Ops)
-
-### Agents (6)
-
-1. `marketing/weekly-performance-supervisor`
-2. `marketing/campaign-qa-supervisor`
-3. `adtech/bi-insights-orchestrator`
-4. `agentops/agent-control-plane-supervisor`
-5. `adtech/ad-platform-control-plane-supervisor`
-6. `marketing/creative-operating-system-supervisor`
-
-### Tools & MCP (5)
-
-1. `analytics/ga4-mcp-connector`
-2. `ads/meta-ads-mcp-connector`
-3. `warehouse/bigquery-mcp-query-runner`
-4. `agentops/agent-control-plane-server`
-5. `adtech/ad-platform-executor-template`
-
-### Plugins (10)
-
-1. `marketing/performance-reporting-plugin`
-2. `marketing/campaign-audit-plugin`
-3. `marketing/content-repurposing-plugin`
-4. `marketing/page-speed-technical-seo-plugin`
-5. `marketing/competitive-intelligence-plugin`
-6. `marketing/ad-creative-plugin`
-7. `engineering/code-maintenance-plugin`
-8. `security/runtime-safety-plugin`
-9. `agentops/harness-governance-plugin`
-10. `marketing/creative-operating-system-plugin`
-
-## Recent Additions
-
-- `ai-output-eval-scorecard`
-- `cross-channel-budget-pacing-agent`
-- `ab-test-planner-analyzer`
-- `lifecycle-journey-trigger-designer`
-- `dynamic-creative-rules-engine`
-- `brand-rag-memory-bootstrap`
-- `weekly-performance-review-bi`
-- `dashboard-generator`
-- `dashboard-qa-checker`
-- `executive-narrative-writer`
-- `marketing/weekly-performance-supervisor`
-- `marketing/campaign-qa-supervisor`
-- `adtech/bi-insights-orchestrator`
-- `analytics/ga4-mcp-connector`
-- `ads/meta-ads-mcp-connector`
-- `warehouse/bigquery-mcp-query-runner`
-- `marketing/performance-reporting-plugin`
-- `marketing/campaign-audit-plugin`
-- `marketing/content-repurposing-plugin`
-- `marketing/page-speed-technical-seo-plugin`
-- `marketing/competitive-intelligence-plugin`
-- `marketing/ad-creative-plugin`
-- `engineering/code-maintenance-plugin`
-- `security/runtime-safety-plugin`
-- `agentops/harness-governance-plugin`
-- `engineering/implementation-strategy`
-- `engineering/code-change-verification`
-- `engineering/test-gap-analyzer`
-- `engineering/coverage-gap-reporter`
-- `engineering/pr-review-and-draft`
-- `security/handle-untrusted-content`
-- `security/dependency-supply-chain-audit`
-- `security/secrets-and-credential-hygiene`
-- `security/environment-risk-assessment`
-- `agentops/harness-run-reflection`
-- `agentops/harness-skill-proposal`
-- `agentops/harness-regression-evaluator`
-- `agentops/agent-control-plane-review`
-- `security/marketing-agent-risk-review`
-- `agentops/agent-control-plane-supervisor`
-- `agentops/agent-control-plane-server`
-- `security/ad-platform-agent-auth-review`
-- `agentops/ad-platform-policy-gate-designer`
-- `adtech/ad-platform-control-plane-supervisor`
-- `adtech/ad-platform-executor-template`
-- `marketing/creative-operating-system-audit`
-- `marketing/utility-campaign-concept-designer`
-- `marketing/product-as-media-mapper`
-- `marketing/cultural-timing-signal-triage`
-- `marketing/creator-strategy-brief`
-- `marketing/creative-operating-system-supervisor`
-- `marketing/creative-operating-system-plugin`
+Use `./bin/skills-hub list --module <skills|agents|tools|plugins>` for the current inventory. `packs/` remains documentation-only and is intentionally outside the install registry.
 
 ## Definition of done for each module entry
 

--- a/agents/adtech/chatgpt-ads-experiment-supervisor/AGENT.md
+++ b/agents/adtech/chatgpt-ads-experiment-supervisor/AGENT.md
@@ -16,7 +16,7 @@ Coordinate task design, creative evaluation, signal ownership, policy controls, 
 1. Use `marketing/task-map-designer` to define task hypotheses.
 2. Route creative work through `marketing/creative-operating-system-supervisor` and compliance evaluation.
 3. Use `adtech/advertising-signal-ownership-auditor` before activation.
-4. Inspect mock or live read-only data through `adtech/openai-ads-adapter-template`.
+4. Inspect mock or live read-only data through `adtech/openai-ads-api-client`.
 5. Use the existing policy gate and executor for any proposed write.
 6. Reconcile Pixel, server, CRM, order, and reversal events with `adtech/conversion-event-reconciler`.
 7. Use `marketing/agent-share-of-choice-evaluator` to evaluate paid, earned, and executable routes.

--- a/agents/adtech/chatgpt-ads-experiment-supervisor/README.md
+++ b/agents/adtech/chatgpt-ads-experiment-supervisor/README.md
@@ -3,3 +3,5 @@
 Coordinate a practical task-led advertising experiment from hypothesis through independently reconciled evidence.
 
 Start in `mock-run` mode with the bundled pack. Move to read-only or approval-gated operation only after credentials, policy, consent, and ownership are reviewed.
+
+For the shortest working path, install `marketing/chatgpt-advertising-experiment-plugin` and run its deterministic mock lab before invoking this supervisor.

--- a/agents/adtech/chatgpt-ads-experiment-supervisor/agent.yaml
+++ b/agents/adtech/chatgpt-ads-experiment-supervisor/agent.yaml
@@ -35,9 +35,9 @@ dependencies:
     - marketing/agent-share-of-choice-evaluator
     - agentops/ad-platform-policy-gate-designer
   tools:
-    - conversion_event_reconciler
-    - openai_ads_adapter_template
-    - ad_platform_executor_template
+    - adtech/conversion-event-reconciler
+    - adtech/openai-ads-api-client
+    - adtech/ad-platform-executor-template
 operational:
   role: Experiment supervisor for task-led conversational advertising and agent-mediated commerce.
   coordinates:
@@ -53,6 +53,15 @@ operational:
     - Readiness decision
     - Reconciled evidence
     - Experiment memory record
+usability:
+  availability: setup-required
+  execution: orchestrator
+  requires_setup:
+    - Install all declared agent, skill, and tool dependencies, preferably through the ChatGPT Advertising Experiment Plugin.
+    - Configure mock or live read-only tool bindings and a governance profile.
+  limitations:
+    - The supervisor is advisory and does not execute campaign writes.
+  quickstart: Run the plugin mock lab, then invoke this agent in mock-run mode with the generated evidence bundle.
 verification:
   tests_min_prompts: 5
   security_reviewed: false

--- a/apps/web/app/agents/[...id]/page.tsx
+++ b/apps/web/app/agents/[...id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import InstallCommands from "@/components/InstallCommands";
 import { buildModuleInstallSnippet, getEntryById, loadAgentsRegistry } from "@/lib/registry";
 import { formatCategoryLabel, formatReadinessLabel } from "@/lib/categoryLabels";
+import UsabilityPanel from "@/components/UsabilityPanel";
 
 export async function generateStaticParams() {
   const registry = await loadAgentsRegistry();
@@ -42,6 +43,7 @@ export default async function AgentDetailPage({ params }: { params: { id: string
       </article>
 
       <section className="detail-grid">
+        <UsabilityPanel usability={entry.usability} />
         <article className="card detail-panel">
           <h2>Operational Summary</h2>
           <p><span className="meta">Role:</span> {entry.operational?.role ?? "Not documented"}</p>
@@ -59,6 +61,7 @@ export default async function AgentDetailPage({ params }: { params: { id: string
           <p><span className="meta">ID:</span> {entry.id}</p>
           <p><span className="meta">Runtimes:</span> {entry.runtimes.join(", ")}</p>
           <p><span className="meta">Skill dependencies:</span> {entry.dependencies?.skills?.length ?? 0}</p>
+          <p><span className="meta">Agent dependencies:</span> {entry.dependencies?.agents?.length ?? 0}</p>
           <p><span className="meta">Tool dependencies:</span> {entry.dependencies?.tools?.length ?? 0}</p>
           {entry.replaced_by ? <p><span className="meta">Replaced by:</span> {entry.replaced_by}</p> : null}
         </article>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -240,6 +240,38 @@ p {
   color: #ffb0b0;
 }
 
+.usability-badge.is-usable-now {
+  background: rgba(51, 215, 111, 0.12);
+  border-color: rgba(51, 215, 111, 0.28);
+  color: #d8fee7;
+}
+
+.usability-badge.is-setup-required {
+  background: rgba(235, 185, 74, 0.12);
+  border-color: rgba(235, 185, 74, 0.28);
+  color: #f4d78c;
+}
+
+.usability-badge.is-template-only,
+.usability-badge.is-documentation-only {
+  background: rgba(148, 163, 184, 0.1);
+  border-color: rgba(148, 163, 184, 0.26);
+  color: #c7d0dc;
+}
+
+.usability-guide {
+  margin: 0 0 1.8rem;
+}
+
+.usability-guide-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 0.8rem;
+}
+
+.usability-guide-grid p {
+  margin-bottom: 0;
+}
+
 .meta {
   font-family: var(--font-code);
   font-size: 0.78rem;
@@ -622,6 +654,10 @@ p {
     grid-template-columns: 1fr;
   }
 
+  .usability-guide-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .detail-grid {
     grid-template-columns: 1fr;
   }
@@ -645,5 +681,11 @@ p {
   .button {
     width: 100%;
     text-align: center;
+  }
+}
+
+@media (max-width: 560px) {
+  .usability-guide-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,7 @@
 import { loadAgentsRegistry, loadPluginsRegistry, loadSkillsRegistry, loadToolsRegistry } from "@/lib/registry";
 import { FEATURED_PLUGIN_IDS, FEATURED_SKILL_IDS } from "@/lib/home";
 import { formatCategoryFamily } from "@/lib/categoryLabels";
+import UsabilityBadge from "@/components/UsabilityBadge";
 
 export default async function HomePage() {
   const [skillsRegistry, agentsRegistry, toolsRegistry] = await Promise.all([
@@ -96,6 +97,19 @@ export default async function HomePage() {
         </article>
       </section>
 
+      <section className="usability-guide" aria-labelledby="use-the-catalog">
+        <div className="section-head">
+          <h2 id="use-the-catalog">Know what you are installing</h2>
+          <p className="meta">Review maturity and operational usability are separate signals.</p>
+        </div>
+        <div className="grid usability-guide-grid">
+          <article className="card"><UsabilityBadge availability="usable-now" /><p>Instructions or a local executable you can use after installation.</p></article>
+          <article className="card"><UsabilityBadge availability="setup-required" /><p>A working integration or orchestrator that needs credentials, bindings, or local policy.</p></article>
+          <article className="card"><UsabilityBadge availability="template-only" /><p>A reference contract or scaffold to adapt before it can execute.</p></article>
+          <article className="card"><UsabilityBadge availability="documentation-only" /><p>A learning pack or architecture guide; it is not installed as runtime capability.</p></article>
+        </div>
+      </section>
+
       <section className="featured-section">
         <div className="section-head">
           <h2>Featured Skills</h2>
@@ -109,7 +123,7 @@ export default async function HomePage() {
       <section className="grid featured-grid">
         {featuredSkills.map((skill) => (
           <a key={skill.id} href={`/skills/${skill.id}`} className="card catalog-card">
-            <p className="meta catalog-card-domain">{formatCategoryFamily(skill.category)}</p>
+            <div className="catalog-card-head"><p className="meta catalog-card-domain">{formatCategoryFamily(skill.category)}</p><UsabilityBadge availability={skill.usability.availability} /></div>
             <h3>{skill.name}</h3>
             <p>{skill.description}</p>
           </a>
@@ -129,7 +143,7 @@ export default async function HomePage() {
       <section className="grid featured-grid">
         {featuredPlugins.map((plugin) => (
           <a key={plugin.id} href={`/plugins/${plugin.id}`} className="card catalog-card">
-            <p className="meta catalog-card-domain">{formatCategoryFamily(plugin.category)}</p>
+            <div className="catalog-card-head"><p className="meta catalog-card-domain">{formatCategoryFamily(plugin.category)}</p><UsabilityBadge availability={plugin.usability.availability} /></div>
             <h3>{plugin.name}</h3>
             <p>{plugin.description}</p>
           </a>

--- a/apps/web/app/plugins/[...id]/page.tsx
+++ b/apps/web/app/plugins/[...id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import InstallCommands from "@/components/InstallCommands";
 import { buildModuleInstallSnippet, getEntryById, loadPluginsRegistry } from "@/lib/registry";
 import { formatCategoryLabel, formatReadinessLabel } from "@/lib/categoryLabels";
+import UsabilityPanel from "@/components/UsabilityPanel";
 
 const REPO_BLOB_BASE = "https://github.com/ai-knowledge-hub/ai-skills-guide/blob/main";
 
@@ -59,6 +60,7 @@ export default async function PluginDetailPage({ params }: { params: { id: strin
       </article>
 
       <section className="detail-grid">
+        <UsabilityPanel usability={entry.usability} />
         <article className="card detail-panel">
           <h2>Status</h2>
           <p><span className="meta">Readiness:</span> {formatReadinessLabel(entry.readiness)}</p>

--- a/apps/web/app/skills/[...id]/page.tsx
+++ b/apps/web/app/skills/[...id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { buildInstallSnippet, getSkillById, loadSkillsRegistry } from "@/lib/registry";
 import InstallCommands from "@/components/InstallCommands";
 import { formatCategoryLabel, formatReadinessLabel } from "@/lib/categoryLabels";
+import UsabilityPanel from "@/components/UsabilityPanel";
 
 export async function generateStaticParams() {
   const registry = await loadSkillsRegistry();
@@ -43,6 +44,7 @@ export default async function SkillDetailPage({ params }: { params: { id: string
       </article>
 
       <section className="detail-grid">
+        <UsabilityPanel usability={skill.usability} />
         <article className="card detail-panel">
           <h2>Operational Summary</h2>
           <p><span className="meta">Use when:</span> {skill.operational?.use_when ?? "Not documented"}</p>

--- a/apps/web/app/tools-mcp/[...id]/page.tsx
+++ b/apps/web/app/tools-mcp/[...id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import InstallCommands from "@/components/InstallCommands";
 import { buildModuleInstallSnippet, getEntryById, loadToolsRegistry } from "@/lib/registry";
 import { formatCategoryLabel, formatReadinessLabel } from "@/lib/categoryLabels";
+import UsabilityPanel from "@/components/UsabilityPanel";
 
 export async function generateStaticParams() {
   const registry = await loadToolsRegistry();
@@ -42,6 +43,7 @@ export default async function ToolDetailPage({ params }: { params: { id: string[
       </article>
 
       <section className="detail-grid">
+        <UsabilityPanel usability={entry.usability} />
         <article className="card detail-panel">
           <h2>Operational Summary</h2>
           <p><span className="meta">Connected system:</span> {entry.operational?.connected_system ?? "Not documented"}</p>

--- a/apps/web/components/CatalogClient.tsx
+++ b/apps/web/components/CatalogClient.tsx
@@ -6,6 +6,7 @@ import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import type { RegistryEntry } from "@/lib/registry";
 import FilterSelect, { type FilterOption } from "@/components/FilterSelect";
 import type { CatalogInitialFilters } from "@/lib/catalogFilters";
+import UsabilityBadge from "@/components/UsabilityBadge";
 import {
   formatDomainLabel,
   formatCategoryFamily,
@@ -200,7 +201,10 @@ export default function CatalogClient({ entries, categories, tags, basePath, ini
         {filtered.map((entry) => (
           <article key={entry.id} className="card catalog-card">
             <Link href={`${basePath}/${entry.id}`} className="catalog-card-link">
-              <p className="meta catalog-card-domain">{formatCategoryFamily(entry.category)}</p>
+              <div className="catalog-card-head">
+                <p className="meta catalog-card-domain">{formatCategoryFamily(entry.category)}</p>
+                <UsabilityBadge availability={entry.usability.availability} />
+              </div>
               <h2>{entry.name}</h2>
               <p>{entry.description}</p>
             </Link>

--- a/apps/web/components/SkillsCatalogClient.tsx
+++ b/apps/web/components/SkillsCatalogClient.tsx
@@ -7,6 +7,7 @@ import type { SkillEntry } from "@/lib/registry";
 import FilterSelect, { type FilterOption } from "@/components/FilterSelect";
 import type { CatalogInitialFilters } from "@/lib/catalogFilters";
 import { formatCategoryLabel } from "@/lib/categoryLabels";
+import UsabilityBadge from "@/components/UsabilityBadge";
 
 type SkillsCatalogClientProps = {
   skills: SkillEntry[];
@@ -171,7 +172,10 @@ export default function SkillsCatalogClient({ skills, categories, tags, initial 
       <section className="grid">
         {filtered.map((skill) => (
           <Link key={skill.id} href={`/skills/${skill.id}`} className="card">
-            <p className="meta">{skill.id}</p>
+            <div className="catalog-card-head">
+              <p className="meta">{skill.id}</p>
+              <UsabilityBadge availability={skill.usability.availability} />
+            </div>
             <h2>{skill.name}</h2>
             <p className="meta">{formatCategoryLabel(skill.category)}</p>
             <p>{skill.description}</p>

--- a/apps/web/components/UsabilityBadge.tsx
+++ b/apps/web/components/UsabilityBadge.tsx
@@ -1,0 +1,18 @@
+import type { RegistryEntry } from "@/lib/registry";
+
+type Availability = RegistryEntry["usability"]["availability"];
+
+const labels: Record<Availability, string> = {
+  "usable-now": "Usable now",
+  "setup-required": "Setup required",
+  "template-only": "Template only",
+  "documentation-only": "Documentation"
+};
+
+export default function UsabilityBadge({ availability }: { availability: Availability }) {
+  return (
+    <span className={`catalog-status-badge usability-badge is-${availability}`}>
+      {labels[availability]}
+    </span>
+  );
+}

--- a/apps/web/components/UsabilityPanel.tsx
+++ b/apps/web/components/UsabilityPanel.tsx
@@ -1,0 +1,20 @@
+import type { RegistryEntry } from "@/lib/registry";
+import UsabilityBadge from "@/components/UsabilityBadge";
+
+export default function UsabilityPanel({ usability }: { usability: RegistryEntry["usability"] }) {
+  return (
+    <article className="card detail-panel">
+      <h2>How You Can Use This</h2>
+      <p><UsabilityBadge availability={usability.availability} /></p>
+      <p><span className="meta">Execution:</span> {usability.execution}</p>
+      {usability.quickstart ? <p><span className="meta">First run:</span> <code>{usability.quickstart}</code></p> : null}
+      {usability.requires_setup?.length ? (
+        <><p className="meta">Setup required</p><ul>{usability.requires_setup.map((item) => <li key={item}>{item}</li>)}</ul></>
+      ) : null}
+      {usability.limitations?.length ? (
+        <><p className="meta">Current limits</p><ul>{usability.limitations.map((item) => <li key={item}>{item}</li>)}</ul></>
+      ) : null}
+      <p className="meta">Classification: {usability.source}</p>
+    </article>
+  );
+}

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -15,6 +15,7 @@ test("home route smoke", async ({ page }) => {
   await expect(page.getByRole("link", { name: "Plugins", exact: true })).toBeVisible();
   await expect(page.getByRole("link", { name: "Tools & MCP" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Explore skills" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Know what you are installing" })).toBeVisible();
 });
 
 test("skills route filter interaction smoke", async ({ page }) => {
@@ -34,6 +35,7 @@ test("skill detail copy-button smoke", async ({ page }) => {
 
   await page.goto(sampleSkillPath);
   await expect(page.getByRole("heading", { name: "Operational Summary" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "How You Can Use This" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Outputs" })).toBeVisible();
   await expect(page.getByText("may-run-local-verification")).toBeVisible();
   const copyButtons = page.locator(".copy-button");

--- a/apps/web/lib/registry.ts
+++ b/apps/web/lib/registry.ts
@@ -21,6 +21,14 @@ export type RegistryEntry = {
   runtimes: string[];
   tags: string[];
   readiness: "experimental" | "reviewed" | "deprecated";
+  usability: {
+    availability: "usable-now" | "setup-required" | "template-only" | "documentation-only";
+    execution: "instructions" | "local-tool" | "remote-integration" | "integration-template" | "orchestrator" | "bundle" | "documentation";
+    requires_setup?: string[];
+    limitations?: string[];
+    quickstart?: string;
+    source: "declared" | "inferred";
+  };
   security_reviewed: boolean;
   deprecated: boolean;
   replaced_by?: string;
@@ -39,6 +47,7 @@ export type RegistryEntry = {
     execution_mode?: string;
   };
   dependencies?: {
+    agents?: string[];
     skills?: string[];
     tools?: string[];
     apis?: string[];

--- a/cmd/skills-hub/main.go
+++ b/cmd/skills-hub/main.go
@@ -74,7 +74,7 @@ func runList(args []string) error {
 		if s.Deprecated {
 			status = "deprecated"
 		}
-		fmt.Printf("%s\t%s\t%s\t%s\n", s.ID, status, s.Latest, s.Name)
+		fmt.Printf("%s\t%s\t%s\t%s\t%s\n", s.ID, status, s.Usability.Availability, s.Latest, s.Name)
 	}
 	return nil
 }
@@ -167,6 +167,7 @@ func runInfo(args []string) error {
 	fmt.Printf("selected_version: %s\n", resolvedVersion.Version)
 	fmt.Printf("versions: %s\n", strings.Join(versions, ", "))
 	fmt.Printf("runtimes: %s\n", strings.Join(skill.Runtimes, ", "))
+	printUsabilitySummary(os.Stdout, skill)
 	fmt.Printf("deprecated: %t\n", skill.Deprecated)
 	if skill.ReplacedBy != "" {
 		fmt.Printf("replaced_by: %s\n", skill.ReplacedBy)
@@ -305,6 +306,7 @@ func runInstall(args []string) error {
 		}
 		fmt.Fprintln(os.Stderr)
 	}
+	printInstallUsabilityWarning(os.Stderr, skill)
 
 	sourceDir := filepath.Join(resolveModuleRoot(*entriesRoot, moduleName), filepath.FromSlash(skill.ID))
 	if stat, statErr := os.Stat(sourceDir); statErr != nil || !stat.IsDir() {
@@ -349,10 +351,35 @@ func runInstall(args []string) error {
 	}
 
 	fmt.Printf("Installed %s@%s to %s (runtime=%s)\n", skill.ID, resolvedVersion.Version, destination, rt.Runtime)
+	printUsabilitySummary(os.Stdout, skill)
 	if moduleName == "plugins" {
 		printPluginInstallNotes(os.Stdout, os.Stderr, skill, rt.Runtime, destination, runtimeArtifacts, dependencyResult)
 	}
 	return nil
+}
+
+func printUsabilitySummary(w io.Writer, entry registry.SkillEntry) {
+	fmt.Fprintf(w, "usability.availability: %s\n", entry.Usability.Availability)
+	fmt.Fprintf(w, "usability.execution: %s\n", entry.Usability.Execution)
+	fmt.Fprintf(w, "usability.source: %s\n", entry.Usability.Source)
+	if entry.Usability.Quickstart != "" {
+		fmt.Fprintf(w, "usability.quickstart: %s\n", entry.Usability.Quickstart)
+	}
+	if len(entry.Usability.RequiresSetup) > 0 {
+		fmt.Fprintf(w, "usability.requires_setup: %s\n", strings.Join(entry.Usability.RequiresSetup, "; "))
+	}
+	if len(entry.Usability.Limitations) > 0 {
+		fmt.Fprintf(w, "usability.limitations: %s\n", strings.Join(entry.Usability.Limitations, "; "))
+	}
+}
+
+func printInstallUsabilityWarning(w io.Writer, entry registry.SkillEntry) {
+	switch entry.Usability.Availability {
+	case "template-only":
+		fmt.Fprintf(w, "warning: %s installs a reference template, not a connected executable integration\n", entry.ID)
+	case "setup-required":
+		fmt.Fprintf(w, "note: %s requires configuration before operational use\n", entry.ID)
+	}
 }
 
 func printPluginSummary(w io.Writer, entry registry.SkillEntry) {
@@ -406,7 +433,10 @@ func printPluginInstallNotes(
 	if runtime == "codex" || runtime == "claude" {
 		fmt.Fprintf(stdout, "install.next_step: review the generated %s runtime manifest before enabling the plugin\n", runtime)
 	} else if runtime != "" {
-		fmt.Fprintf(stdout, "install.next_step: connect this plugin directory to your runtime manually and verify required secrets before use\n")
+		fmt.Fprintf(stdout, "install.next_step: connect this plugin directory to your runtime manually; configure secrets only for features that need them\n")
+	}
+	if entry.Usability.Quickstart != "" {
+		fmt.Fprintf(stdout, "install.quickstart: %s\n", entry.Usability.Quickstart)
 	}
 	printPluginDependencySummary(stdout, deps)
 	printPluginSummary(stdout, entry)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,11 +5,13 @@
 1. Choose one entry matching your workflow:
    - `skills/` for task-level expertise
    - `agents/` for orchestrated templates
+   - `plugins/` for installable bundles that resolve dependencies
    - `tools-mcp/` for integration connectors
-2. Copy the module spec (`SKILL.md`, `AGENT.md`, or `TOOL.md`) into your runtime workflow.
-3. Run the prompts in `tests/test-prompts.md`.
-4. Evaluate output consistency against expected format.
-5. Tune wording and constraints, then re-test.
+2. Check the entry's usability label. Prefer `usable-now`, or follow every item under `requires_setup`.
+3. Copy or install the module spec (`SKILL.md`, `AGENT.md`, `plugin.json`, or `TOOL.md`) into your runtime workflow.
+4. Run the prompts in `tests/test-prompts.md`.
+5. Evaluate output consistency against expected format.
+6. Tune wording and constraints, then re-test.
 
 ## Track B: Ad-Tech Engineer
 
@@ -36,3 +38,6 @@ Primary routes:
 - `/skills`
 - `/agents`
 - `/tools-mcp`
+- `/plugins`
+
+Read [using-the-catalog.md](using-the-catalog.md) before assuming installation means an external integration is connected.

--- a/docs/how-to-run-skills.md
+++ b/docs/how-to-run-skills.md
@@ -7,6 +7,8 @@ Open the entry `README.md` and spec file:
 - agents: `AGENT.md`
 - tools-mcp: `TOOL.md`
 
+Run `skills-hub info` and inspect `usability` first. `template-only` entries need implementation; `setup-required` entries need their listed credentials, bindings, and policies.
+
 ## 2. Provide minimum context
 
 Supply account IDs, date range, platforms, and objective as requested.

--- a/docs/using-the-catalog.md
+++ b/docs/using-the-catalog.md
@@ -1,0 +1,69 @@
+# Using the Catalog
+
+The catalog separates **what a package is** from **how ready it is to use**.
+
+## Two independent signals
+
+`readiness` describes review maturity:
+
+- `experimental`: not security reviewed
+- `reviewed`: security review recorded
+- `deprecated`: retained for compatibility, no longer preferred
+
+`usability` describes operational behavior:
+
+| Availability | Install result | What remains |
+| --- | --- | --- |
+| `usable-now` | Instructions or a local executable are copied into the runtime. | Supply task inputs and run the documented first step. |
+| `setup-required` | The package is installed, but does not become operational by installation alone. | Configure dependencies, tool bindings, credentials, and policy. |
+| `template-only` | A reference contract or scaffold is installed. | Implement and review the missing provider/runtime binding. |
+| `documentation-only` | No runtime installation is implied. | Use the material as a guide or contribution map. |
+
+The `execution` value adds the technical shape:
+
+- `instructions`: reusable procedural knowledge for an agent
+- `local-tool`: deterministic code runnable on the local machine
+- `remote-integration`: client or connector to an external system
+- `integration-template`: a provider boundary without a working connection
+- `orchestrator`: an agent that coordinates dependencies and requires bindings
+- `bundle`: a plugin that installs several catalog entries together
+- `documentation`: a learning or architecture pack
+
+## Module behavior
+
+### Skills
+
+Skills are usually `usable-now` instructions. A skill may still depend on local tools or APIs. Installation makes the instructions discoverable; it does not create missing credentials or external services.
+
+### Tools and MCP
+
+Local deterministic tools can be `usable-now`. Remote connectors are `setup-required`. Entries ending in `-template` are normally `template-only` unless their manifest explicitly says otherwise.
+
+### Agents
+
+Agents are orchestrators. Installation copies their specification, but operational use requires every declared skill, agent, and tool dependency plus tool bindings, memory, and governance. Prefer a plugin when one exists because plugin installation resolves bundled dependencies.
+
+### Plugins
+
+Plugins are the installable composition layer. They install declared skills, agents, and tools into native runtime directories and retain hooks, config, templates, and examples inside the plugin directory. Required secrets and approvals still need local configuration.
+
+### Packs
+
+Packs curate learning paths and related catalog entries. They are documentation-only and are not part of the install registry.
+
+## Inspect before installing
+
+```bash
+./bin/skills-hub info --module tools --entry adtech/openai-ads-api-client@latest
+```
+
+The output includes:
+
+- `usability.availability`
+- `usability.execution`
+- `usability.requires_setup`
+- `usability.limitations`
+- `usability.quickstart`
+- `usability.source`
+
+An inferred classification is a conservative registry default. A declared classification has been set in the package manifest and should be preferred when planning implementation.

--- a/internal/agents/manifest.go
+++ b/internal/agents/manifest.go
@@ -42,6 +42,8 @@ func ParseAgentManifest(path string) (Manifest, error) {
 			item = unquote(item)
 			if section == "dependencies" {
 				switch currentList {
+				case "agents":
+					out.DependencyAgents = append(out.DependencyAgents, item)
 				case "skills":
 					out.DependencySkills = append(out.DependencySkills, item)
 				case "tools":

--- a/internal/agents/manifest_test.go
+++ b/internal/agents/manifest_test.go
@@ -20,6 +20,8 @@ tags:
 runtimes:
   - codex
 dependencies:
+  agents:
+    - marketing/creative-supervisor
   skills:
     - adtech/dashboard-generator
   tools:
@@ -37,6 +39,9 @@ dependencies:
 	}
 	if len(m.DependencySkills) != 1 || m.DependencySkills[0] != "adtech/dashboard-generator" {
 		t.Fatalf("unexpected skills deps: %#v", m.DependencySkills)
+	}
+	if len(m.DependencyAgents) != 1 || m.DependencyAgents[0] != "marketing/creative-supervisor" {
+		t.Fatalf("unexpected agent deps: %#v", m.DependencyAgents)
 	}
 	if len(m.DependencyTools) != 1 || m.DependencyTools[0] != "ga4_query" {
 		t.Fatalf("unexpected tools deps: %#v", m.DependencyTools)

--- a/internal/agents/run.go
+++ b/internal/agents/run.go
@@ -36,6 +36,7 @@ func RunPreflight(opts RunOptions) (RunReport, error) {
 		Checks:           []string{},
 		Warnings:         []string{},
 		BlockingReasons:  []string{},
+		DependencyAgents: append([]string{}, m.DependencyAgents...),
 		DependencySkills: append([]string{}, m.DependencySkills...),
 		DependencyTools:  append([]string{}, m.DependencyTools...),
 		ResolvedTools:    map[string]ToolBinding{},
@@ -58,6 +59,13 @@ func RunPreflight(opts RunOptions) (RunReport, error) {
 			report.BlockingReasons = append(report.BlockingReasons, fmt.Sprintf("Missing skill dependency: %s", dep))
 		}
 	}
+	for _, dep := range m.DependencyAgents {
+		p := filepath.Join(opts.AgentsRoot, filepath.FromSlash(dep))
+		if _, err := os.Stat(p); err != nil {
+			report.Status = "blocked"
+			report.BlockingReasons = append(report.BlockingReasons, fmt.Sprintf("Missing agent dependency: %s", dep))
+		}
+	}
 
 	bindings := ToolBindingsFile{Tools: map[string]ToolBinding{}}
 	if strings.TrimSpace(opts.BindingsPath) != "" {
@@ -69,6 +77,13 @@ func RunPreflight(opts RunOptions) (RunReport, error) {
 	}
 
 	for _, depTool := range m.DependencyTools {
+		if strings.Contains(depTool, "/") {
+			p := filepath.Join(opts.ToolsRoot, filepath.FromSlash(depTool))
+			if _, err := os.Stat(p); err != nil {
+				report.Status = "blocked"
+				report.BlockingReasons = append(report.BlockingReasons, fmt.Sprintf("Missing tool dependency: %s", depTool))
+			}
+		}
 		binding, ok := bindings.Tools[depTool]
 		if !ok {
 			report.Status = "blocked"

--- a/internal/agents/run_test.go
+++ b/internal/agents/run_test.go
@@ -9,9 +9,13 @@ import (
 func TestRunPreflightReady(t *testing.T) {
 	root := t.TempDir()
 	agentDir := filepath.Join(root, "agents", "marketing", "demo")
+	dependencyAgentDir := filepath.Join(root, "agents", "marketing", "creative-supervisor")
 	skillDir := filepath.Join(root, "skills", "adtech", "dashboard-generator")
 	if err := os.MkdirAll(agentDir, 0o755); err != nil {
 		t.Fatalf("mkdir agent: %v", err)
+	}
+	if err := os.MkdirAll(dependencyAgentDir, 0o755); err != nil {
+		t.Fatalf("mkdir dependency agent: %v", err)
 	}
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatalf("mkdir skill: %v", err)
@@ -30,6 +34,8 @@ tags:
 runtimes:
   - codex
 dependencies:
+  agents:
+    - marketing/creative-supervisor
   skills:
     - adtech/dashboard-generator
   tools:
@@ -59,5 +65,51 @@ dependencies:
 	}
 	if len(report.WorkflowSteps) != 2 {
 		t.Fatalf("expected workflow steps, got %#v", report.WorkflowSteps)
+	}
+}
+
+func TestRunPreflightBlocksMissingCanonicalToolPackage(t *testing.T) {
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agents", "marketing", "demo")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "AGENT.md"), []byte("## Workflow\n1. Inspect\n"), 0o644); err != nil {
+		t.Fatalf("write AGENT.md: %v", err)
+	}
+	manifest := `id: marketing/demo
+name: Demo
+description: Demo.
+version: 0.1.0
+released_at: "2026-07-25T00:00:00Z"
+category: marketing-agents/performance
+tags:
+  - demo
+runtimes:
+  - codex
+dependencies:
+  tools:
+    - adtech/missing-tool
+`
+	if err := os.WriteFile(filepath.Join(agentDir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	bindings := filepath.Join(root, "bindings.json")
+	if err := os.WriteFile(bindings, []byte(`{"tools":{"adtech/missing-tool":{"endpoint":"local://missing","mode":"read_only"}}}`), 0o644); err != nil {
+		t.Fatalf("write bindings: %v", err)
+	}
+	report, err := RunPreflight(RunOptions{
+		AgentsRoot:   filepath.Join(root, "agents"),
+		SkillsRoot:   filepath.Join(root, "skills"),
+		ToolsRoot:    filepath.Join(root, "tools-mcp"),
+		AgentID:      "marketing/demo",
+		BindingsPath: bindings,
+		ApproveLive:  true,
+	})
+	if err != nil {
+		t.Fatalf("run preflight: %v", err)
+	}
+	if report.Status != "blocked" || len(report.BlockingReasons) == 0 {
+		t.Fatalf("expected missing tool to block preflight, got %#v", report)
 	}
 }

--- a/internal/agents/types.go
+++ b/internal/agents/types.go
@@ -9,6 +9,7 @@ type Manifest struct {
 	Category         string
 	Tags             []string
 	Runtimes         []string
+	DependencyAgents []string
 	DependencySkills []string
 	DependencyTools  []string
 }
@@ -40,6 +41,7 @@ type RunReport struct {
 	Checks           []string               `json:"checks"`
 	Warnings         []string               `json:"warnings"`
 	BlockingReasons  []string               `json:"blocking_reasons"`
+	DependencyAgents []string               `json:"dependency_agents"`
 	DependencySkills []string               `json:"dependency_skills"`
 	DependencyTools  []string               `json:"dependency_tools"`
 	ResolvedTools    map[string]ToolBinding `json:"resolved_tools"`

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -77,6 +77,7 @@ func buildIndexFor(root, moduleDir, manifestName string) (Index, error) {
 			SecurityReviewed: m.SecurityReviewed,
 			Deprecated:       m.Deprecated,
 			ReplacedBy:       m.ReplacedBy,
+			Usability:        usabilityFor(m, moduleDir),
 		}
 		if hasOperational(m.Operational) {
 			operational := m.Operational
@@ -115,6 +116,62 @@ func buildIndexFor(root, moduleDir, manifestName string) (Index, error) {
 		GeneratedAt:     generatedAt,
 		Skills:          skills,
 	}, nil
+}
+
+func usabilityFor(m Manifest, moduleDir string) UsabilityMetadata {
+	result := m.Usability
+	declared := result.Availability != "" || result.Execution != "" || result.Quickstart != "" ||
+		len(result.RequiresSetup) > 0 || len(result.Limitations) > 0
+
+	if result.Availability == "" {
+		switch moduleDir {
+		case "skills":
+			result.Availability = "usable-now"
+		case "agents", "plugins":
+			result.Availability = "setup-required"
+		case "tools-mcp":
+			if strings.Contains(m.ID, "template") || strings.Contains(strings.ToLower(m.Name), "template") {
+				result.Availability = "template-only"
+			} else if m.Operational.TrustBoundary == "local-tool" {
+				result.Availability = "usable-now"
+			} else {
+				result.Availability = "setup-required"
+			}
+		}
+	}
+	if result.Execution == "" {
+		switch moduleDir {
+		case "skills":
+			result.Execution = "instructions"
+		case "agents":
+			result.Execution = "orchestrator"
+		case "plugins":
+			result.Execution = "bundle"
+		case "tools-mcp":
+			if m.Operational.TrustBoundary == "local-tool" {
+				result.Execution = "local-tool"
+			} else if result.Availability == "template-only" {
+				result.Execution = "integration-template"
+			} else {
+				result.Execution = "remote-integration"
+			}
+		}
+	}
+	if result.Availability == "setup-required" && len(result.RequiresSetup) == 0 {
+		if moduleDir == "agents" {
+			result.RequiresSetup = []string{"Install declared dependencies and configure tool bindings."}
+		} else if moduleDir == "plugins" {
+			result.RequiresSetup = []string{"Review bundled components, secrets, and approval rules before enabling."}
+		} else if moduleDir == "tools-mcp" {
+			result.RequiresSetup = []string{"Configure the connected system and authentication outside agent context."}
+		}
+	}
+	if declared {
+		result.Source = "declared"
+	} else {
+		result.Source = "inferred"
+	}
+	return result
 }
 
 func hasIncludes(includes IncludeSet) bool {

--- a/internal/registry/builder_test.go
+++ b/internal/registry/builder_test.go
@@ -60,6 +60,9 @@ deprecated: false
 	if entry.Dependencies == nil || len(entry.Dependencies.Tools) != 1 {
 		t.Fatalf("expected dependencies in index, got %#v", entry.Dependencies)
 	}
+	if entry.Usability.Availability != "usable-now" || entry.Usability.Execution != "instructions" || entry.Usability.Source != "inferred" {
+		t.Fatalf("unexpected default usability: %#v", entry.Usability)
+	}
 }
 
 func TestBuildAgentsIndex(t *testing.T) {
@@ -123,6 +126,9 @@ deprecated: false
 	}
 	if entry.Dependencies == nil || len(entry.Dependencies.Agents) != 1 || len(entry.Dependencies.Skills) != 1 {
 		t.Fatalf("expected agent and skill dependencies in index, got %#v", entry.Dependencies)
+	}
+	if entry.Usability.Availability != "setup-required" || entry.Usability.Execution != "orchestrator" {
+		t.Fatalf("unexpected agent usability: %#v", entry.Usability)
 	}
 	if !strings.Contains(entry.Versions[0].ManifestURL, "/agents/marketing/demo-agent/agent.yaml") {
 		t.Fatalf("unexpected manifest url: %s", entry.Versions[0].ManifestURL)

--- a/internal/registry/manifest_parser.go
+++ b/internal/registry/manifest_parser.go
@@ -90,6 +90,13 @@ func ParseManifest(path string) (Manifest, error) {
 				case "approvals":
 					out.Requires.Approvals = append(out.Requires.Approvals, item)
 				}
+			case "usability":
+				switch currentNestedListKey {
+				case "requires_setup":
+					out.Usability.RequiresSetup = append(out.Usability.RequiresSetup, item)
+				case "limitations":
+					out.Usability.Limitations = append(out.Usability.Limitations, item)
+				}
 			}
 			continue
 		}
@@ -128,6 +135,15 @@ func ParseManifest(path string) (Manifest, error) {
 							out.Operational.UseWhen = nestedValue
 						case "execution_mode":
 							out.Operational.ExecutionMode = nestedValue
+						}
+					case "usability":
+						switch nestedKey {
+						case "availability":
+							out.Usability.Availability = nestedValue
+						case "execution":
+							out.Usability.Execution = nestedValue
+						case "quickstart":
+							out.Usability.Quickstart = nestedValue
 						}
 					}
 					currentNestedListKey = ""
@@ -186,7 +202,7 @@ func ParseManifest(path string) (Manifest, error) {
 			out.Deprecated = strings.EqualFold(value, "true")
 		case "replaced_by":
 			out.ReplacedBy = value
-		case "author", "entrypoints", "dependencies", "verification", "includes", "requires", "install", "operational":
+		case "author", "entrypoints", "dependencies", "verification", "includes", "requires", "install", "operational", "usability":
 			inNestedMap = true
 			nestedMapKey = key
 		}

--- a/internal/registry/manifest_parser_test.go
+++ b/internal/registry/manifest_parser_test.go
@@ -118,6 +118,47 @@ deprecated: false
 	}
 }
 
+func TestParseManifestUsability(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tool.yaml")
+	content := `id: adtech/example-tool
+name: Example Tool
+description: Example tool manifest for usability parsing.
+version: 0.1.0
+released_at: "2026-07-25T00:00:00Z"
+category: tools-mcp/adtech
+tags:
+  - example
+license: MIT
+author:
+  name: Example
+runtimes:
+  - codex
+usability:
+  availability: setup-required
+  execution: remote-integration
+  requires_setup:
+    - Configure an account-scoped key.
+  limitations:
+    - Dry-run mode is the default.
+  quickstart: python3 scripts/client.py account
+deprecated: false
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	m, err := ParseManifest(path)
+	if err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	if m.Usability.Availability != "setup-required" || m.Usability.Execution != "remote-integration" {
+		t.Fatalf("unexpected usability: %#v", m.Usability)
+	}
+	if len(m.Usability.RequiresSetup) != 1 || len(m.Usability.Limitations) != 1 {
+		t.Fatalf("unexpected usability lists: %#v", m.Usability)
+	}
+}
+
 func TestParseAgentManifestOperationalMetadata(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agent.yaml")

--- a/internal/registry/types.go
+++ b/internal/registry/types.go
@@ -13,9 +13,19 @@ type Manifest struct {
 	Deprecated       bool
 	ReplacedBy       string
 	Operational      OperationalMetadata
+	Usability        UsabilityMetadata
 	Dependencies     DependencySet
 	Includes         IncludeSet
 	Requires         RequirementSet
+}
+
+type UsabilityMetadata struct {
+	Availability  string   `json:"availability"`
+	Execution     string   `json:"execution"`
+	RequiresSetup []string `json:"requires_setup,omitempty"`
+	Limitations   []string `json:"limitations,omitempty"`
+	Quickstart    string   `json:"quickstart,omitempty"`
+	Source        string   `json:"source"`
 }
 
 type OperationalMetadata struct {
@@ -73,6 +83,7 @@ type SkillEntry struct {
 	Deprecated       bool                 `json:"deprecated"`
 	ReplacedBy       string               `json:"replaced_by,omitempty"`
 	Operational      *OperationalMetadata `json:"operational,omitempty"`
+	Usability        UsabilityMetadata    `json:"usability"`
 	Dependencies     *DependencySet       `json:"dependencies,omitempty"`
 	Includes         *IncludeSet          `json:"includes,omitempty"`
 	Requires         *RequirementSet      `json:"requires,omitempty"`

--- a/packs/chatgpt-advertising-experiment-lab/README.md
+++ b/packs/chatgpt-advertising-experiment-lab/README.md
@@ -1,5 +1,7 @@
 # ChatGPT Advertising Experiment Lab
 
+> **Installable path:** Use `marketing/chatgpt-advertising-experiment-plugin` for the bundled skills, agents, tools, configuration, and one-command offline mock lab. This page remains the documentation pack.
+
 A practical pack for testing the advertising shift described in **Who Owns the Pixel? ChatGPT and the Repricing of Advertising**.
 
 Article link: pending publication.
@@ -19,7 +21,8 @@ Advertising inside an agent-mediated channel needs two control planes:
 | `adtech/advertising-signal-ownership-auditor` | Map collection, control, visibility, and use of every signal. |
 | `marketing/agent-share-of-choice-evaluator` | Evaluate progression through agent-mediated decision stages. |
 | `adtech/conversion-event-reconciler` | Deduplicate Pixel and server events and verify first-party outcomes. |
-| `adtech/openai-ads-adapter-template` | Start with read-only mock OpenAI Ads contracts and fixtures. |
+| `adtech/openai-ads-api-client` | Run mock or live read-only OpenAI Ads retrieval and validate conversion batches without saving them. |
+| `adtech/openai-ads-adapter-template` | Reference the provider-boundary contract when building another integration. |
 | `adtech/chatgpt-ads-experiment-supervisor` | Coordinate the end-to-end experiment. |
 
 ## Reused foundations
@@ -32,12 +35,11 @@ Advertising inside an agent-mediated channel needs two control planes:
 
 ## Recommended first run
 
-1. Install the supervisor and its dependencies.
-2. Start in `mock-run` mode.
-3. Use the Northstar Meals task-map and event fixtures.
-4. Run the conversion reconciler.
-5. Compare platform-reported conversions with settled and refunded outcomes.
-6. Add the missing retention signal before drawing a performance conclusion.
+1. Install `marketing/chatgpt-advertising-experiment-plugin`.
+2. Run `python3 scripts/run_mock_lab.py` from the installed plugin directory.
+3. Give the generated evidence bundle to the supervisor in `mock-run` mode.
+4. Compare platform-reported conversions with settled and refunded outcomes.
+5. Add the missing retention signal before drawing a performance conclusion.
 
 ```text
 Use ChatGPT Ads Experiment Supervisor in mock-run mode.
@@ -48,4 +50,4 @@ Stop if the measurement ledger cannot independently verify conversion quality.
 
 ## Live-system boundary
 
-The pack does not ship a live OpenAI Ads client and does not grant write authority. Confirm current official API access and schemas before replacing fixtures. Route all future writes through the existing policy-gated executor with human approval and rollback evidence.
+The installable plugin includes a live read-only OpenAI Ads client and non-persisting conversion validation. It does not grant write authority. Route all future mutations through a reviewed policy-gated executor with human approval and rollback evidence.

--- a/plugins/marketing/chatgpt-advertising-experiment-plugin/README.md
+++ b/plugins/marketing/chatgpt-advertising-experiment-plugin/README.md
@@ -1,0 +1,58 @@
+# ChatGPT Advertising Experiment Plugin
+
+This bundle turns the ChatGPT advertising experiment pack into an installable workflow. It separates three things that are easy to confuse:
+
+- **Usable now:** planning skills, the local event reconciler, mock fixtures, and the deterministic mock lab.
+- **Usable after setup:** live read-only OpenAI Ads account, campaign, ad, and insights retrieval; remote conversion validation.
+- **Template only:** the write-capable ad-platform executor. Replace and review it before live mutation work.
+
+## Install
+
+```bash
+./bin/skills-hub install \
+  --module plugins \
+  --entry marketing/chatgpt-advertising-experiment-plugin@0.1.0 \
+  --runtime codex
+```
+
+The installer places bundled skills, agents, and tools in their native runtime directories. Plugin config, hooks, examples, and the mock runner stay in the plugin directory.
+
+## First run: no credentials
+
+From the installed plugin directory:
+
+```bash
+python3 scripts/run_mock_lab.py
+```
+
+The command reads the installed mock Ads API fixtures, validates a conversion batch, reconciles platform events against business outcomes, and writes `output/mock-evidence-bundle.json`. It makes no network calls.
+
+Use that evidence bundle with `adtech/chatgpt-ads-experiment-supervisor` in `mock-run` mode.
+
+## Live read-only setup
+
+Create an account-scoped API key in OpenAI Ads Manager, store it outside agent context, and run:
+
+```bash
+export OPENAI_ADS_API_KEY='...'
+python3 ../../../tools-mcp/adtech/openai-ads-api-client/scripts/openai_ads_client.py --mode live account
+```
+
+For remote conversion validation, also configure `OPENAI_ADS_PIXEL_ID` and `OPENAI_ADS_CONVERSIONS_API_KEY`. The bundled validator always sends `validate_only: true`.
+
+## Live writes
+
+No live OpenAI Ads writer ships in this plugin. The included executor is an architecture template. A production implementation must add:
+
+- explicit operation allowlists
+- bounded budget and targeting deltas
+- two-step approval
+- current-state validation
+- idempotency and retry policy
+- immutable audit records and rollback evidence
+
+## Official OpenAI Ads references
+
+- https://developers.openai.com/ads/api-overview
+- https://developers.openai.com/ads/api-quickstart
+- https://developers.openai.com/ads/conversions-api

--- a/plugins/marketing/chatgpt-advertising-experiment-plugin/config/governance.mock.json
+++ b/plugins/marketing/chatgpt-advertising-experiment-plugin/config/governance.mock.json
@@ -1,0 +1,5 @@
+{
+  "require_approval_for_live": false,
+  "allow_write_tools": false,
+  "max_tool_calls": 30
+}

--- a/plugins/marketing/chatgpt-advertising-experiment-plugin/config/memory-profile.mock.json
+++ b/plugins/marketing/chatgpt-advertising-experiment-plugin/config/memory-profile.mock.json
@@ -1,0 +1,5 @@
+{
+  "context_files": [],
+  "state_store": "output/mock-evidence-bundle.json",
+  "retention_days": 30
+}

--- a/plugins/marketing/chatgpt-advertising-experiment-plugin/config/tool-bindings.mock.json
+++ b/plugins/marketing/chatgpt-advertising-experiment-plugin/config/tool-bindings.mock.json
@@ -1,0 +1,7 @@
+{
+  "tools": {
+    "adtech/conversion-event-reconciler": {"endpoint": "local://conversion-event-reconciler", "mode": "read_only"},
+    "adtech/openai-ads-api-client": {"endpoint": "local://openai-ads-api-client?mode=mock", "mode": "read_only"},
+    "adtech/ad-platform-executor-template": {"endpoint": "disabled://template-only", "mode": "read_only"}
+  }
+}

--- a/plugins/marketing/chatgpt-advertising-experiment-plugin/examples/experiment.json
+++ b/plugins/marketing/chatgpt-advertising-experiment-plugin/examples/experiment.json
@@ -1,0 +1,8 @@
+{
+  "experiment_id": "northstar-task-led-001",
+  "mode": "mock-run",
+  "brand": "Northstar Meals",
+  "task": "Choose a nut-free family meal plan under GBP 45",
+  "hypothesis": "Showing verified allergen, weekly price, and availability evidence will improve qualified plan selection.",
+  "decision_policy": "No live writes; require independently verified outcomes before interpretation."
+}

--- a/plugins/marketing/chatgpt-advertising-experiment-plugin/examples/reconciliation-input.json
+++ b/plugins/marketing/chatgpt-advertising-experiment-plugin/examples/reconciliation-input.json
@@ -1,0 +1,5 @@
+{
+  "browser_events": [{"event_name":"order_created","event_id":"order_12345"}],
+  "server_events": [{"event_name":"order_created","event_id":"order_12345","order_id":"order_12345","value":39,"currency":"GBP"}],
+  "outcomes": [{"order_id":"order_12345","status":"settled"}]
+}

--- a/plugins/marketing/chatgpt-advertising-experiment-plugin/hooks/require-measurement-before-activation.md
+++ b/plugins/marketing/chatgpt-advertising-experiment-plugin/hooks/require-measurement-before-activation.md
@@ -1,0 +1,11 @@
+# Require Measurement Before Activation
+
+Trigger before any campaign activation or tracking change.
+
+## Intent
+
+- require a completed signal ownership ledger
+- require event IDs and deduplication rules for browser and server events
+- require an independently verifiable business outcome
+- block activation when platform-reported conversions are the only evidence source
+- require named approval owners for tracking and campaign changes

--- a/plugins/marketing/chatgpt-advertising-experiment-plugin/plugin.json
+++ b/plugins/marketing/chatgpt-advertising-experiment-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "chatgpt-advertising-experiment-plugin",
+  "version": "0.1.0",
+  "description": "Installable task-led ChatGPT Ads experimentation workflow with a deterministic mock lab and guarded API boundaries."
+}

--- a/plugins/marketing/chatgpt-advertising-experiment-plugin/plugin.yaml
+++ b/plugins/marketing/chatgpt-advertising-experiment-plugin/plugin.yaml
@@ -1,0 +1,66 @@
+id: marketing/chatgpt-advertising-experiment-plugin
+name: ChatGPT Advertising Experiment Plugin
+description: Install a task-led ChatGPT Ads experiment workflow with planning skills, supervisors, read-only API access, conversion reconciliation, policy gates, and a one-command mock lab.
+version: 0.1.0
+released_at: "2026-07-25T00:00:00Z"
+category: marketing-plugins/intelligence
+tags:
+  - chatgpt-ads
+  - advertiser-api
+  - experimentation
+  - measurement
+  - agentic-commerce
+  - governance
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: plugin.json
+  readme: README.md
+  tests: tests/test-prompts.md
+  examples_dir: examples
+includes:
+  skills:
+    - marketing/task-map-designer
+    - marketing/ai-output-eval-scorecard
+    - adtech/advertising-signal-ownership-auditor
+    - marketing/agent-share-of-choice-evaluator
+    - agentops/ad-platform-policy-gate-designer
+  agents:
+    - adtech/chatgpt-ads-experiment-supervisor
+    - marketing/creative-operating-system-supervisor
+    - adtech/ad-platform-control-plane-supervisor
+  tools:
+    - adtech/conversion-event-reconciler
+    - adtech/openai-ads-api-client
+    - adtech/ad-platform-executor-template
+  hooks:
+    - require-measurement-before-activation
+requires:
+  secrets:
+    - OPENAI_ADS_API_KEY
+    - OPENAI_ADS_PIXEL_ID
+    - OPENAI_ADS_CONVERSIONS_API_KEY
+  approvals:
+    - human-approval-before-live-campaign-write
+    - human-approval-before-tracking-change
+usability:
+  availability: usable-now
+  execution: bundle
+  requires_setup:
+    - For live reads, configure account-scoped API credentials only after the mock lab passes.
+    - Replace the executor template with an approved platform executor before any mutation.
+  limitations:
+    - The installed OpenAI Ads client does not mutate campaigns, ad groups, ads, files, or feeds.
+    - The bundled executor remains a reference template rather than a live OpenAI Ads writer.
+  quickstart: python3 scripts/run_mock_lab.py
+verification:
+  tests_min_prompts: 5
+  security_reviewed: false
+deprecated: false

--- a/plugins/marketing/chatgpt-advertising-experiment-plugin/scripts/run_mock_lab.py
+++ b/plugins/marketing/chatgpt-advertising-experiment-plugin/scripts/run_mock_lab.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Build a deterministic ChatGPT Ads mock evidence bundle without network access."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+RUNTIME_ROOT = PLUGIN_DIR.parents[2]
+TOOLS_ROOT = RUNTIME_ROOT / "tools-mcp" / "adtech"
+CLIENT = TOOLS_ROOT / "openai-ads-api-client" / "scripts" / "openai_ads_client.py"
+VALIDATOR = TOOLS_ROOT / "openai-ads-api-client" / "scripts" / "validate_conversion_events.py"
+CONVERSION_FIXTURE = TOOLS_ROOT / "openai-ads-api-client" / "examples" / "conversion-events.json"
+RECONCILER = TOOLS_ROOT / "conversion-event-reconciler" / "scripts" / "reconcile_events.py"
+RECONCILIATION_INPUT = PLUGIN_DIR / "examples" / "reconciliation-input.json"
+EXPERIMENT = PLUGIN_DIR / "examples" / "experiment.json"
+OUTPUT = PLUGIN_DIR / "output" / "mock-evidence-bundle.json"
+REFERENCE_NOW_MS = "1784937600000"
+
+
+def run_json(*args):
+    process = subprocess.run(args, check=True, capture_output=True, text=True)
+    return json.loads(process.stdout)
+
+
+def require(path):
+    if not path.exists():
+        raise SystemExit(f"missing installed dependency: {path}")
+
+
+def main():
+    for path in (CLIENT, VALIDATOR, CONVERSION_FIXTURE, RECONCILER, RECONCILIATION_INPUT, EXPERIMENT):
+        require(path)
+
+    bundle = {
+        "experiment": json.loads(EXPERIMENT.read_text()),
+        "platform": {
+            "account": run_json(sys.executable, str(CLIENT), "--mode", "mock", "account"),
+            "campaigns": run_json(sys.executable, str(CLIENT), "--mode", "mock", "campaigns"),
+            "insights": run_json(sys.executable, str(CLIENT), "--mode", "mock", "insights", "--scope", "campaign", "--entity-id", "cmpn_101"),
+        },
+        "conversion_validation": run_json(sys.executable, str(VALIDATOR), str(CONVERSION_FIXTURE), "--now-ms", REFERENCE_NOW_MS),
+        "reconciliation": run_json(sys.executable, str(RECONCILER), str(RECONCILIATION_INPUT)),
+        "network_calls": 0,
+        "next_step": "Review this bundle with adtech/chatgpt-ads-experiment-supervisor in mock-run mode."
+    }
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(json.dumps(bundle, indent=2, sort_keys=True) + "\n")
+    print(OUTPUT)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/marketing/chatgpt-advertising-experiment-plugin/tests/test-prompts.md
+++ b/plugins/marketing/chatgpt-advertising-experiment-plugin/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Explain what in this plugin works without credentials and run the mock lab.
+2. Identify which component is still a template and why it cannot execute live writes.
+3. Prepare live read-only OpenAI Ads setup without exposing a credential to agent context.
+4. Review the mock evidence bundle and keep platform-reported conversions separate from verified outcomes.
+5. Refuse campaign activation when the measurement hook or human approvals are missing.

--- a/plugins/marketing/chatgpt-advertising-experiment-plugin/tests/test_mock_lab.py
+++ b/plugins/marketing/chatgpt-advertising-experiment-plugin/tests/test_mock_lab.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class MockLabTests(unittest.TestCase):
+    def test_mock_lab_builds_offline_evidence_bundle(self):
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "run_mock_lab.py")],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        output = Path(result.stdout.strip())
+        payload = json.loads(output.read_text())
+        self.assertEqual(payload["network_calls"], 0)
+        self.assertTrue(payload["conversion_validation"]["valid"])
+        self.assertEqual(payload["reconciliation"]["summary"]["verified_outcome_count"], 1)
+        output.unlink()
+        output.parent.rmdir()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/registry/agents-index.json
+++ b/registry/agents-index.json
@@ -49,6 +49,14 @@
           "Executor and rollback checklist"
         ]
       },
+      "usability": {
+        "availability": "setup-required",
+        "execution": "orchestrator",
+        "requires_setup": [
+          "Install declared dependencies and configure tool bindings."
+        ],
+        "source": "inferred"
+      },
       "dependencies": {
         "skills": [
           "security/ad-platform-agent-auth-review",
@@ -105,6 +113,14 @@
           "Risks and data limitations"
         ]
       },
+      "usability": {
+        "availability": "setup-required",
+        "execution": "orchestrator",
+        "requires_setup": [
+          "Install declared dependencies and configure tool bindings."
+        ],
+        "source": "inferred"
+      },
       "dependencies": {
         "skills": [
           "adtech/analyst-copilot-bigquery-redshift",
@@ -129,7 +145,7 @@
           "released_at": "2026-07-24T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/agents/adtech/chatgpt-ads-experiment-supervisor/agent.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/chatgpt-ads-experiment-supervisor/0.1.0.tar.gz",
-          "sha256": "ac8a8a26dab49607fbc3e8bdeba97ad68415901f2832f9a3cbe2343e8df013cd"
+          "sha256": "fe13951af91f9ebc8f65750db3ceb0b110eb7340e88187c687a98fd262c507d0"
         }
       ],
       "runtimes": [
@@ -165,6 +181,19 @@
           "Experiment memory record"
         ]
       },
+      "usability": {
+        "availability": "setup-required",
+        "execution": "orchestrator",
+        "requires_setup": [
+          "Install all declared agent, skill, and tool dependencies, preferably through the ChatGPT Advertising Experiment Plugin.",
+          "Configure mock or live read-only tool bindings and a governance profile."
+        ],
+        "limitations": [
+          "The supervisor is advisory and does not execute campaign writes."
+        ],
+        "quickstart": "Run the plugin mock lab, then invoke this agent in mock-run mode with the generated evidence bundle.",
+        "source": "declared"
+      },
       "dependencies": {
         "agents": [
           "marketing/creative-operating-system-supervisor",
@@ -178,9 +207,9 @@
           "agentops/ad-platform-policy-gate-designer"
         ],
         "tools": [
-          "conversion_event_reconciler",
-          "openai_ads_adapter_template",
-          "ad_platform_executor_template"
+          "adtech/conversion-event-reconciler",
+          "adtech/openai-ads-api-client",
+          "adtech/ad-platform-executor-template"
         ]
       }
     },
@@ -230,6 +259,14 @@
           "Policy and approval recommendations",
           "Audit evidence checklist"
         ]
+      },
+      "usability": {
+        "availability": "setup-required",
+        "execution": "orchestrator",
+        "requires_setup": [
+          "Install declared dependencies and configure tool bindings."
+        ],
+        "source": "inferred"
       },
       "dependencies": {
         "skills": [
@@ -284,6 +321,14 @@
           "Remediation action list",
           "Alert summary for escalation"
         ]
+      },
+      "usability": {
+        "availability": "setup-required",
+        "execution": "orchestrator",
+        "requires_setup": [
+          "Install declared dependencies and configure tool bindings."
+        ],
+        "source": "inferred"
       },
       "dependencies": {
         "skills": [
@@ -347,6 +392,14 @@
           "Launch-readiness scorecard"
         ]
       },
+      "usability": {
+        "availability": "setup-required",
+        "execution": "orchestrator",
+        "requires_setup": [
+          "Install declared dependencies and configure tool bindings."
+        ],
+        "source": "inferred"
+      },
       "dependencies": {
         "skills": [
           "marketing/creative-operating-system-audit",
@@ -402,6 +455,14 @@
           "QA package",
           "Executive narrative"
         ]
+      },
+      "usability": {
+        "availability": "setup-required",
+        "execution": "orchestrator",
+        "requires_setup": [
+          "Install declared dependencies and configure tool bindings."
+        ],
+        "source": "inferred"
       },
       "dependencies": {
         "skills": [

--- a/registry/index.json
+++ b/registry/index.json
@@ -42,6 +42,11 @@
         "use_when": "Use before campaign activation or measurement redesign to determine who owns and can verify each signal.",
         "execution_mode": "analysis-only"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "shared/schemas/advertising/signal-ownership-ledger.schema.json"
@@ -86,6 +91,11 @@
         ],
         "use_when": "Use when an analyst question needs safe SQL drafting, metric validation, and stakeholder-ready findings across BigQuery or Redshift.",
         "execution_mode": "read-only-local-inspection"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -133,6 +143,11 @@
         "use_when": "Use when you need to structure approved brand, campaign, and policy documents into a retrieval-ready memory layer.",
         "execution_mode": "analysis-only"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -177,6 +192,11 @@
         ],
         "use_when": "Use when normalized performance tables need to be turned into deterministic weekly dashboard sections.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -223,6 +243,11 @@
         "use_when": "Use when a dashboard or BI package needs freshness, completeness, reconciliation, and anomaly checks before publish.",
         "execution_mode": "may-run-local-verification"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -267,6 +292,11 @@
         ],
         "use_when": "Use when QA-approved BI outputs need to be converted into concise executive narrative and action framing.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -313,6 +343,11 @@
         ],
         "use_when": "Use when a web app needs Playwright smoke coverage, failure diagnosis, and minimal healing suggestions.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -362,6 +397,11 @@
         "use_when": "Use when Codex is orchestrating a VS Code-compatible Playwright planner, generator, and healer loop.",
         "execution_mode": "may-run-local-verification"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "node",
@@ -409,6 +449,11 @@
         "use_when": "Use when ad copy, URLs, or tracking conventions need policy and brand validation before launch.",
         "execution_mode": "may-run-local-verification"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -454,6 +499,11 @@
         ],
         "use_when": "Use when weekly BI reporting needs deterministic orchestration across dashboard generation, QA, and narrative drafting.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -501,6 +551,11 @@
         ],
         "use_when": "Use when defining what an ad-platform agent may auto-execute, what requires approval, and what must be denied.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -542,6 +597,11 @@
         ],
         "use_when": "Use before deploying or expanding an agent workflow that can call tools, access data, or trigger operational actions.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -582,6 +642,11 @@
         ],
         "use_when": "Use when proposed harness changes need benchmark and red-team evaluation before adoption.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -622,6 +687,11 @@
         ],
         "use_when": "Use when recent agent run logs need review for repeated misses, skipped skills, and inefficient loops.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -662,6 +732,11 @@
         ],
         "use_when": "Use when repeated harness failures justify drafting new or revised harness skills and policy text.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -702,6 +777,11 @@
         ],
         "use_when": "Use when a code change needs stack-aware lint, typecheck, build, and test verification based on touched files.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -747,6 +827,11 @@
         ],
         "use_when": "Use when coverage artifacts need to be mapped to changed files and uncovered regression risk.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -787,6 +872,11 @@
         ],
         "use_when": "Use when a repository needs scope analysis, impact mapping, and change planning before edits begin.",
         "execution_mode": "read-only-local-inspection"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -832,6 +922,11 @@
         ],
         "use_when": "Use when code changes need correctness, performance, security, and test review plus a structured PR draft.",
         "execution_mode": "read-only-local-inspection"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -872,6 +967,11 @@
         ],
         "use_when": "Use when changed code needs missing unit, integration, regression, and edge-case scenarios identified.",
         "execution_mode": "read-only-local-inspection"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -913,6 +1013,11 @@
         ],
         "use_when": "Use when an A/B test needs explicit hypotheses, sample-size assumptions, and decision rules.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -959,6 +1064,11 @@
         ],
         "use_when": "Use when a team needs a repeatable task-panel evaluation of paid, earned, and executable brand participation.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1009,6 +1119,11 @@
         "use_when": "Use when AI-generated marketing outputs need repeatable scoring across quality, compliance, actionability, and creative operating system fit.",
         "execution_mode": "analysis-only"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -1055,6 +1170,11 @@
         ],
         "use_when": "Use when a brand or team wants to assess whether it can turn AI output into distinctive, useful, governed creative work.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1095,6 +1215,11 @@
         ],
         "use_when": "Use when you need platform-ready creative variants for Google PMax and Meta Reels with bounded formatting checks.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1143,6 +1268,11 @@
         ],
         "use_when": "Use when building creator-led campaigns where creators should shape the idea, not just distribute it.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1184,6 +1314,11 @@
         ],
         "use_when": "Use when pacing and efficiency signals across channels need bounded reallocation recommendations.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1230,6 +1365,11 @@
         ],
         "use_when": "Use when a brand notices a live moment and needs a fast go/no-go recommendation with guardrails.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1271,6 +1411,11 @@
         ],
         "use_when": "Use when audience-aware creative assembly rules need to be defined under brand and policy constraints.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1316,6 +1461,11 @@
         ],
         "use_when": "Use when a lifecycle experiment needs statistical assumptions, stop rules, and guardrail metrics defined clearly.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1363,6 +1513,11 @@
         "use_when": "Use when lifecycle entry, progression, and suppression rules need to be designed with measurement plans.",
         "execution_mode": "analysis-only"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -1408,6 +1563,11 @@
         "use_when": "Use when weekly performance across Meta and Google Ads needs KPI comparison and prioritized actions.",
         "execution_mode": "may-run-local-verification"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -1452,6 +1612,11 @@
         ],
         "use_when": "Use when a campaign should use owned product or service surfaces as the campaign platform.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1492,6 +1657,11 @@
         ],
         "use_when": "Use when SEO winners need to be translated into paid search opportunities and test-ready keyword structures.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1539,6 +1709,11 @@
         "use_when": "Use when an advertising or commerce experiment should begin from a customer task rather than a keyword or placement list.",
         "execution_mode": "analysis-only"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "shared/schemas/advertising/task-map.schema.json"
@@ -1585,6 +1760,11 @@
         ],
         "use_when": "Use when a team wants campaign concepts that do something useful rather than only communicate a message.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1627,6 +1807,11 @@
         ],
         "use_when": "Use before an agent reads or writes to DV360, Google Ads, Meta Ads, product feeds, or commerce/analytics APIs using OAuth or service credentials.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1667,6 +1852,11 @@
         ],
         "use_when": "Use when manifests and lockfiles need vulnerability, provenance, and package risk review before trust is granted.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1713,6 +1903,11 @@
         ],
         "use_when": "Use when you need to assess whether the current runtime is safe for autonomous agent execution.",
         "execution_mode": "read-only-local-inspection"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1753,6 +1948,11 @@
         ],
         "use_when": "Use when logs, tickets, webpages, or MCP outputs may contain prompt injection or unsafe instructions.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1794,6 +1994,11 @@
         ],
         "use_when": "Use when reviewing marketing or adtech agents that touch spend, audiences, product data, analytics, customer data, or publishing workflows.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1834,6 +2039,11 @@
         ],
         "use_when": "Use when diffs or repository context need secret scanning and credential exposure review.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [

--- a/registry/plugins-index.json
+++ b/registry/plugins-index.json
@@ -1,6 +1,6 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-06-28T00:00:00Z",
+  "generated_at": "2026-07-25T00:00:00Z",
   "skills": [
     {
       "id": "agentops/harness-governance-plugin",
@@ -31,6 +31,14 @@
       "readiness": "experimental",
       "security_reviewed": false,
       "deprecated": false,
+      "usability": {
+        "availability": "setup-required",
+        "execution": "bundle",
+        "requires_setup": [
+          "Review bundled components, secrets, and approval rules before enabling."
+        ],
+        "source": "inferred"
+      },
       "includes": {
         "skills": [
           "agentops/harness-run-reflection",
@@ -76,6 +84,14 @@
       "readiness": "experimental",
       "security_reviewed": false,
       "deprecated": false,
+      "usability": {
+        "availability": "setup-required",
+        "execution": "bundle",
+        "requires_setup": [
+          "Review bundled components, secrets, and approval rules before enabling."
+        ],
+        "source": "inferred"
+      },
       "includes": {
         "skills": [
           "engineering/implementation-strategy",
@@ -123,6 +139,14 @@
       "readiness": "experimental",
       "security_reviewed": false,
       "deprecated": false,
+      "usability": {
+        "availability": "setup-required",
+        "execution": "bundle",
+        "requires_setup": [
+          "Review bundled components, secrets, and approval rules before enabling."
+        ],
+        "source": "inferred"
+      },
       "includes": {
         "skills": [
           "marketing/creative-workshop-pmax-reels",
@@ -175,6 +199,14 @@
       "readiness": "experimental",
       "security_reviewed": false,
       "deprecated": false,
+      "usability": {
+        "availability": "setup-required",
+        "execution": "bundle",
+        "requires_setup": [
+          "Review bundled components, secrets, and approval rules before enabling."
+        ],
+        "source": "inferred"
+      },
       "includes": {
         "skills": [
           "adtech/policy-brand-compliance-checker",
@@ -198,6 +230,85 @@
         ],
         "approvals": [
           "human-approval-for-live-changes"
+        ]
+      }
+    },
+    {
+      "id": "marketing/chatgpt-advertising-experiment-plugin",
+      "name": "ChatGPT Advertising Experiment Plugin",
+      "description": "Install a task-led ChatGPT Ads experiment workflow with planning skills, supervisors, read-only API access, conversion reconciliation, policy gates, and a one-command mock lab.",
+      "category": "marketing-plugins/intelligence",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-07-25T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/plugins/marketing/chatgpt-advertising-experiment-plugin/plugin.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/marketing/chatgpt-advertising-experiment-plugin/0.1.0.tar.gz",
+          "sha256": "cecee5e90eac1be1b2ffc35e7619f501bbbf0cc972e456638ed4dd049a3464bb"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "chatgpt-ads",
+        "advertiser-api",
+        "experimentation",
+        "measurement",
+        "agentic-commerce",
+        "governance"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "usability": {
+        "availability": "usable-now",
+        "execution": "bundle",
+        "requires_setup": [
+          "For live reads, configure account-scoped API credentials only after the mock lab passes.",
+          "Replace the executor template with an approved platform executor before any mutation."
+        ],
+        "limitations": [
+          "The installed OpenAI Ads client does not mutate campaigns, ad groups, ads, files, or feeds.",
+          "The bundled executor remains a reference template rather than a live OpenAI Ads writer."
+        ],
+        "quickstart": "python3 scripts/run_mock_lab.py",
+        "source": "declared"
+      },
+      "includes": {
+        "skills": [
+          "marketing/task-map-designer",
+          "marketing/ai-output-eval-scorecard",
+          "adtech/advertising-signal-ownership-auditor",
+          "marketing/agent-share-of-choice-evaluator",
+          "agentops/ad-platform-policy-gate-designer"
+        ],
+        "agents": [
+          "adtech/chatgpt-ads-experiment-supervisor",
+          "marketing/creative-operating-system-supervisor",
+          "adtech/ad-platform-control-plane-supervisor"
+        ],
+        "tools": [
+          "adtech/conversion-event-reconciler",
+          "adtech/openai-ads-api-client",
+          "adtech/ad-platform-executor-template"
+        ],
+        "hooks": [
+          "require-measurement-before-activation"
+        ]
+      },
+      "requires": {
+        "secrets": [
+          "OPENAI_ADS_API_KEY",
+          "OPENAI_ADS_PIXEL_ID",
+          "OPENAI_ADS_CONVERSIONS_API_KEY"
+        ],
+        "approvals": [
+          "human-approval-before-live-campaign-write",
+          "human-approval-before-tracking-change"
         ]
       }
     },
@@ -230,6 +341,14 @@
       "readiness": "experimental",
       "security_reviewed": false,
       "deprecated": false,
+      "usability": {
+        "availability": "setup-required",
+        "execution": "bundle",
+        "requires_setup": [
+          "Review bundled components, secrets, and approval rules before enabling."
+        ],
+        "source": "inferred"
+      },
       "includes": {
         "skills": [
           "adtech/brand-rag-memory-bootstrap",
@@ -275,6 +394,14 @@
       "readiness": "experimental",
       "security_reviewed": false,
       "deprecated": false,
+      "usability": {
+        "availability": "setup-required",
+        "execution": "bundle",
+        "requires_setup": [
+          "Review bundled components, secrets, and approval rules before enabling."
+        ],
+        "source": "inferred"
+      },
       "includes": {
         "skills": [
           "marketing/creative-workshop-pmax-reels",
@@ -322,6 +449,14 @@
       "readiness": "experimental",
       "security_reviewed": false,
       "deprecated": false,
+      "usability": {
+        "availability": "setup-required",
+        "execution": "bundle",
+        "requires_setup": [
+          "Review bundled components, secrets, and approval rules before enabling."
+        ],
+        "source": "inferred"
+      },
       "includes": {
         "skills": [
           "adtech/brand-rag-memory-bootstrap",
@@ -376,6 +511,14 @@
       "readiness": "experimental",
       "security_reviewed": false,
       "deprecated": false,
+      "usability": {
+        "availability": "setup-required",
+        "execution": "bundle",
+        "requires_setup": [
+          "Review bundled components, secrets, and approval rules before enabling."
+        ],
+        "source": "inferred"
+      },
       "includes": {
         "skills": [
           "marketing/seo-paid-search-synergy",
@@ -427,6 +570,14 @@
       "readiness": "experimental",
       "security_reviewed": false,
       "deprecated": false,
+      "usability": {
+        "availability": "setup-required",
+        "execution": "bundle",
+        "requires_setup": [
+          "Review bundled components, secrets, and approval rules before enabling."
+        ],
+        "source": "inferred"
+      },
       "includes": {
         "skills": [
           "marketing/meta-google-weekly-performance-review",
@@ -486,6 +637,14 @@
       "readiness": "experimental",
       "security_reviewed": false,
       "deprecated": false,
+      "usability": {
+        "availability": "setup-required",
+        "execution": "bundle",
+        "requires_setup": [
+          "Review bundled components, secrets, and approval rules before enabling."
+        ],
+        "source": "inferred"
+      },
       "includes": {
         "skills": [
           "security/handle-untrusted-content",

--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -42,6 +42,11 @@
         "use_when": "Use before campaign activation or measurement redesign to determine who owns and can verify each signal.",
         "execution_mode": "analysis-only"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "shared/schemas/advertising/signal-ownership-ledger.schema.json"
@@ -86,6 +91,11 @@
         ],
         "use_when": "Use when an analyst question needs safe SQL drafting, metric validation, and stakeholder-ready findings across BigQuery or Redshift.",
         "execution_mode": "read-only-local-inspection"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -133,6 +143,11 @@
         "use_when": "Use when you need to structure approved brand, campaign, and policy documents into a retrieval-ready memory layer.",
         "execution_mode": "analysis-only"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -177,6 +192,11 @@
         ],
         "use_when": "Use when normalized performance tables need to be turned into deterministic weekly dashboard sections.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -223,6 +243,11 @@
         "use_when": "Use when a dashboard or BI package needs freshness, completeness, reconciliation, and anomaly checks before publish.",
         "execution_mode": "may-run-local-verification"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -267,6 +292,11 @@
         ],
         "use_when": "Use when QA-approved BI outputs need to be converted into concise executive narrative and action framing.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -313,6 +343,11 @@
         ],
         "use_when": "Use when a web app needs Playwright smoke coverage, failure diagnosis, and minimal healing suggestions.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -362,6 +397,11 @@
         "use_when": "Use when Codex is orchestrating a VS Code-compatible Playwright planner, generator, and healer loop.",
         "execution_mode": "may-run-local-verification"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "node",
@@ -409,6 +449,11 @@
         "use_when": "Use when ad copy, URLs, or tracking conventions need policy and brand validation before launch.",
         "execution_mode": "may-run-local-verification"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -454,6 +499,11 @@
         ],
         "use_when": "Use when weekly BI reporting needs deterministic orchestration across dashboard generation, QA, and narrative drafting.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -501,6 +551,11 @@
         ],
         "use_when": "Use when defining what an ad-platform agent may auto-execute, what requires approval, and what must be denied.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -542,6 +597,11 @@
         ],
         "use_when": "Use before deploying or expanding an agent workflow that can call tools, access data, or trigger operational actions.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -582,6 +642,11 @@
         ],
         "use_when": "Use when proposed harness changes need benchmark and red-team evaluation before adoption.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -622,6 +687,11 @@
         ],
         "use_when": "Use when recent agent run logs need review for repeated misses, skipped skills, and inefficient loops.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -662,6 +732,11 @@
         ],
         "use_when": "Use when repeated harness failures justify drafting new or revised harness skills and policy text.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -702,6 +777,11 @@
         ],
         "use_when": "Use when a code change needs stack-aware lint, typecheck, build, and test verification based on touched files.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -747,6 +827,11 @@
         ],
         "use_when": "Use when coverage artifacts need to be mapped to changed files and uncovered regression risk.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -787,6 +872,11 @@
         ],
         "use_when": "Use when a repository needs scope analysis, impact mapping, and change planning before edits begin.",
         "execution_mode": "read-only-local-inspection"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -832,6 +922,11 @@
         ],
         "use_when": "Use when code changes need correctness, performance, security, and test review plus a structured PR draft.",
         "execution_mode": "read-only-local-inspection"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -872,6 +967,11 @@
         ],
         "use_when": "Use when changed code needs missing unit, integration, regression, and edge-case scenarios identified.",
         "execution_mode": "read-only-local-inspection"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -913,6 +1013,11 @@
         ],
         "use_when": "Use when an A/B test needs explicit hypotheses, sample-size assumptions, and decision rules.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -959,6 +1064,11 @@
         ],
         "use_when": "Use when a team needs a repeatable task-panel evaluation of paid, earned, and executable brand participation.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1009,6 +1119,11 @@
         "use_when": "Use when AI-generated marketing outputs need repeatable scoring across quality, compliance, actionability, and creative operating system fit.",
         "execution_mode": "analysis-only"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -1055,6 +1170,11 @@
         ],
         "use_when": "Use when a brand or team wants to assess whether it can turn AI output into distinctive, useful, governed creative work.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1095,6 +1215,11 @@
         ],
         "use_when": "Use when you need platform-ready creative variants for Google PMax and Meta Reels with bounded formatting checks.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1143,6 +1268,11 @@
         ],
         "use_when": "Use when building creator-led campaigns where creators should shape the idea, not just distribute it.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1184,6 +1314,11 @@
         ],
         "use_when": "Use when pacing and efficiency signals across channels need bounded reallocation recommendations.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1230,6 +1365,11 @@
         ],
         "use_when": "Use when a brand notices a live moment and needs a fast go/no-go recommendation with guardrails.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1271,6 +1411,11 @@
         ],
         "use_when": "Use when audience-aware creative assembly rules need to be defined under brand and policy constraints.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1316,6 +1461,11 @@
         ],
         "use_when": "Use when a lifecycle experiment needs statistical assumptions, stop rules, and guardrail metrics defined clearly.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1363,6 +1513,11 @@
         "use_when": "Use when lifecycle entry, progression, and suppression rules need to be designed with measurement plans.",
         "execution_mode": "analysis-only"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -1408,6 +1563,11 @@
         "use_when": "Use when weekly performance across Meta and Google Ads needs KPI comparison and prioritized actions.",
         "execution_mode": "may-run-local-verification"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -1452,6 +1612,11 @@
         ],
         "use_when": "Use when a campaign should use owned product or service surfaces as the campaign platform.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1492,6 +1657,11 @@
         ],
         "use_when": "Use when SEO winners need to be translated into paid search opportunities and test-ready keyword structures.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1539,6 +1709,11 @@
         "use_when": "Use when an advertising or commerce experiment should begin from a customer task rather than a keyword or placement list.",
         "execution_mode": "analysis-only"
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "shared/schemas/advertising/task-map.schema.json"
@@ -1585,6 +1760,11 @@
         ],
         "use_when": "Use when a team wants campaign concepts that do something useful rather than only communicate a message.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1627,6 +1807,11 @@
         ],
         "use_when": "Use before an agent reads or writes to DV360, Google Ads, Meta Ads, product feeds, or commerce/analytics APIs using OAuth or service credentials.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1667,6 +1852,11 @@
         ],
         "use_when": "Use when manifests and lockfiles need vulnerability, provenance, and package risk review before trust is granted.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [
@@ -1713,6 +1903,11 @@
         ],
         "use_when": "Use when you need to assess whether the current runtime is safe for autonomous agent execution.",
         "execution_mode": "read-only-local-inspection"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1753,6 +1948,11 @@
         ],
         "use_when": "Use when logs, tickets, webpages, or MCP outputs may contain prompt injection or unsafe instructions.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1794,6 +1994,11 @@
         ],
         "use_when": "Use when reviewing marketing or adtech agents that touch spend, audiences, product data, analytics, customer data, or publishing workflows.",
         "execution_mode": "analysis-only"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       }
     },
     {
@@ -1834,6 +2039,11 @@
         ],
         "use_when": "Use when diffs or repository context need secret scanning and credential exposure review.",
         "execution_mode": "may-run-local-verification"
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "instructions",
+        "source": "inferred"
       },
       "dependencies": {
         "tools": [

--- a/registry/tools-index.json
+++ b/registry/tools-index.json
@@ -1,6 +1,6 @@
 {
   "registry_version": "1.0",
-  "generated_at": "2026-07-24T00:00:00Z",
+  "generated_at": "2026-07-25T00:00:00Z",
   "skills": [
     {
       "id": "ads/meta-ads-mcp-connector",
@@ -43,6 +43,14 @@
         "access_level": "read-only",
         "trust_boundary": "remote-mcp-server",
         "approval_boundary": "Safe for reporting queries only; require human approval before pairing with any workflow that can modify campaigns, budgets, or creative state."
+      },
+      "usability": {
+        "availability": "setup-required",
+        "execution": "remote-integration",
+        "requires_setup": [
+          "Configure the connected system and authentication outside agent context."
+        ],
+        "source": "inferred"
       },
       "dependencies": {
         "mcp_servers": [
@@ -97,6 +105,11 @@
         "trust_boundary": "remote-mcp-server",
         "approval_boundary": "Applies only policy-approved bounded writes; high-risk changes require human approval and rollback evidence."
       },
+      "usability": {
+        "availability": "template-only",
+        "execution": "integration-template",
+        "source": "inferred"
+      },
       "dependencies": {
         "tools": [
           "authorization_broker",
@@ -121,7 +134,7 @@
           "released_at": "2026-07-24T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/adtech/conversion-event-reconciler/tool.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/conversion-event-reconciler/0.1.0.tar.gz",
-          "sha256": "418018d071d17ceae8b76a0515c5e5d27fe31a7bae85a35e4c4faf2d8713e282"
+          "sha256": "43e7546f8ae971d5987f751cb9f0bcdb22a9976e2f5762934154d9440db8c918"
         }
       ],
       "runtimes": [
@@ -153,6 +166,12 @@
         "trust_boundary": "local-tool",
         "approval_boundary": "Reads supplied files and writes JSON to stdout; live event collection and platform uploads are out of scope."
       },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "local-tool",
+        "quickstart": "python3 scripts/reconcile_events.py examples/input.json",
+        "source": "declared"
+      },
       "dependencies": {
         "tools": [
           "python3"
@@ -171,7 +190,7 @@
           "released_at": "2026-07-24T00:00:00Z",
           "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/adtech/openai-ads-adapter-template/tool.yaml",
           "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/openai-ads-adapter-template/0.1.0.tar.gz",
-          "sha256": "01b4b7841260505f22ea1dddbde2c2b5ed44e520a3be294ec2e88f3db8e32958"
+          "sha256": "2b83ca41d925b251fd71dd7e7f8263e79cdedb5c8b79e35e3292a3a088cb59a3"
         }
       ],
       "runtimes": [
@@ -204,12 +223,92 @@
         "trust_boundary": "third-party-hosted",
         "approval_boundary": "Read-only by design; future writes must use the existing policy-gated ad-platform executor."
       },
+      "usability": {
+        "availability": "template-only",
+        "execution": "integration-template",
+        "limitations": [
+          "This package contains contracts and fixtures, not an API client."
+        ],
+        "quickstart": "Use adtech/openai-ads-api-client for an executable mock or live read-only integration.",
+        "source": "declared"
+      },
       "dependencies": {
         "tools": [
           "secret_manager"
         ],
         "apis": [
           "OpenAI Ads API"
+        ]
+      }
+    },
+    {
+      "id": "adtech/openai-ads-api-client",
+      "name": "OpenAI Ads API Client",
+      "description": "Dry-run-first client for mock or live read-only OpenAI Ads account, campaign, ad, and insights retrieval plus non-persisting Conversions API validation.",
+      "category": "tools-mcp/adtech",
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "released_at": "2026-07-25T00:00:00Z",
+          "manifest_url": "https://skills.ai-knowledge-hub.org/tools-mcp/adtech/openai-ads-api-client/tool.yaml",
+          "artifact_url": "https://skills.ai-knowledge-hub.org/artifacts/adtech/openai-ads-api-client/0.1.0.tar.gz",
+          "sha256": "d202296ac427521dc4c6af470c7e6550c384f7d5c1f390fdd992433d5679727a"
+        }
+      ],
+      "runtimes": [
+        "codex",
+        "claude",
+        "generic"
+      ],
+      "tags": [
+        "openai-ads",
+        "advertiser-api",
+        "campaign-insights",
+        "conversions-api",
+        "read-only"
+      ],
+      "readiness": "experimental",
+      "security_reviewed": false,
+      "deprecated": false,
+      "operational": {
+        "connected_system": "OpenAI Advertiser API and Ads Conversions API",
+        "capabilities": [
+          "Read ad-account metadata.",
+          "List campaigns and ads.",
+          "Retrieve account, campaign, ad-group, or ad insights.",
+          "Validate conversion event batches locally or through validate-only server mode."
+        ],
+        "auth_required": [
+          "OPENAI_ADS_API_KEY for live Advertiser API reads",
+          "OPENAI_ADS_PIXEL_ID and OPENAI_ADS_CONVERSIONS_API_KEY for remote conversion validation"
+        ],
+        "access_level": "read-only",
+        "trust_boundary": "third-party-hosted",
+        "approval_boundary": "Advertiser operations are GET-only; Conversions API requests always force validate_only true and cannot persist events."
+      },
+      "usability": {
+        "availability": "usable-now",
+        "execution": "remote-integration",
+        "requires_setup": [
+          "For live reads, create an account-scoped Ads API key in OpenAI Ads Manager.",
+          "Keep API keys in environment variables outside agent context."
+        ],
+        "limitations": [
+          "Campaign, ad-group, ad, file, and feed mutations are intentionally excluded.",
+          "Remote conversion requests validate events without saving them.",
+          "Automatic pagination, retries, and rate-limit backoff are not included in this first client."
+        ],
+        "quickstart": "python3 scripts/openai_ads_client.py --mode mock account",
+        "source": "declared"
+      },
+      "dependencies": {
+        "tools": [
+          "python3"
+        ],
+        "apis": [
+          "OpenAI Advertiser API",
+          "OpenAI Ads Conversions API"
         ]
       }
     },
@@ -260,6 +359,14 @@
         "trust_boundary": "remote-mcp-server",
         "approval_boundary": "Safe for policy checks and audit writes; requires human approval before executing high-risk operational actions or changing policy."
       },
+      "usability": {
+        "availability": "setup-required",
+        "execution": "remote-integration",
+        "requires_setup": [
+          "Configure the connected system and authentication outside agent context."
+        ],
+        "source": "inferred"
+      },
       "dependencies": {
         "mcp_servers": [
           "agent-control-plane"
@@ -308,6 +415,14 @@
         "trust_boundary": "remote-mcp-server",
         "approval_boundary": "Safe for read-only analytics retrieval; require human approval before combining with any workflow that writes back to ad platforms or reporting systems."
       },
+      "usability": {
+        "availability": "setup-required",
+        "execution": "remote-integration",
+        "requires_setup": [
+          "Configure the connected system and authentication outside agent context."
+        ],
+        "source": "inferred"
+      },
       "dependencies": {
         "mcp_servers": [
           "ga4"
@@ -355,6 +470,14 @@
         "access_level": "read-only",
         "trust_boundary": "remote-mcp-server",
         "approval_boundary": "Safe for parameterized read-only queries; require human approval before broadening dataset scope or enabling any non-read-only SQL path."
+      },
+      "usability": {
+        "availability": "setup-required",
+        "execution": "remote-integration",
+        "requires_setup": [
+          "Configure the connected system and authentication outside agent context."
+        ],
+        "source": "inferred"
       },
       "dependencies": {
         "mcp_servers": [

--- a/scripts/test-skill-scripts.sh
+++ b/scripts/test-skill-scripts.sh
@@ -51,4 +51,13 @@ JSON
 )"
 echo "$sample_out" | grep -q '"recommended_total_sample_size"'
 
+echo "[check] conversion event reconciler tests"
+python3 -m unittest discover -s "$ROOT/tools-mcp/adtech/conversion-event-reconciler/tests" -p 'test_*.py'
+
+echo "[check] OpenAI Ads API client tests"
+python3 -m unittest discover -s "$ROOT/tools-mcp/adtech/openai-ads-api-client/tests" -p 'test_*.py'
+
+echo "[check] ChatGPT advertising plugin mock lab"
+python3 -m unittest discover -s "$ROOT/plugins/marketing/chatgpt-advertising-experiment-plugin/tests" -p 'test_*.py'
+
 echo "All skill scripts passed deterministic checks."

--- a/shared/schemas/agent.schema.json
+++ b/shared/schemas/agent.schema.json
@@ -204,6 +204,9 @@
         }
       }
     },
+    "usability": {
+      "$ref": "#/$defs/usability"
+    },
     "verification": {
       "type": "object",
       "additionalProperties": false,
@@ -224,6 +227,19 @@
     "replaced_by": {
       "type": "string",
       "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+    }
+  },
+  "$defs": {
+    "usability": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "availability": { "type": "string", "enum": ["usable-now", "setup-required", "template-only", "documentation-only"] },
+        "execution": { "type": "string", "enum": ["instructions", "local-tool", "remote-integration", "integration-template", "orchestrator", "bundle", "documentation"] },
+        "requires_setup": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+        "limitations": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+        "quickstart": { "type": "string", "minLength": 3, "maxLength": 300 }
+      }
     }
   },
   "allOf": [

--- a/shared/schemas/plugin.schema.json
+++ b/shared/schemas/plugin.schema.json
@@ -185,6 +185,9 @@
         }
       }
     },
+    "usability": {
+      "$ref": "#/$defs/usability"
+    },
     "verification": {
       "type": "object",
       "additionalProperties": false,
@@ -205,6 +208,19 @@
     "replaced_by": {
       "type": "string",
       "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+    }
+  },
+  "$defs": {
+    "usability": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "availability": { "type": "string", "enum": ["usable-now", "setup-required", "template-only", "documentation-only"] },
+        "execution": { "type": "string", "enum": ["instructions", "local-tool", "remote-integration", "integration-template", "orchestrator", "bundle", "documentation"] },
+        "requires_setup": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+        "limitations": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+        "quickstart": { "type": "string", "minLength": 3, "maxLength": 300 }
+      }
     }
   },
   "allOf": [

--- a/shared/schemas/registry-index.schema.json
+++ b/shared/schemas/registry-index.schema.json
@@ -38,6 +38,7 @@
           "runtimes",
           "tags",
           "readiness",
+          "usability",
           "security_reviewed",
           "deprecated"
         ],
@@ -174,6 +175,9 @@
               }
             }
           },
+          "usability": {
+            "$ref": "#/$defs/registry_usability"
+          },
           "dependencies": {
             "type": "object",
             "additionalProperties": false,
@@ -304,6 +308,19 @@
     }
   },
   "$defs": {
+    "registry_usability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["availability", "execution", "source"],
+      "properties": {
+        "availability": { "type": "string", "enum": ["usable-now", "setup-required", "template-only", "documentation-only"] },
+        "execution": { "type": "string", "enum": ["instructions", "local-tool", "remote-integration", "integration-template", "orchestrator", "bundle", "documentation"] },
+        "requires_setup": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+        "limitations": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+        "quickstart": { "type": "string", "minLength": 3, "maxLength": 300 },
+        "source": { "type": "string", "enum": ["declared", "inferred"] }
+      }
+    },
     "version_entry": {
       "type": "object",
       "additionalProperties": false,

--- a/shared/schemas/skill.schema.json
+++ b/shared/schemas/skill.schema.json
@@ -204,6 +204,9 @@
         }
       }
     },
+    "usability": {
+      "$ref": "#/$defs/usability"
+    },
     "verification": {
       "type": "object",
       "additionalProperties": false,
@@ -227,6 +230,19 @@
     "replaced_by": {
       "type": "string",
       "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+    }
+  },
+  "$defs": {
+    "usability": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "availability": { "type": "string", "enum": ["usable-now", "setup-required", "template-only", "documentation-only"] },
+        "execution": { "type": "string", "enum": ["instructions", "local-tool", "remote-integration", "integration-template", "orchestrator", "bundle", "documentation"] },
+        "requires_setup": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+        "limitations": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+        "quickstart": { "type": "string", "minLength": 3, "maxLength": 300 }
+      }
     }
   },
   "allOf": [

--- a/shared/schemas/tool.schema.json
+++ b/shared/schemas/tool.schema.json
@@ -208,6 +208,9 @@
         }
       }
     },
+    "usability": {
+      "$ref": "#/$defs/usability"
+    },
     "verification": {
       "type": "object",
       "additionalProperties": false,
@@ -231,6 +234,19 @@
     "replaced_by": {
       "type": "string",
       "pattern": "^[a-z0-9-]+/[a-z0-9-]+$"
+    }
+  },
+  "$defs": {
+    "usability": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "availability": { "type": "string", "enum": ["usable-now", "setup-required", "template-only", "documentation-only"] },
+        "execution": { "type": "string", "enum": ["instructions", "local-tool", "remote-integration", "integration-template", "orchestrator", "bundle", "documentation"] },
+        "requires_setup": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+        "limitations": { "type": "array", "items": { "type": "string", "minLength": 3 }, "uniqueItems": true },
+        "quickstart": { "type": "string", "minLength": 3, "maxLength": 300 }
+      }
     }
   },
   "allOf": [

--- a/tools-mcp/adtech/conversion-event-reconciler/tool.yaml
+++ b/tools-mcp/adtech/conversion-event-reconciler/tool.yaml
@@ -38,6 +38,10 @@ operational:
   access_level: read-only
   trust_boundary: local-tool
   approval_boundary: Reads supplied files and writes JSON to stdout; live event collection and platform uploads are out of scope.
+usability:
+  availability: usable-now
+  execution: local-tool
+  quickstart: python3 scripts/reconcile_events.py examples/input.json
 verification:
   tests_min_prompts: 5
   deterministic_scripts: true

--- a/tools-mcp/adtech/openai-ads-adapter-template/tool.yaml
+++ b/tools-mcp/adtech/openai-ads-adapter-template/tool.yaml
@@ -41,6 +41,12 @@ operational:
   access_level: read-only
   trust_boundary: third-party-hosted
   approval_boundary: Read-only by design; future writes must use the existing policy-gated ad-platform executor.
+usability:
+  availability: template-only
+  execution: integration-template
+  limitations:
+    - This package contains contracts and fixtures, not an API client.
+  quickstart: Use adtech/openai-ads-api-client for an executable mock or live read-only integration.
 verification:
   tests_min_prompts: 5
   deterministic_scripts: false

--- a/tools-mcp/adtech/openai-ads-api-client/README.md
+++ b/tools-mcp/adtech/openai-ads-api-client/README.md
@@ -1,0 +1,16 @@
+# OpenAI Ads API Client
+
+A standard-library Python client that turns the OpenAI Ads adapter contract into a runnable integration boundary.
+
+- Mock mode works immediately with bundled fixtures.
+- Live Advertiser API mode is read-only.
+- Conversions API integration supports local validation and remote `validate_only` requests.
+- No campaign mutation path is included.
+
+Start here:
+
+```bash
+python3 scripts/openai_ads_client.py --mode mock account
+```
+
+Then read `TOOL.md` before connecting an Ads Manager account.

--- a/tools-mcp/adtech/openai-ads-api-client/TOOL.md
+++ b/tools-mcp/adtech/openai-ads-api-client/TOOL.md
@@ -1,0 +1,51 @@
+# OpenAI Ads API Client
+
+## Contract
+
+Use mock mode without credentials:
+
+```bash
+python3 scripts/openai_ads_client.py --mode mock account
+python3 scripts/openai_ads_client.py --mode mock campaigns --limit 20
+python3 scripts/openai_ads_client.py --mode mock ads --ad-group-id adgrp_301
+python3 scripts/openai_ads_client.py --mode mock insights --scope campaign --entity-id cmpn_101
+```
+
+Use live read-only mode after setting an account-scoped key:
+
+```bash
+export OPENAI_ADS_API_KEY='...'
+python3 scripts/openai_ads_client.py --mode live account
+```
+
+Validate conversion events locally:
+
+```bash
+python3 scripts/validate_conversion_events.py examples/conversion-events.json --now-ms 1784937600000
+```
+
+Add `--remote-validate` only when `OPENAI_ADS_PIXEL_ID` and `OPENAI_ADS_CONVERSIONS_API_KEY` are set. The script overwrites `validate_only` with `true` before sending.
+
+## Exposed operations
+
+- `get_account`
+- `list_campaigns`
+- `list_ads`
+- `get_insights`
+- `validate_conversion_events`
+
+## Guardrails
+
+1. Never pass API keys as command arguments or place them in prompts.
+2. Advertiser API methods are restricted to GET requests.
+3. Conversion batches are limited to 1,000 events.
+4. Remote conversion validation cannot persist an event.
+5. Route mutations through a policy-gated executor with human approval.
+
+## Official references
+
+- https://developers.openai.com/ads/api-overview
+- https://developers.openai.com/ads/api-quickstart
+- https://developers.openai.com/ads/api-reference/authentication
+- https://developers.openai.com/ads/api-reference/insights
+- https://developers.openai.com/ads/conversions-api

--- a/tools-mcp/adtech/openai-ads-api-client/examples/account.json
+++ b/tools-mcp/adtech/openai-ads-api-client/examples/account.json
@@ -1,0 +1,1 @@
+{"id":"adacct_mock","name":"Mock Ads Lab","url":"https://example.com","preview_url":null,"status":"active","timezone":"UTC","currency_code":"GBP","review":{"status":"approved"}}

--- a/tools-mcp/adtech/openai-ads-api-client/examples/ads.json
+++ b/tools-mcp/adtech/openai-ads-api-client/examples/ads.json
@@ -1,0 +1,1 @@
+{"object":"list","data":[{"id":"ad_501","name":"Task completion card","status":"active","review_status":"approved","creative":{"type":"chat_card","title":"Finish the task with less friction","body":"A practical next step for the task in progress.","target_url":"https://example.com/task"}}],"first_id":"ad_501","last_id":"ad_501","has_more":false}

--- a/tools-mcp/adtech/openai-ads-api-client/examples/campaigns.json
+++ b/tools-mcp/adtech/openai-ads-api-client/examples/campaigns.json
@@ -1,0 +1,1 @@
+{"object":"list","data":[{"id":"cmpn_101","name":"Task-led pilot","status":"active","bidding_type":"clicks","budget":{"lifetime_spend_limit_micros":25000000},"targeting":{}}],"first_id":"cmpn_101","last_id":"cmpn_101","has_more":false}

--- a/tools-mcp/adtech/openai-ads-api-client/examples/conversion-events.json
+++ b/tools-mcp/adtech/openai-ads-api-client/examples/conversion-events.json
@@ -1,0 +1,1 @@
+{"validate_only":true,"events":[{"id":"order_12345","type":"order_created","timestamp_ms":1784937600000,"source_url":"https://example.com/checkout/confirmation","action_source":"web","user":{"country":"GB"},"data":{"type":"contents"}}]}

--- a/tools-mcp/adtech/openai-ads-api-client/examples/insights.json
+++ b/tools-mcp/adtech/openai-ads-api-client/examples/insights.json
@@ -1,0 +1,1 @@
+{"object":"list","count":1,"data":[{"id":"mock-insight-1","readable_time":"2026-07-24","timezone":"UTC","impressions":1200,"clicks":48,"spend":96.0,"start_time":1784851200,"end_time":1784937600}],"first_id":"mock-insight-1","last_id":"mock-insight-1","has_more":false}

--- a/tools-mcp/adtech/openai-ads-api-client/scripts/openai_ads_client.py
+++ b/tools-mcp/adtech/openai-ads-api-client/scripts/openai_ads_client.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Read-only OpenAI Advertiser API client with deterministic mock fixtures."""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+DEFAULT_BASE_URL = "https://api.ads.openai.com/v1"
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class AdsClientError(RuntimeError):
+    pass
+
+
+class AdsClient:
+    def __init__(self, mode="mock", api_key=None, base_url=DEFAULT_BASE_URL, fixture_dir=None):
+        if mode not in {"mock", "live"}:
+            raise ValueError("mode must be mock or live")
+        self.mode = mode
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.fixture_dir = Path(fixture_dir or ROOT / "examples")
+        if self.mode == "live" and not self.api_key:
+            raise AdsClientError("OPENAI_ADS_API_KEY is required for live mode")
+
+    def get_account(self):
+        return self._get("/ad_account", fixture="account.json")
+
+    def list_campaigns(self, limit=20, order="desc"):
+        return self._get(
+            "/campaigns",
+            params={"limit": limit, "order": order},
+            fixture="campaigns.json",
+        )
+
+    def list_ads(self, ad_group_id, limit=20, order="desc"):
+        if not ad_group_id:
+            raise AdsClientError("ad_group_id is required")
+        return self._get(
+            "/ads",
+            params={"ad_group_id": ad_group_id, "limit": limit, "order": order},
+            fixture="ads.json",
+        )
+
+    def get_insights(self, scope, entity_id=None, time_granularity="daily", limit=20):
+        if scope == "ad_account":
+            path = "/ad_account/insights"
+        elif scope in {"campaign", "ad_group", "ad"}:
+            if not entity_id:
+                raise AdsClientError(f"entity_id is required for {scope} insights")
+            plural = {"campaign": "campaigns", "ad_group": "ad_groups", "ad": "ads"}[scope]
+            path = f"/{plural}/{urllib.parse.quote(entity_id, safe='')}/insights"
+        else:
+            raise AdsClientError("scope must be ad_account, campaign, ad_group, or ad")
+        return self._get(
+            path,
+            params={"time_granularity": time_granularity, "limit": limit},
+            fixture="insights.json",
+        )
+
+    def _get(self, path, params=None, fixture=None):
+        if self.mode == "mock":
+            if not fixture:
+                raise AdsClientError("mock operation has no fixture")
+            return json.loads((self.fixture_dir / fixture).read_text())
+
+        query = urllib.parse.urlencode(params or {})
+        url = f"{self.base_url}{path}" + (f"?{query}" if query else "")
+        request = urllib.request.Request(
+            url,
+            method="GET",
+            headers={"Authorization": f"Bearer {self.api_key}", "Accept": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise AdsClientError(f"OpenAI Ads API returned HTTP {exc.code}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise AdsClientError(f"OpenAI Ads API request failed: {exc.reason}") from exc
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=["mock", "live"], default="mock")
+    parser.add_argument("--api-key-env", default="OPENAI_ADS_API_KEY")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("account")
+
+    campaigns = subparsers.add_parser("campaigns")
+    campaigns.add_argument("--limit", type=int, default=20)
+    campaigns.add_argument("--order", choices=["asc", "desc"], default="desc")
+
+    ads = subparsers.add_parser("ads")
+    ads.add_argument("--ad-group-id", required=True)
+    ads.add_argument("--limit", type=int, default=20)
+    ads.add_argument("--order", choices=["asc", "desc"], default="desc")
+
+    insights = subparsers.add_parser("insights")
+    insights.add_argument("--scope", choices=["ad_account", "campaign", "ad_group", "ad"], required=True)
+    insights.add_argument("--entity-id")
+    insights.add_argument("--time-granularity", choices=["hourly", "daily", "monthly", "none"], default="daily")
+    insights.add_argument("--limit", type=int, default=20)
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    try:
+        client = AdsClient(
+            mode=args.mode,
+            api_key=os.environ.get(args.api_key_env),
+        )
+        if args.command == "account":
+            result = client.get_account()
+        elif args.command == "campaigns":
+            result = client.list_campaigns(args.limit, args.order)
+        elif args.command == "ads":
+            result = client.list_ads(args.ad_group_id, args.limit, args.order)
+        else:
+            result = client.get_insights(args.scope, args.entity_id, args.time_granularity, args.limit)
+        print(json.dumps(result, indent=2, sort_keys=True))
+    except (AdsClientError, ValueError, OSError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools-mcp/adtech/openai-ads-api-client/scripts/validate_conversion_events.py
+++ b/tools-mcp/adtech/openai-ads-api-client/scripts/validate_conversion_events.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Validate OpenAI Ads conversion events locally or via remote validate-only mode."""
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+CAPI_URL = "https://bzr.openai.com/v1/events"
+ALLOWED_ACTION_SOURCES = {"web", "mobile_app", "offline", "physical_store", "phone_call", "email", "other"}
+
+
+def validate_payload(payload, now_ms=None):
+    now_ms = int(now_ms if now_ms is not None else time.time() * 1000)
+    errors = []
+    events = payload.get("events")
+    if not isinstance(events, list) or not events:
+        return ["events must be a non-empty array"]
+    if len(events) > 1000:
+        errors.append("events cannot contain more than 1000 items")
+
+    for index, event in enumerate(events):
+        prefix = f"events[{index}]"
+        if not isinstance(event, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        for field in ("id", "type", "timestamp_ms"):
+            if event.get(field) in (None, ""):
+                errors.append(f"{prefix}.{field} is required")
+        timestamp = event.get("timestamp_ms")
+        if isinstance(timestamp, int):
+            if timestamp < now_ms - 7 * 24 * 60 * 60 * 1000:
+                errors.append(f"{prefix}.timestamp_ms is older than 7 days")
+            if timestamp > now_ms + 10 * 60 * 1000:
+                errors.append(f"{prefix}.timestamp_ms is more than 10 minutes in the future")
+        elif timestamp is not None:
+            errors.append(f"{prefix}.timestamp_ms must be an integer")
+        action_source = event.get("action_source")
+        if action_source and action_source not in ALLOWED_ACTION_SOURCES:
+            errors.append(f"{prefix}.action_source is unsupported")
+        if action_source == "web" and not event.get("source_url"):
+            errors.append(f"{prefix}.source_url is required for web events")
+        if event.get("type") == "custom" and not event.get("custom_event_name"):
+            errors.append(f"{prefix}.custom_event_name is required for custom events")
+    return errors
+
+
+def remote_validate(payload, pixel_id, api_key, endpoint=CAPI_URL):
+    if not pixel_id or not api_key:
+        raise ValueError("pixel ID and Conversions API key are required for remote validation")
+    body = dict(payload)
+    body["validate_only"] = True
+    url = f"{endpoint}?{urllib.parse.urlencode({'pid': pixel_id})}"
+    request = urllib.request.Request(
+        url,
+        method="POST",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Conversions API returned HTTP {exc.code}: {detail}") from exc
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path)
+    parser.add_argument("--now-ms", type=int)
+    parser.add_argument("--remote-validate", action="store_true")
+    parser.add_argument("--pixel-id-env", default="OPENAI_ADS_PIXEL_ID")
+    parser.add_argument("--api-key-env", default="OPENAI_ADS_CONVERSIONS_API_KEY")
+    args = parser.parse_args(argv)
+
+    payload = json.loads(args.input.read_text())
+    errors = validate_payload(payload, args.now_ms)
+    result = {"valid": not errors, "errors": errors, "event_count": len(payload.get("events", [])), "validate_only": True}
+    if errors:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1
+    if args.remote_validate:
+        result["provider_response"] = remote_validate(
+            payload,
+            os.environ.get(args.pixel_id_env),
+            os.environ.get(args.api_key_env),
+        )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools-mcp/adtech/openai-ads-api-client/tests/test-prompts.md
+++ b/tools-mcp/adtech/openai-ads-api-client/tests/test-prompts.md
@@ -1,0 +1,7 @@
+# Test Prompts
+
+1. Run the client in mock mode and summarize the bundled ad account without asking for credentials.
+2. Explain which environment variable is needed before a live account read.
+3. Retrieve campaign insights without proposing a campaign mutation.
+4. Validate the bundled conversion batch locally and explain every required field.
+5. Explain why remote conversion validation cannot save events and where live mutations must be routed.

--- a/tools-mcp/adtech/openai-ads-api-client/tests/test_client.py
+++ b/tools-mcp/adtech/openai-ads-api-client/tests/test_client.py
@@ -1,0 +1,82 @@
+import importlib.util
+import json
+import os
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+CLIENT = load_module("openai_ads_client", ROOT / "scripts" / "openai_ads_client.py")
+CONVERSIONS = load_module("validate_conversion_events", ROOT / "scripts" / "validate_conversion_events.py")
+
+
+class Handler(BaseHTTPRequestHandler):
+    last_request = None
+
+    def do_GET(self):
+        Handler.last_request = {"method": "GET", "path": self.path, "authorization": self.headers.get("Authorization")}
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"id": "adacct_live_test"}).encode())
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length))
+        Handler.last_request = {"method": "POST", "path": self.path, "body": body}
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"validated": True}).encode())
+
+    def log_message(self, *_):
+        return
+
+
+class OpenAIAdsClientTests(unittest.TestCase):
+    def setUp(self):
+        self.server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join()
+
+    def test_mock_mode_requires_no_credentials(self):
+        client = CLIENT.AdsClient(mode="mock")
+        self.assertEqual(client.get_account()["id"], "adacct_mock")
+        self.assertEqual(client.list_campaigns()["data"][0]["id"], "cmpn_101")
+
+    def test_live_client_only_sends_get_requests(self):
+        client = CLIENT.AdsClient(mode="live", api_key="test-key", base_url=self.base_url)
+        self.assertEqual(client.get_account()["id"], "adacct_live_test")
+        self.assertEqual(Handler.last_request["method"], "GET")
+        self.assertEqual(Handler.last_request["authorization"], "Bearer test-key")
+
+    def test_conversion_remote_mode_forces_validate_only(self):
+        payload = {"validate_only": False, "events": [{"id": "x", "type": "lead", "timestamp_ms": 1}]}
+        response = CONVERSIONS.remote_validate(payload, "px_1", "key", endpoint=self.base_url)
+        self.assertTrue(response["validated"])
+        self.assertTrue(Handler.last_request["body"]["validate_only"])
+        self.assertIn("pid=px_1", Handler.last_request["path"])
+
+    def test_conversion_fixture_is_valid_at_reference_time(self):
+        payload = json.loads((ROOT / "examples" / "conversion-events.json").read_text())
+        self.assertEqual(CONVERSIONS.validate_payload(payload, 1784937600000), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools-mcp/adtech/openai-ads-api-client/tool.yaml
+++ b/tools-mcp/adtech/openai-ads-api-client/tool.yaml
@@ -1,0 +1,62 @@
+id: adtech/openai-ads-api-client
+name: OpenAI Ads API Client
+description: Dry-run-first client for mock or live read-only OpenAI Ads account, campaign, ad, and insights retrieval plus non-persisting Conversions API validation.
+version: 0.1.0
+released_at: "2026-07-25T00:00:00Z"
+category: tools-mcp/adtech
+tags:
+  - openai-ads
+  - advertiser-api
+  - campaign-insights
+  - conversions-api
+  - read-only
+license: MIT
+author:
+  name: AI Skills Guide Maintainers
+  url: https://github.com/ai-knowledge-hub/ai-skills-guide
+repository: https://github.com/ai-knowledge-hub/ai-skills-guide
+runtimes:
+  - codex
+  - claude
+  - generic
+entrypoints:
+  spec: TOOL.md
+  readme: README.md
+  tests: tests/test-prompts.md
+  scripts_dir: scripts
+  examples_dir: examples
+dependencies:
+  apis:
+    - OpenAI Advertiser API
+    - OpenAI Ads Conversions API
+  tools:
+    - python3
+operational:
+  connected_system: OpenAI Advertiser API and Ads Conversions API
+  capabilities:
+    - Read ad-account metadata.
+    - List campaigns and ads.
+    - Retrieve account, campaign, ad-group, or ad insights.
+    - Validate conversion event batches locally or through validate-only server mode.
+  auth_required:
+    - OPENAI_ADS_API_KEY for live Advertiser API reads
+    - OPENAI_ADS_PIXEL_ID and OPENAI_ADS_CONVERSIONS_API_KEY for remote conversion validation
+  access_level: read-only
+  trust_boundary: third-party-hosted
+  approval_boundary: Advertiser operations are GET-only; Conversions API requests always force validate_only true and cannot persist events.
+usability:
+  availability: usable-now
+  execution: remote-integration
+  requires_setup:
+    - For live reads, create an account-scoped Ads API key in OpenAI Ads Manager.
+    - Keep API keys in environment variables outside agent context.
+  limitations:
+    - Campaign, ad-group, ad, file, and feed mutations are intentionally excluded.
+    - Remote conversion requests validate events without saving them.
+    - Automatic pagination, retries, and rate-limit backoff are not included in this first client.
+  quickstart: python3 scripts/openai_ads_client.py --mode mock account
+verification:
+  tests_min_prompts: 5
+  deterministic_scripts: true
+  security_reviewed: false
+deprecated: false


### PR DESCRIPTION
## Summary

- Add first-class usability metadata across skills, agents, tools, and plugins:
  - usable now
  - setup required
  - template only
  - documentation
- Surface readiness, setup requirements, limitations, and quickstarts in the CLI and catalog UI.
- Add dependency preflight checks for agent skills, tools, and supporting agents.
- Add a tested OpenAI Ads API client with mock and live read-only modes.
- Add local and remote `validate_only` conversion-event validation.
- Package the ChatGPT advertising workflow as an installable plugin.
- Add a credential-free mock lab that produces a structured experiment evidence bundle.
- Clarify that live campaign execution remains an approval-gated integration template.
- Regenerate all registry indexes.

## Verification

- Go unit tests passed
- Manifest and schema validation passed
- Deterministic script tests passed
- OpenAI Ads client tests passed
- Plugin mock-lab test passed
- Clean Codex installation and agent preflight passed
- Web lint and production build passed
- Playwright: 7 tests passed
- Generated registry stability check passed
- `git diff --check` passed

## Operational Boundary

The OpenAI Ads client currently supports read-only account, campaign, ad, and insights retrieval. Conversion API requests are restricted to `validate_only: true`. Live campaign mutation is intentionally excluded until a reviewed executor provides policy checks, bounded changes, approval gates, idempotency, audit records, and rollback support.